### PR TITLE
Improve TypeScript monorepo configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "fix": "run-s 'fix:*' && wsrun -e -c -s fix",
     "build": "wsrun -e -c -s build",
     "format": "prettier --write .",
+    "typecheck": "wsrun -e -c -s typecheck",
     "test": "wsrun -e -c -s test"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
+    "typescript": "^4.5.5",
     "wsrun": "^5.2.4"
   },
   "packageManager": "yarn@1.22.17"

--- a/packages/status-core/package.json
+++ b/packages/status-core/package.json
@@ -17,6 +17,7 @@
     "build": "run-s 'build:*'",
     "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",
     "build:cjs": "tsc --outDir dist/cjs",
+    "build:types": "tsc --emitDeclarationOnly",
     "fix": "run-s 'fix:*'",
     "fix:lint": "eslint src --ext .ts --fix",
     "test": "run-s 'test:*'",
@@ -24,7 +25,8 @@
     "test:unit": "mocha",
     "proto": "run-s 'proto:*'",
     "proto:lint": "buf lint",
-    "proto:build": "buf generate"
+    "proto:build": "buf generate",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",
@@ -46,8 +48,7 @@
     "mocha": "^9.1.1",
     "npm-run-all": "^4.1.5",
     "ts-node": "^10.2.1",
-    "ts-proto": "^1.83.0",
-    "typescript": "^4.4.3"
+    "ts-proto": "^1.83.0"
   },
   "dependencies": {
     "bn.js": "^5.2.0",

--- a/packages/status-core/package.json
+++ b/packages/status-core/package.json
@@ -10,9 +10,9 @@
   "bugs": {
     "url": "https://github.com/status-im/status-web/issues"
   },
-  "main": "dist/cjs/src/index.js",
-  "module": "dist/esm/src/index.js",
-  "types": "dist/esm/src/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "run-s 'build:*'",
     "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",

--- a/packages/status-core/src/index.ts
+++ b/packages/status-core/src/index.ts
@@ -5,6 +5,7 @@ export { Contacts } from './contacts'
 export { Chat } from './chat'
 export * from './groupChats'
 export * as utils from './utils'
+export * from './utils'
 export { ApplicationMetadataMessage } from './wire/application_metadata_message'
 export {
   ChatMessage,

--- a/packages/status-core/tsconfig.json
+++ b/packages/status-core/tsconfig.json
@@ -1,51 +1,8 @@
 {
-  "compilerOptions": {
-    "incremental": true,
-    "target": "es6",
-    "outDir": "dist",
-    "rootDir": "src",
-    "moduleResolution": "node",
-    "module": "commonjs",
-    "declaration": true,
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "composite": true,
-    "strict": true /* Enable all strict type-checking options. */,
-
-    /* Strict Type-Checking Options */
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-
-    /* Additional Checks */
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": false /* to set at a later stage */,
-    "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
-
-    /* Debugging Options */
-    "traceResolution": false,
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "pretty": true,
-
-    // Due to broken types in indirect dependencies
-    "skipLibCheck": true,
-
-    "lib": ["es6", "dom"],
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/types",
-      "../../node_modules/@types"
-    ]
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules/**"],
-  "types": ["mocha"],
-  "compileOnSave": false
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationDir": "dist/types"
+  }
 }

--- a/packages/status-react/package.json
+++ b/packages/status-react/package.json
@@ -18,13 +18,15 @@
     "build": "run-s 'build:*'",
     "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",
     "build:cjs": "tsc --outDir dist/cjs",
+    "build:types": "tsc --emitDeclarationOnly",
     "fix": "run-s 'fix:*'",
     "fix:lint": "eslint './{src,test}/**/*.{ts,tsx}' --fix",
     "test": "run-s 'test:*'",
     "test:lint": "eslint './{src,test}/**/*.{ts,tsx}'",
     "proto": "run-s 'proto:*'",
     "proto:lint": "buf lint",
-    "proto:build": "buf generate"
+    "proto:build": "buf generate",
+    "typecheck": "tsc"
   },
   "devDependencies": {
     "@hcaptcha/react-hcaptcha": "^1.0.0",
@@ -49,8 +51,7 @@
     "npm-watch": "^0.11.0",
     "qrcode.react": "^1.0.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^10.1.0",
-    "typescript": "^4.3.5"
+    "ts-node": "^10.1.0"
   },
   "dependencies": {
     "@status-im/core": "^0.0.0",

--- a/packages/status-react/package.json
+++ b/packages/status-react/package.json
@@ -11,9 +11,9 @@
   "bugs": {
     "url": "https://github.com/status-im/status-web/issues"
   },
-  "main": "dist/cjs/src/index.js",
-  "module": "dist/esm/src/index.js",
-  "types": "dist/esm/src/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "run-s 'build:*'",
     "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",
@@ -26,7 +26,7 @@
     "proto": "run-s 'proto:*'",
     "proto:lint": "buf lint",
     "proto:build": "buf generate",
-    "typecheck": "tsc"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@hcaptcha/react-hcaptcha": "^1.0.0",

--- a/packages/status-react/tsconfig.json
+++ b/packages/status-react/tsconfig.json
@@ -1,48 +1,9 @@
 {
-  "compilerOptions": {
-    "target": "es6",
-    "jsx": "react",
-    "outDir": "dist",
-    "moduleResolution": "node",
-    "module": "commonjs",
-    "declaration": true,
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "composite": true,
-    "strict": true /* Enable all strict type-checking options. */,
-
-    /* Strict Type-Checking Options */
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-
-    /* Additional Checks */
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": false /* to set at a later stage */,
-    "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
-
-    /* Debugging Options */
-    "traceResolution": false,
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "pretty": true,
-
-    // Due to broken types in indirect dependencies
-    "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/types",
-      "../../node_modules/@types"
-    ]
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules/**"],
-  "types": ["mocha"],
-  "compileOnSave": false
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "dist/types",
+    "resolveJsonModule": true
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "jsx": "preserve",
+    "declaration": true,
+    "declarationMap": true,
+    // "emitDeclarationOnly": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    // "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    // "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    // "noImplicitReturns": true,
+    // "noUncheckedIndexedAccess": true,
+    // "noPropertyAccessFromIndexSignature": true /* Enforces using indexed accessors for keys declared using an indexed type */,
+    "skipLibCheck": true,
+    "pretty": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6572,7 +6572,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.0, typescript@^4.3.5, typescript@^4.4.3:
+typescript@^4.0.0, typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==


### PR DESCRIPTION
Similarly to #225, this PR makes some changes for ease of maintainability.

1. Deduplicates as much as possible of TypeScript configuration between packages.
2. Moves TypeScript to the root of the monorepo.
3. Adds more strict rules
4. Fixes package.json target fields (previously pointing to non-existent bundles)
