### PR TITLE
Use Parcel for building of packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test": "wsrun -e -c -s test"
   },
   "devDependencies": {
+    "@parcel/packager-ts": "2.3.2",
+    "@parcel/transformer-typescript-types": "2.3.2",
     "npm-run-all": "^4.1.5",
+    "parcel": "^2.3.2",
     "prettier": "^2.5.1",
     "typescript": "^4.5.5",
     "wsrun": "^5.2.4"

--- a/packages/status-core/package.json
+++ b/packages/status-core/package.json
@@ -10,13 +10,13 @@
   "bugs": {
     "url": "https://github.com/status-im/status-web/issues"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "run-s 'build:*'",
-    "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",
-    "build:cjs": "tsc --outDir dist/cjs",
+    "prebuild": "rm -rf dist",
+    "build": "parcel build",
     "build:types": "tsc --emitDeclarationOnly",
     "fix": "run-s 'fix:*'",
     "fix:lint": "eslint src --ext .ts --fix",

--- a/packages/status-core/package.json
+++ b/packages/status-core/package.json
@@ -53,10 +53,12 @@
   "dependencies": {
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",
+    "debug": "^4.3.3",
     "ecies-geth": "^1.5.3",
     "elliptic": "^6.5.4",
     "js-sha3": "^0.8.0",
     "js-waku": "^0.16.0",
+    "long": "^5.2.0",
     "pbkdf2": "^3.1.2",
     "protobufjs": "^6.11.2",
     "secp256k1": "^4.0.2",

--- a/packages/status-core/src/index.ts
+++ b/packages/status-core/src/index.ts
@@ -3,12 +3,18 @@ export { Messenger } from './messenger'
 export { Community } from './community'
 export { Contacts } from './contacts'
 export { Chat } from './chat'
-export * from './groupChats'
-export * as utils from './utils'
-export * from './utils'
-export { ApplicationMetadataMessage } from './wire/application_metadata_message'
+export { GroupChats } from './groupChats'
+export type { GroupChat, GroupChatsType } from './groupChats'
 export {
-  ChatMessage,
+  bufToHex,
+  hexToBuf,
+  genPrivateKeyWithEntropy,
+  getLatestUserNickname,
+  compressPublicKey,
+} from './utils'
+export { ApplicationMetadataMessage } from './wire/application_metadata_message'
+export { ChatMessage } from './wire/chat_message'
+export type {
   ContentType,
   Content,
   StickerContent,

--- a/packages/status-react/package.json
+++ b/packages/status-react/package.json
@@ -29,7 +29,6 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@hcaptcha/react-hcaptcha": "^1.0.0",
     "@types/chai": "^4.2.21",
     "@types/emoji-mart": "^3.0.6",
     "@types/hcaptcha__react-hcaptcha": "^0.1.5",
@@ -49,12 +48,13 @@
     "mocha": "^9.0.3",
     "npm-run-all": "^4.1.5",
     "npm-watch": "^0.11.0",
-    "qrcode.react": "^1.0.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.1.0"
   },
   "dependencies": {
     "@status-im/core": "^0.0.0",
+    "@hcaptcha/react-hcaptcha": "^1.0.0",
+    "qrcode.react": "^1.0.1",
     "emoji-mart": "^3.0.1",
     "html-entities": "^2.3.2",
     "js-sha3": "^0.8.0",

--- a/packages/status-react/package.json
+++ b/packages/status-react/package.json
@@ -11,13 +11,13 @@
   "bugs": {
     "url": "https://github.com/status-im/status-web/issues"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/types.d.ts",
   "scripts": {
-    "build": "run-s 'build:*'",
-    "build:esm": "tsc --module es2020 --target es2017 --outDir dist/esm",
-    "build:cjs": "tsc --outDir dist/cjs",
+    "prebuild": "rm -rf dist",
+    "build": "parcel build",
     "build:types": "tsc --emitDeclarationOnly",
     "fix": "run-s 'fix:*'",
     "fix:lint": "eslint './{src,test}/**/*.{ts,tsx}' --fix",

--- a/packages/status-react/src/components/Modals/ProfileFoundModal.tsx
+++ b/packages/status-react/src/components/Modals/ProfileFoundModal.tsx
@@ -1,4 +1,4 @@
-import { Identity, utils } from '@status-im/core'
+import { Identity, bufToHex } from '@status-im/core'
 import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
@@ -58,9 +58,9 @@ export function ProfileFoundModal() {
         <MiddleSection>
           <Logo
             contact={{
-              id: utils.bufToHex(decryptedIdentity.publicKey),
+              id: bufToHex(decryptedIdentity.publicKey),
               customName: nickname,
-              trueName: utils.bufToHex(decryptedIdentity.publicKey),
+              trueName: bufToHex(decryptedIdentity.publicKey),
             }}
             radius={80}
             colorWheel={[

--- a/packages/status-react/src/index.ts
+++ b/packages/status-react/src/index.ts
@@ -1,6 +1,4 @@
-import { CommunityChat } from './components/CommunityChat'
-import { ConfigType } from './contexts/configProvider'
-import { GroupChat } from './groupChatComponents/GroupChat'
-import { darkTheme, lightTheme } from './styles/themes'
-
-export { CommunityChat, GroupChat, lightTheme, darkTheme, ConfigType }
+export { CommunityChat } from './components/CommunityChat'
+export { GroupChat } from './groupChatComponents/GroupChat'
+export { darkTheme, lightTheme } from './styles/themes'
+export type { ConfigType } from './contexts/configProvider'

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,6 +584,13 @@
     "@parcel/utils" "2.3.2"
     posthtml "^0.16.4"
 
+"@parcel/packager-ts@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-ts/-/packager-ts-2.3.2.tgz#e2092e89bd7ee48b7b217ab9c4374c7ceef17e13"
+  integrity sha512-8Yb0N8Rnvj4Ag+jd2nTJPSrUKZxFEqju77cTRkkg4jFSNSFw8GTRsappNAyCID0W1tjcTyxMTfxetPmCC1Xm9g==
+  dependencies:
+    "@parcel/plugin" "2.3.2"
+
 "@parcel/plugin@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.3.2.tgz#7701c40567d2eddd5d5b2b6298949cd03a2a22fa"
@@ -790,6 +797,24 @@
     posthtml-parser "^0.10.1"
     posthtml-render "^3.0.0"
     semver "^5.7.1"
+
+"@parcel/transformer-typescript-types@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.3.2.tgz#569d06d876594766d48c7bca79464f49e7fe5002"
+  integrity sha512-iYPah0UK2o10bsk5Ukr7meyI5vA27mnBWXHp8bOG5a2pJ/UzS1B7IKbgHBOzLmvpD7lSDfPLGpmbSWbIhsI5+g==
+  dependencies:
+    "@parcel/diagnostic" "2.3.2"
+    "@parcel/plugin" "2.3.2"
+    "@parcel/source-map" "^2.0.0"
+    "@parcel/ts-utils" "2.3.2"
+    nullthrows "^1.1.1"
+
+"@parcel/ts-utils@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@parcel/ts-utils/-/ts-utils-2.3.2.tgz#d63f7027574f3c1a128e1c865d683d6aacb4476d"
+  integrity sha512-jYCHoSmU+oVtFA4q0BygVf74FpVnCDSNtVfLzd1EfGVHlBFMo9GzSY5luMTG4qhnNCDEEco89bkMIgjPHQ3qnA==
+  dependencies:
+    nullthrows "^1.1.1"
 
 "@parcel/types@2.3.2":
   version "2.3.2"
@@ -2239,7 +2264,7 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1:
+debug@4, debug@4.3.3, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -4420,6 +4445,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
+  integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -5129,7 +5159,7 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-parcel@^2.0.0:
+parcel@^2.0.0, parcel@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.3.2.tgz#d1cb475f27edae981edea7a7104e04d3a35a87ca"
   integrity sha512-4jhgoBcQaiGKmnmBvNyKyOvZrxCgzgUzdEoVup/fRCOP99hNmvYIN5IErIIJxsU9ObcG/RGCFF8wa4kVRsWfIg==


### PR DESCRIPTION
After researching many different tools for transpiling and building libraries, I decided to use [Parcel](https://parceljs.org) for now.

Other tools considered were:
- [tsdx](https://github.com/jaredpalmer/tsdx)
- [microbundle](https://github.com/developit/microbundle)
- [Vite](https://vitejs.dev/)
- [tsup](https://tsup.egoist.sh/)
- [Preconstruct](https://preconstruct.tools)
- ...

Parcel v2, released a couple of months ago, has [first-class support for libraries](https://parceljs.org/getting-started/library/), it uses an incredibly fast Rust-based compiler [SWC](https://swc.rs/) under-the-hood and it's already being used for examples.

This decision is not final and may change after I set up a process to measure the size of the library.



