### PR TITLE
Support relative imports in packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     // TODO: Enable type-aware linting (https://typescript-eslint.io/docs/linting/type-linting)
+    // "tsconfigRootDir": ".",
+    // "project": ["./packages/*/tsconfig.json"],
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": true
@@ -70,10 +72,12 @@
     },
     "import/resolver": {
       "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+        "extensions": [".js", ".jsx", ".ts", ".tsx"],
+        "project": ["tsconfig.base.json", "packages/*/tsconfig.json"]
       },
       "typescript": {
-        "alwaysTryTypes": true
+        "alwaysTryTypes": true,
+        "project": ["tsconfig.base.json", "packages/*/tsconfig.json"]
       }
     }
   }

--- a/packages/status-core/tsconfig.json
+++ b/packages/status-core/tsconfig.json
@@ -3,6 +3,10 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "dist",
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
   }
 }

--- a/packages/status-react/tsconfig.json
+++ b/packages/status-react/tsconfig.json
@@ -4,6 +4,10 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declarationDir": "dist/types",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
   }
 }


### PR DESCRIPTION
Adds support for relative imports inside packages.

The relative path is not ideal, because Parcel [does not allow](https://parceljs.org/features/dependency-resolution) to specify different `baseUrl`, so relative paths have to start with `/src`. Since all code lies in the `src` folder, ideally it would be omitted.

For the sake of simplicity and maintainability, I don't want to mess with Parcel module resolution. ¯\_(ツ)_/¯