### PR TITLE
Emit to self on send

### DIFF
--- a/packages/status-js/src/client.ts
+++ b/packages/status-js/src/client.ts
@@ -42,6 +42,7 @@ class Client {
           // '/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/8000/wss/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ',
         ],
       },
+      libp2p: { config: { pubsub: { enabled: true, emitSelf: true } } },
     })
     await waku.waitForRemotePeer()
 

--- a/packages/status-react/src/routes/chat/components/chat-message/index.tsx
+++ b/packages/status-react/src/routes/chat/components/chat-message/index.tsx
@@ -77,14 +77,14 @@ export const ChatMessage = (props: Props) => {
   const userProfileDialog = useDialog(UserProfileDialog)
 
   const handleMessageSubmit = (message: string) => {
-    client.community.get(chatId).sendTextMessage(
+    client.community.chats.get(chatId).sendTextMessage(
       message,
       '0x0fa999097568d1fdcc39108a08d75340bd2cee5ec59c36799007150d0a9fc896'
     )
   }
 
   const handleReaction = (reaction: Reaction) => {
-    client.community.get(chatId).sendReaction(chatId, messageId, reaction)
+    client.community.chats.get(chatId).sendReaction(chatId, messageId, reaction)
   }
 
   const handleReplyClick = () => {

--- a/packages/status-react/src/routes/chat/index.tsx
+++ b/packages/status-react/src/routes/chat/index.tsx
@@ -82,7 +82,7 @@ export const Chat = () => {
   const showMembers = enableMembers && state.showMembers
 
   const handleMessageSubmit = (message: string) => {
-    client.community.get(chatId).sendTextMessage(
+    client.community.chats.get(chatId).sendTextMessage(
       message
       // '0x0fa999097568d1fdcc39108a08d75340bd2cee5ec59c36799007150d0a9fc896'
     )


### PR DESCRIPTION
Tried without internet connection to test that sent messages don't need to hit the network to be processed.

Also,

>emitSelf is "cheating" as it made your local app emit the message it sent as if it received it. It does nothing about ensuring the message is sent over the network. – https://discord.com/channels/864066763682218004/865466694554484738/937495906876526633

>if publish should emit to self, if subscribed – https://github.com/libp2p/js-libp2p-interfaces/blob/7e9caebab4dae2f92550db09f0a773b36b14a9c0/packages/interface-pubsub/src/index.ts#L89