### PR TITLE
Get peer based on environment

### DIFF
--- a/examples/community/.env.example
+++ b/examples/community/.env.example
@@ -1,1 +1,2 @@
 PUBLIC_KEY=""
+NODE_ENV=""

--- a/examples/community/src/app.tsx
+++ b/examples/community/src/app.tsx
@@ -10,6 +10,10 @@ if (!publicKey) {
   )
 }
 
+const environment = process.env.NODE_ENV
+
 export const App = () => {
-  return <Community publicKey={publicKey} theme="light" />
+  return (
+    <Community publicKey={publicKey} environment={environment} theme="light" />
+  )
 }


### PR DESCRIPTION
**tldr:** In our case, I'm convinced of using `wakuv2.test` and `wakuv2.prod`.

Because,

1. `status.prod`, for example, was created for Desktop's "dogfooding"

>status.prod, which is exclusively used for status dogfooding and has the bridging. The new store is active there as it's required for the dogfooding. – https://discord.com/channels/864066763682218004/865466680129880074/991617462934179930

2. and does not even have a websocket address (look for `/wss` in Fleets below)

Fleets:

- https://fleets.status.im
- https://github.com/status-im/status-react/blob/develop/resources/config/fleets.json
- https://github.com/status-im/status-desktop/blob/master/fleets.json
- https://github.com/status-im/status-desktop/blob/master/resources/fleets.json
- https://github.com/status-im/status-go/blob/develop/config/cli/fleet-status.prod.json
- https://github.com/status-im/status-go/blob/develop/services/mailservers/fleet.go
- https://github.com/status-im/js-waku/blob/master/src/lib/discovery/predefined.ts

However,

>wakuv2.prod only keeps about 10000 messages of history. Depending on message rates, this translates to roughly a couple of hours' worth of historical messages. We have a beta version of the store protocol out that can keep up to 30 days of history (or even longer), but it's not yet deployed to the wakuv2.prod fleet while it's being dogfooded and query performance is improved – https://github.com/status-im/js-waku/issues/809#issuecomment-1170923344

>Oh. I thought we reverted both prod fleets.
>
>Only wakuv2.prod
>
>– https://discord.com/channels/864066763682218004/865466680129880074/991617579124797501

So,

keep in mind that the `Failed to intiliaze Community` errors might be more frequent on `wakuv2.prod` now.