### PR TITLE
Terminate `storybook` on `SIGINT`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,8 @@
     "build:types": "tsc --noEmit false --emitDeclarationOnly || true",
     "lint": "eslint src",
     "typecheck": "tsc",
-    "storybook": "TAMAGUI_TARGET='web' storybook dev -p 3001",
+    "storybook": "node ./scripts/storybook.js",
+    "storybook:dev": "TAMAGUI_TARGET='web' storybook dev -p 3001",
     "storybook:build": "TAMAGUI_TARGET='web' storybook build",
     "clean": "rimraf node_modules dist .turbo storybook-static"
   },

--- a/packages/components/scripts/storybook.js
+++ b/packages/components/scripts/storybook.js
@@ -1,0 +1,17 @@
+#!/usr/bin/node
+
+// todo: remove after adding `"type": "module",` to `package.json`
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const child_process = require('node:child_process')
+const process = require('node:process')
+
+const subprocess = child_process.spawn('yarn', ['storybook:dev'], {
+  detached: true,
+  stdio: 'inherit',
+})
+
+process.once('SIGINT', () => {
+  process.kill(-subprocess.pid, 'SIGKILL')
+})


### PR DESCRIPTION
## Why

Storybook hangs on termination and forces manual stopping or using of another process with new port.

Dump of open handles (server and file watchers):
```
^C
SIGINT
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
  - fd 0 (tty)
- Sockets:
  - ::1:3001 -> ::1:54047
  - ::1:3001 -> ::1:54054
  - ::1:3001 -> ::1:54055
  - ::1:3001 -> ::1:54056
  - ::1:3001 -> ::1:54063
- Servers:
  - :::3001 (HTTP)
    - Listeners:
      - request: app @ <project>/node_modules/@storybook/core-server/dist/index.js:31
- Others:
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
  - FSWatcher
```