### PR TITLE
Fix spacing in system message

### DIFF
--- a/packages/components/src/system-message/system-message.tsx
+++ b/packages/components/src/system-message/system-message.tsx
@@ -82,7 +82,7 @@ const SystemMessage = (props: Props) => {
   return (
     <Base
       flexDirection="row"
-      space={8}
+      gap={8}
       padding={8}
       alignItems="center"
       state={


### PR DESCRIPTION
Not sure how that happen, probably some shuffling and changing children, but there's no gap in system message between icon / avatar and message itself. This PR fixes that.

Wrong:
<img width="851" alt="Screenshot 2023-04-12 at 15 16 31" src="https://user-images.githubusercontent.com/520927/231469553-cfd685c7-53cd-4eab-9384-d8838b7232a5.png">

Fixed:
<img width="817" alt="Screenshot 2023-04-12 at 15 16 23" src="https://user-images.githubusercontent.com/520927/231469514-ffedc33d-d7d7-491a-8729-db379bf33924.png">
