### PR TITLE
fix: keep icon color if defined as part of button

### DIFF
--- a/.changeset/dirty-books-argue.md
+++ b/.changeset/dirty-books-argue.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix: keep icon color if defined as part of button

--- a/packages/components/src/button/button.stories.tsx
+++ b/packages/components/src/button/button.stories.tsx
@@ -1,3 +1,4 @@
+import { PopupIcon } from '@status-im/icons'
 import { action } from '@storybook/addon-actions'
 import { Stack } from 'tamagui'
 
@@ -82,6 +83,14 @@ export const PrimaryIconBefore: Story = {
   },
 }
 
+export const PrimaryIconBeforeDifferentColor: Story = {
+  name: 'Primary icon before/Different color',
+  args: {
+    children: 'Click me',
+    icon: <PopupIcon size={20} color="$yellow-50" />,
+  },
+}
+
 export const PrimaryIconAfter: Story = {
   name: 'Primary/Icon after',
   args: {
@@ -89,6 +98,15 @@ export const PrimaryIconAfter: Story = {
     iconAfter: icon,
   },
 }
+
+export const PrimaryIconAfterDifferentColor: Story = {
+  name: 'Primary/Icon after/Different color',
+  args: {
+    children: 'Click me',
+    iconAfter: <PopupIcon size={20} color="$yellow-50" />,
+  },
+}
+
 export const PrimaryIconOnly: Story = {
   name: 'Primary/Icon only',
   args: {

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -82,11 +82,17 @@ const Button = (props: Props, ref: Ref<View>) => {
       iconOnly={iconOnly}
       width={fullWidth ? '100%' : 'auto'}
     >
-      {icon ? cloneElement(icon, { color: textColor || '$neutral-40' }) : null}
+      {icon
+        ? cloneElement(icon, {
+            color: iconOnly ? textColor : icon.props.color ?? textColor,
+          })
+        : null}
       <Text weight="medium" color={textColor} size={textSize}>
         {children}
       </Text>
-      {iconAfter ? cloneElement(iconAfter, { color: textColor }) : null}
+      {iconAfter
+        ? cloneElement(iconAfter, { color: iconAfter.props.color ?? textColor })
+        : null}
     </Base>
   )
 }


### PR DESCRIPTION
This code:
![carbon](https://github.com/status-im/status-web/assets/520927/d15066e7-9383-4c00-95bf-3b136e2fd89b)

was translated as this:
<img width="129" alt="Screenshot 2023-09-14 at 21 55 14" src="https://github.com/status-im/status-web/assets/520927/f22f34cf-0493-4937-9e27-b1c06b920562">

Color of button variant was automatically applied. But there are cases where we need to apply specific icon color. In case color is defined for icon, defined color is used.

In case it's icon only variant, classic color variant of button is applied.

After change:
<img width="145" alt="Screenshot 2023-09-14 at 21 54 45" src="https://github.com/status-im/status-web/assets/520927/4e95b24a-be56-467d-b538-10a5bddae046">
