### PR TITLE
update toast

### DIFF
--- a/.changeset/old-donkeys-report.md
+++ b/.changeset/old-donkeys-report.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+update toast options

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -12,31 +12,46 @@ import type { ToastProps as RootProps } from '@radix-ui/react-toast'
 type ToastRootProps = Partial<Pick<RootProps, 'duration' | 'type'>>
 
 type ToastState = {
-  toast: ToastProps | null
+  toast: (ToastProps & { rootProps?: ToastRootProps }) | null
   dismiss: () => void
-  positive: (
-    message: string,
+  positive: (args: {
+    message: string
     actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-  ) => void
-  negative: (
-    message: string,
+    rootProps?: ToastRootProps
+  }) => void
+  negative: (args: {
+    message: string
     actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-  ) => void
-  custom: (
-    message: string,
-    icon: React.ReactElement,
+    rootProps?: ToastRootProps
+  }) => void
+  custom: (args: {
+    message: string
+    icon: React.ReactElement
     actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-  ) => void
+    rootProps?: ToastRootProps
+  }) => void
 }
 
 const useStore = create<ToastState>()(set => ({
   toast: null,
-  positive: (message, actionProps) =>
-    set({ toast: { ...actionProps, message, type: 'positive' } }),
-  negative: (message, actionProps) =>
-    set({ toast: { ...actionProps, message, type: 'negative' } }),
-  custom: (message, icon, actionProps) =>
-    set({ toast: { ...actionProps, message, icon } }),
+  positive: args =>
+    set({
+      toast: {
+        ...args,
+        type: 'positive',
+      },
+    }),
+  negative: args =>
+    set({
+      toast: {
+        ...args,
+        type: 'negative',
+      },
+    }),
+  custom: args =>
+    set({
+      toast: { ...args },
+    }),
   dismiss: () => set({ toast: null }),
 }))
 
@@ -53,6 +68,8 @@ const ToastContainer = () => {
     }
   }
 
+  const { rootProps, ...restProps } = store.toast
+
   return (
     <Provider>
       <ToastRoot
@@ -64,8 +81,9 @@ const ToastContainer = () => {
         onSwipeMove={event => event.preventDefault()}
         onSwipeCancel={event => event.preventDefault()}
         onSwipeEnd={event => event.preventDefault()}
+        {...rootProps}
       >
-        <Toast {...store.toast} />
+        <Toast {...restProps} />
       </ToastRoot>
       <Viewport />
     </Provider>

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -74,8 +74,8 @@ const ToastContainer = () => {
         onSwipeMove={event => event.preventDefault()}
         onSwipeCancel={event => event.preventDefault()}
         onSwipeEnd={event => event.preventDefault()}
-        {...(duration && { duration })}
-        {...(originType && { type: originType })}
+        duration={duration}
+        type={originType}
       >
         <Toast {...restProps} />
       </ToastRoot>

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -56,6 +56,11 @@ const ToastContainer = () => {
         defaultOpen
         onOpenChange={handleOpenChange}
         style={{ position: 'fixed' }}
+        // note: prevent swipe gestures from closing the toast until animation is implemented
+        onSwipeStart={event => event.preventDefault()}
+        onSwipeMove={event => event.preventDefault()}
+        onSwipeCancel={event => event.preventDefault()}
+        onSwipeEnd={event => event.preventDefault()}
       >
         <Toast {...store.toast} />
       </ToastRoot>

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -72,6 +72,7 @@ const useToast = () => {
       positive: store.positive,
       negative: store.negative,
       custom: store.custom,
+      dismiss: store.dismiss,
     }),
     [store]
   )

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -9,33 +9,18 @@ import { Toast } from './toast'
 import type { ToastProps } from './toast'
 import type { ToastProps as RootProps } from '@radix-ui/react-toast'
 
-type ToastRootProps = Partial<Pick<RootProps, 'duration' | 'type'>>
+type ToastRootProps = Partial<Pick<RootProps, 'duration'>> & {
+  originType?: RootProps['type']
+}
+
+type Options = ToastRootProps & Pick<ToastProps, 'action' | 'onAction'>
 
 type ToastState = {
-  toast: (ToastProps & { rootProps?: ToastRootProps }) | null
+  toast: (ToastProps & ToastRootProps) | null
   dismiss: () => void
-  positive: (
-    message: string,
-    options?: {
-      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-      rootProps?: ToastRootProps
-    }
-  ) => void
-  negative: (
-    message: string,
-    options?: {
-      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-      rootProps?: ToastRootProps
-    }
-  ) => void
-  custom: (
-    message: string,
-    icon: React.ReactElement,
-    options?: {
-      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-      rootProps?: ToastRootProps
-    }
-  ) => void
+  positive: (message: string, options?: Options) => void
+  negative: (message: string, options?: Options) => void
+  custom: (message: string, icon: React.ReactElement, options?: Options) => void
 }
 
 const useStore = create<ToastState>()(set => ({
@@ -76,7 +61,7 @@ const ToastContainer = () => {
     }
   }
 
-  const { rootProps, ...restProps } = store.toast
+  const { duration, originType, ...restProps } = store.toast
 
   return (
     <Provider>
@@ -89,7 +74,8 @@ const ToastContainer = () => {
         onSwipeMove={event => event.preventDefault()}
         onSwipeCancel={event => event.preventDefault()}
         onSwipeEnd={event => event.preventDefault()}
-        {...rootProps}
+        {...(duration && { duration })}
+        {...(originType && { type: originType })}
       >
         <Toast {...restProps} />
       </ToastRoot>

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -14,43 +14,51 @@ type ToastRootProps = Partial<Pick<RootProps, 'duration' | 'type'>>
 type ToastState = {
   toast: (ToastProps & { rootProps?: ToastRootProps }) | null
   dismiss: () => void
-  positive: (args: {
-    message: string
-    actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-    rootProps?: ToastRootProps
-  }) => void
-  negative: (args: {
-    message: string
-    actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-    rootProps?: ToastRootProps
-  }) => void
-  custom: (args: {
-    message: string
-    icon: React.ReactElement
-    actionProps?: Pick<ToastProps, 'action' | 'onAction'>
-    rootProps?: ToastRootProps
-  }) => void
+  positive: (
+    message: string,
+    options?: {
+      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
+      rootProps?: ToastRootProps
+    }
+  ) => void
+  negative: (
+    message: string,
+    options?: {
+      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
+      rootProps?: ToastRootProps
+    }
+  ) => void
+  custom: (
+    message: string,
+    icon: React.ReactElement,
+    options?: {
+      actionProps?: Pick<ToastProps, 'action' | 'onAction'>
+      rootProps?: ToastRootProps
+    }
+  ) => void
 }
 
 const useStore = create<ToastState>()(set => ({
   toast: null,
-  positive: args =>
+  positive: (message, options) =>
     set({
       toast: {
-        ...args,
+        message,
+        ...options,
         type: 'positive',
       },
     }),
-  negative: args =>
+  negative: (message, options) =>
     set({
       toast: {
-        ...args,
+        message,
+        ...options,
         type: 'negative',
       },
     }),
-  custom: args =>
+  custom: (message, icon, options) =>
     set({
-      toast: { ...args },
+      toast: { message, icon, ...options },
     }),
   dismiss: () => set({ toast: null }),
 }))

--- a/packages/components/src/toast/toast-container.tsx
+++ b/packages/components/src/toast/toast-container.tsx
@@ -7,6 +7,9 @@ import { create } from 'zustand'
 import { Toast } from './toast'
 
 import type { ToastProps } from './toast'
+import type { ToastProps as RootProps } from '@radix-ui/react-toast'
+
+type ToastRootProps = Partial<Pick<RootProps, 'duration' | 'type'>>
 
 type ToastState = {
   toast: ToastProps | null

--- a/packages/components/src/toast/toast.stories.tsx
+++ b/packages/components/src/toast/toast.stories.tsx
@@ -26,9 +26,7 @@ const ToastWithHook = () => {
   return (
     <Button
       size={32}
-      onPress={() =>
-        toast.positive({ message: 'Great success! This means good stuff!' })
-      }
+      onPress={() => toast.positive('Great success! This means good stuff!')}
     >
       Show Toast
     </Button>

--- a/packages/components/src/toast/toast.stories.tsx
+++ b/packages/components/src/toast/toast.stories.tsx
@@ -26,7 +26,9 @@ const ToastWithHook = () => {
   return (
     <Button
       size={32}
-      onPress={() => toast.positive('Great success! This means good stuff!')}
+      onPress={() =>
+        toast.positive({ message: 'Great success! This means good stuff!' })
+      }
     >
       Show Toast
     </Button>

--- a/packages/components/src/toast/toast.tsx
+++ b/packages/components/src/toast/toast.tsx
@@ -38,7 +38,7 @@ const Toast = (props: Props) => {
 
   return (
     <Base action={Boolean(action)}>
-      <Stack flex={1} flexDirection="row" gap={4}>
+      <Stack flex={1} flexDirection="row" gap={4} alignItems="center">
         <Stack width={20}>{renderIcon()}</Stack>
         <Description asChild>
           <Text size={13} weight={'medium'} color="$white-100">


### PR DESCRIPTION
## why

- https://github.com/status-im/status-website/pull/698
- to dismiss a toast on route change
- to keep a toast idefinitely open to reflect an error state
- to keep a toast open for longer, not just to glance at and possibly miss info