### PR TITLE
build: add `prepack` script in `packages/(components|colors/icons)`

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint src",
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write src",
-    "clean": "rimraf dist node_modules .turbo"
+    "clean": "rimraf dist node_modules .turbo",
+    "prepack": "yarn build"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,8 @@
     "storybook": "node ./scripts/storybook.js",
     "storybook:dev": "storybook dev -p 3001",
     "storybook:build": "storybook build",
-    "clean": "rimraf node_modules dist .turbo storybook-static .tamagui"
+    "clean": "rimraf node_modules dist .turbo storybook-static .tamagui",
+    "prepack": "yarn build"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,7 +31,8 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
-    "clean": "rimraf dist node_modules .turbo"
+    "clean": "rimraf dist node_modules .turbo",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@tamagui/core": "1.74.21",


### PR DESCRIPTION
The motivation behind this change is so one can install the libs using the [Git Protocol](https://yarnpkg.com/protocol/git)