### PR TITLE
fix the color of the icon in IconButton

### DIFF
--- a/.changeset/slow-doors-look.md
+++ b/.changeset/slow-doors-look.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix the color of the icon in IconButton

--- a/packages/components/src/icon-button/icon-button.tsx
+++ b/packages/components/src/icon-button/icon-button.tsx
@@ -50,7 +50,7 @@ const IconButton = (props: Props, ref: Ref<View>) => {
       activeBlur={blur ? (selected ? variant : undefined) : undefined}
     >
       {cloneElement(icon, {
-        color,
+        color: icon.props.color ?? color,
         size: 20,
       })}
     </Base>


### PR DESCRIPTION
It fixes bug, where color of the icon was not applied in the `<IconButton />` when used.

Usage of: 
`<OptionsIcon size={20} color="$danger-50" />`

Before:
<img width="303" alt="Screenshot 2024-05-23 at 10 14 31" src="https://github.com/status-im/status-web/assets/520927/abbeab8e-c6d0-41e8-8c76-ac2412690c7a">


After:
<img width="282" alt="Screenshot 2024-05-23 at 10 10 35" src="https://github.com/status-im/status-web/assets/520927/0ed3ba45-be7e-445d-b870-bf60f856deec">
