### PR TITLE
add disabled state to Tabs

### DIFF
--- a/.changeset/lemon-dogs-lie.md
+++ b/.changeset/lemon-dogs-lie.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+draft: add disabled state to Tabs

--- a/packages/components/src/tabs/tabs.stories.tsx
+++ b/packages/components/src/tabs/tabs.stories.tsx
@@ -32,7 +32,7 @@ export const Grey: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3">
+          <Tabs.Trigger type="default" value="3" aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -64,7 +64,7 @@ export const GreyBlur: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3">
+          <Tabs.Trigger type="default" value="3" aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -96,7 +96,7 @@ export const DarkGrey: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3">
+          <Tabs.Trigger type="default" value="3" aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -132,7 +132,7 @@ export const DarkGreyBlur: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3">
+          <Tabs.Trigger type="default" value="3" aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -176,6 +176,7 @@ export const Icon: StoryObj<TabsProps> = {
             type="icon"
             value="3"
             icon={<PlaceholderIcon size={16} />}
+            aria-disabled
           >
             Tab 3
           </Tabs.Trigger>
@@ -208,7 +209,7 @@ export const Counter: StoryObj<TabsProps> = {
           <Tabs.Trigger type="counter" value="2" count={10}>
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="counter" value="3" count={100}>
+          <Tabs.Trigger type="counter" value="3" count={100} aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -240,7 +241,7 @@ export const Step: StoryObj<TabsProps> = {
           <Tabs.Trigger type="step" value="2" step={10}>
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="step" value="3" step={999}>
+          <Tabs.Trigger type="step" value="3" step={999} aria-disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>

--- a/packages/components/src/tabs/tabs.stories.tsx
+++ b/packages/components/src/tabs/tabs.stories.tsx
@@ -32,7 +32,7 @@ export const Grey: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3" aria-disabled>
+          <Tabs.Trigger type="default" value="3" disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -64,7 +64,7 @@ export const GreyBlur: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3" aria-disabled>
+          <Tabs.Trigger type="default" value="3" disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -96,7 +96,7 @@ export const DarkGrey: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3" aria-disabled>
+          <Tabs.Trigger type="default" value="3" disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -132,7 +132,7 @@ export const DarkGreyBlur: StoryObj<TabsProps> = {
           <Tabs.Trigger type="default" value="2">
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="default" value="3" aria-disabled>
+          <Tabs.Trigger type="default" value="3" disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -176,7 +176,7 @@ export const Icon: StoryObj<TabsProps> = {
             type="icon"
             value="3"
             icon={<PlaceholderIcon size={16} />}
-            aria-disabled
+            disabled
           >
             Tab 3
           </Tabs.Trigger>
@@ -209,7 +209,7 @@ export const Counter: StoryObj<TabsProps> = {
           <Tabs.Trigger type="counter" value="2" count={10}>
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="counter" value="3" count={100} aria-disabled>
+          <Tabs.Trigger type="counter" value="3" count={100} disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>
@@ -241,7 +241,7 @@ export const Step: StoryObj<TabsProps> = {
           <Tabs.Trigger type="step" value="2" step={10}>
             Tab 2
           </Tabs.Trigger>
-          <Tabs.Trigger type="step" value="3" step={999} aria-disabled>
+          <Tabs.Trigger type="step" value="3" step={999} disabled>
             Tab 3
           </Tabs.Trigger>
         </Tabs.List>

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -72,7 +72,12 @@ type TriggerProps =
       children: string
       icon: React.ReactElement
     }
-  | { type: 'counter'; value: string; children: string; count: number }
+  | {
+      type: 'counter'
+      value: string
+      children: string
+      count: number
+    }
   | {
       type: 'step'
       value: string
@@ -87,10 +92,16 @@ const TabsTrigger = (props: TriggerProps, ref: Ref<View>) => {
   const providedProps = props as TriggerProps & {
     size: 24 | 32
     'aria-selected': boolean
+    'aria-disabled': boolean
     variant: Variants['variant']
   }
 
-  const { size, 'aria-selected': selected, variant } = providedProps
+  const {
+    size,
+    'aria-selected': selected,
+    'aria-disabled': disabled,
+    variant,
+  } = providedProps
 
   const { color, pressableProps } = usePressableColors(
     {
@@ -112,6 +123,7 @@ const TabsTrigger = (props: TriggerProps, ref: Ref<View>) => {
       size={size}
       variant={variant}
       active={selected}
+      disabled={disabled}
     >
       {props.type === 'icon' &&
         cloneElement(props.icon, {
@@ -228,6 +240,12 @@ const TriggerBase = styled(View, {
             pressStyle: { backgroundColor: '$white-20' },
           }
         }
+      },
+    },
+    disabled: {
+      true: {
+        opacity: 0.3,
+        cursor: 'default',
       },
     },
   } as const,

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -65,24 +65,28 @@ type TriggerProps =
       type: 'default'
       value: string
       children: string
+      disabled?: boolean
     }
   | {
       type: 'icon'
       value: string
       children: string
       icon: React.ReactElement
+      disabled?: boolean
     }
   | {
       type: 'counter'
       value: string
       children: string
       count: number
+      disabled?: boolean
     }
   | {
       type: 'step'
       value: string
       children: string
       step: number
+      disabled?: boolean
     }
 
 const TabsTrigger = (props: TriggerProps, ref: Ref<View>) => {
@@ -92,16 +96,11 @@ const TabsTrigger = (props: TriggerProps, ref: Ref<View>) => {
   const providedProps = props as TriggerProps & {
     size: 24 | 32
     'aria-selected': boolean
-    'aria-disabled': boolean
+    disabled: boolean
     variant: Variants['variant']
   }
 
-  const {
-    size,
-    'aria-selected': selected,
-    'aria-disabled': disabled,
-    variant,
-  } = providedProps
+  const { size, 'aria-selected': selected, disabled, variant } = providedProps
 
   const { color, pressableProps } = usePressableColors(
     {


### PR DESCRIPTION
This PR implements disabled state for Tabs.

It's necessary for implementation in Documentation.

<img width="561" alt="Screenshot 2024-06-03 at 14 34 26" src="https://github.com/status-im/status-web/assets/520927/1950c254-619d-4282-a792-e7dfa7e45ed0">
