### PR TITLE
Fix tag and tabs

### DIFF
--- a/.changeset/few-suits-rescue.md
+++ b/.changeset/few-suits-rescue.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+Fix tag and tabs

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -101,7 +101,7 @@ Trigger.displayName = Tabs.Trigger.displayName
 const tabStyles = cva({
   base: [
     'group inline-flex items-center gap-1 whitespace-nowrap',
-    'disabled:pointer-events-none disabled:opacity-[.3]',
+    'disabled:opacity-[.3]',
   ],
   variants: {
     variant: {

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -1,4 +1,5 @@
 import { PlaceholderIcon } from '@status-im/icons/20'
+import { action } from '@storybook/addon-actions'
 
 import { Tag } from './tag'
 
@@ -10,6 +11,7 @@ const meta = {
   args: {
     label: 'Tag',
     disabled: false,
+    selected: false,
     icon: <PlaceholderIcon />,
     iconPlacement: 'left',
   },
@@ -32,6 +34,7 @@ const meta = {
       <Tag {...props} icon={undefined} />
       <Tag {...props} label={undefined} />
       <Tag {...props} iconPlacement="right" />
+      <Tag {...props} onPress={action('pressed')} label="Pressable tag" />
     </div>
   ),
 } satisfies Meta<typeof Tag>

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -26,11 +26,11 @@ const meta = {
   render: props => (
     <div className="flex flex-col items-start gap-4">
       <Tag {...props} />
-      <Tag {...props} selected />
-      <Tag {...props} disabled />
+      <Tag {...props} onPress={action('pressed')} selected />
+      <Tag {...props} onPress={action('pressed')} disabled={true} />
       <Tag {...props} size="24" />
-      <Tag {...props} size="24" selected />
-      <Tag {...props} size="24" disabled />
+      <Tag {...props} size="24" onPress={action('pressed')} selected />
+      <Tag {...props} size="24" onPress={action('pressed')} disabled={true} />
       <Tag {...props} icon={undefined} />
       <Tag {...props} label={undefined} />
       <Tag {...props} iconPlacement="right" />
@@ -41,7 +41,12 @@ const meta = {
 
 type Story = StoryObj<typeof Tag>
 
-export const Light: Story = {}
+export const Light: Story = {
+  args: {
+    selected: true,
+    disabled: true,
+  },
+}
 
 // export const IconOnly: Story = {
 //   args: {

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta<typeof Tag> = {
       <Tag {...props} icon={undefined} />
       <Tag {...props} label={undefined} />
       <Tag {...props} iconPlacement="right" />
-      <Tag {...props} onPress={action('pressed')} label="Pressable tag" />
     </div>
   ),
 }

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof Tag> = {
 
 type Story = StoryObj<typeof Tag>
 
+export const Light: Story = {}
 
 // export const IconOnly: Story = {
 //   args: {

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -41,12 +41,6 @@ const meta: Meta<typeof Tag> = {
 
 type Story = StoryObj<typeof Tag>
 
-export const Light: Story = {
-  args: {
-    selected: true,
-    disabled: true,
-  },
-}
 
 // export const IconOnly: Story = {
 //   args: {

--- a/packages/components/src/tag/tag.stories.tsx
+++ b/packages/components/src/tag/tag.stories.tsx
@@ -5,7 +5,7 @@ import { Tag } from './tag'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
-const meta = {
+const meta: Meta<typeof Tag> = {
   component: Tag,
   title: 'Components/Tag',
   args: {
@@ -27,17 +27,17 @@ const meta = {
     <div className="flex flex-col items-start gap-4">
       <Tag {...props} />
       <Tag {...props} onPress={action('pressed')} selected />
-      <Tag {...props} onPress={action('pressed')} disabled={true} />
+      <Tag {...props} onPress={action('pressed')} disabled />
       <Tag {...props} size="24" />
       <Tag {...props} size="24" onPress={action('pressed')} selected />
-      <Tag {...props} size="24" onPress={action('pressed')} disabled={true} />
+      <Tag {...props} size="24" onPress={action('pressed')} disabled />
       <Tag {...props} icon={undefined} />
       <Tag {...props} label={undefined} />
       <Tag {...props} iconPlacement="right" />
       <Tag {...props} onPress={action('pressed')} label="Pressable tag" />
     </div>
   ),
-} satisfies Meta<typeof Tag>
+}
 
 type Story = StoryObj<typeof Tag>
 

--- a/packages/components/src/tag/tag.tsx
+++ b/packages/components/src/tag/tag.tsx
@@ -21,9 +21,7 @@ type ButtonProps = {
   disabled?: boolean
 } & Omit<React.ComponentPropsWithoutRef<'button'>, 'children'>
 
-type DivProps = {
-  onPress?: never
-} & Omit<React.ComponentPropsWithoutRef<'div'>, 'children'>
+type DivProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'children'>
 
 function Tag(
   props: Props & (ButtonProps | DivProps),
@@ -34,7 +32,6 @@ function Tag(
     icon,
     iconPlacement = 'left',
     label,
-    onPress,
     ...rest
   } = props
 
@@ -62,7 +59,7 @@ function Tag(
     return (
       <button
         {...buttonProps}
-        onClick={onPress}
+        onClick={props.onPress}
         ref={ref as Ref<HTMLButtonElement>}
         data-selected={selected ? selected : undefined}
         className={styles({

--- a/packages/components/src/tag/tag.tsx
+++ b/packages/components/src/tag/tag.tsx
@@ -8,24 +8,27 @@ import type { Ref } from 'react'
 
 type Variants = VariantProps<typeof styles>
 
-type ButtonProps = React.ComponentProps<'button'> & {
-  disabled?: boolean
-  selected?: boolean
-  onPress: () => void
-}
-
-type DivProps = React.ComponentProps<'div'> & {
-  onPress?: never
-}
-
 type Props = {
   size?: Variants['size']
   label?: string
   icon?: IconElement
   iconPlacement?: 'left' | 'right'
-} & (ButtonProps | DivProps)
+}
 
-function Tag(props: Props, ref: Ref<HTMLButtonElement | HTMLDivElement>) {
+type ButtonProps = {
+  onPress: () => void
+  selected?: boolean
+  disabled?: boolean
+} & Omit<React.ComponentPropsWithoutRef<'button'>, 'children'>
+
+type DivProps = {
+  onPress?: never
+} & Omit<React.ComponentPropsWithoutRef<'div'>, 'children'>
+
+function Tag(
+  props: Props & (ButtonProps | DivProps),
+  ref: Ref<HTMLButtonElement | HTMLDivElement>,
+) {
   const {
     size = '32',
     icon,

--- a/packages/components/src/tag/tag.tsx
+++ b/packages/components/src/tag/tag.tsx
@@ -38,7 +38,13 @@ const Tag = (props: Props, ref: Ref<HTMLButtonElement>) => {
       disabled={disabled}
       ref={ref}
       data-selected={selected}
-      className={styles({ size, selected, disabled, iconOnly })}
+      className={styles({
+        size,
+        selected,
+        disabled,
+        iconOnly,
+        pressable: Boolean(onClick),
+      })}
     >
       {icon && iconPlacement === 'left' && (
         <span className={iconStyles({ size, placement: 'left', iconOnly })}>
@@ -79,6 +85,9 @@ const styles = cva({
     },
     disabled: {
       true: 'pointer-events-none cursor-default border-neutral-20 opacity-[.3]',
+    },
+    pressable: {
+      false: 'cursor-default',
     },
   },
 })

--- a/packages/components/src/tag/tag.tsx
+++ b/packages/components/src/tag/tag.tsx
@@ -8,21 +8,22 @@ import type { Ref } from 'react'
 
 type Variants = VariantProps<typeof styles>
 
+type ButtonProps = React.ComponentProps<'button'> & {
+  disabled?: boolean
+  selected?: boolean
+  onPress: () => void
+}
+
+type DivProps = React.ComponentProps<'div'> & {
+  onPress?: never
+}
+
 type Props = {
   size?: Variants['size']
   label?: string
   icon?: IconElement
   iconPlacement?: 'left' | 'right'
-} & (
-  | (React.ComponentProps<'button'> & {
-      disabled?: boolean
-      selected?: boolean
-      onPress: () => void
-    })
-  | (React.ComponentProps<'div'> & {
-      onPress?: never
-    })
-)
+} & (ButtonProps | DivProps)
 
 function Tag(props: Props, ref: Ref<HTMLButtonElement | HTMLDivElement>) {
   const {
@@ -53,18 +54,18 @@ function Tag(props: Props, ref: Ref<HTMLButtonElement | HTMLDivElement>) {
   )
 
   if ('onPress' in props) {
-    const { ...tagProps } = props
+    const { selected, disabled, ...buttonProps } = props as ButtonProps
 
     return (
       <button
-        {...tagProps}
+        {...buttonProps}
         onClick={onPress}
         ref={ref as Ref<HTMLButtonElement>}
-        data-selected={tagProps.selected ? tagProps.selected : undefined}
+        data-selected={selected ? selected : undefined}
         className={styles({
           size,
-          selected: tagProps.selected,
-          disabled: tagProps.disabled,
+          selected,
+          disabled,
           iconOnly,
         })}
       >
@@ -75,7 +76,7 @@ function Tag(props: Props, ref: Ref<HTMLButtonElement | HTMLDivElement>) {
 
   return (
     <div
-      {...rest}
+      {...(rest as DivProps)}
       ref={ref as Ref<HTMLDivElement>}
       className={styles({
         size,


### PR DESCRIPTION
This PR changes:

Tag
- it doesn't show pointer cursor when there's no onPress event anymore

Tabs
- it enables to use Tooltip over Tabs for Documentation section