### PR TITLE
fix `<DropdowMenu.SubTrigger />` expanded state

### DIFF
--- a/.changeset/early-ligers-act.md
+++ b/.changeset/early-ligers-act.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix `<DropdowMenu.SubTrigger />` expanded state 

--- a/packages/components/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/components/src/dropdown-menu/dropdown-menu.tsx
@@ -231,7 +231,10 @@ export const SubTrigger = (props: SubTriggerProps) => {
   const { icon, label, danger, ...itemProps } = props
 
   return (
-    <DropdownMenu.SubTrigger {...itemProps} className={itemStyles()}>
+    <DropdownMenu.SubTrigger
+      {...itemProps}
+      className={itemStyles({ className: 'aria-expanded:bg-neutral-5' })}
+    >
       {icon && (
         <span className={iconStyles({ danger })}>{cloneElement(icon)}</span>
       )}


### PR DESCRIPTION
`<DropdowMenu.SubTrigger />` was missing a background highlight when expanded

![image](https://github.com/user-attachments/assets/9010aefa-f521-47e5-a54c-6cc1f132fc28)



