### PR TITLE
fix `<Button />` text alignment

### DIFF
--- a/.changeset/stupid-pumpkins-grow.md
+++ b/.changeset/stupid-pumpkins-grow.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix `<Button />` text alignment

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -88,7 +88,7 @@ function Button(
 
 const styles = cva({
   base: [
-    'inline-flex shrink-0 cursor-pointer select-none items-center justify-center gap-1 font-medium transition-all',
+    'inline-flex shrink-0 cursor-pointer select-none items-center justify-center gap-1 text-center font-medium transition-all',
     'outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-customisation-50 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-100',
     'disabled:pointer-events-none disabled:cursor-default disabled:opacity-[.3]',
   ],


### PR DESCRIPTION
before:
<img width="562" alt="image" src="https://github.com/user-attachments/assets/60fead09-8f7d-48ae-a1d1-75f47a4b75c1">

after:
<img width="564" alt="image" src="https://github.com/user-attachments/assets/f3179f4e-a47b-4f66-b468-32b60ba34bc9">
