### PR TITLE
chore: Remove flex-1 class from button component

### DIFF
--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -76,7 +76,7 @@ function Button(
           {iconBefore}
         </span>
       )}
-      <span className="flex-1 whitespace-nowrap">{children}</span>
+      <span className="whitespace-nowrap">{children}</span>
       {iconAfter && (
         <span className={iconStyles({ size, placement: 'after', variant })}>
           {iconAfter}


### PR DESCRIPTION
## why

<img width="136" alt="image" src="https://github.com/user-attachments/assets/5b726208-cba8-4c5c-a208-0f2bcf7a432f">
<img width="225" alt="image" src="https://github.com/user-attachments/assets/62886cf9-0eb3-45f9-a9c4-6dc3d0e22f72">
<img width="219" alt="image" src="https://github.com/user-attachments/assets/9ce4194d-cce6-42ca-b06a-48d210a88dc0">

https://www.figma.com/design/f3dsuwMe1Bocyv5sMe5CAc/status.app?node-id=13572-4846&m=dev
