### PR TITLE
fix `<Shortcut />`

### DIFF
--- a/.changeset/early-apes-judge.md
+++ b/.changeset/early-apes-judge.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix `<Shortcut />`icon prop and symbol centering

--- a/packages/components/src/shortcut/shortcut.stories.tsx
+++ b/packages/components/src/shortcut/shortcut.stories.tsx
@@ -9,7 +9,7 @@ const variants = ['primary', 'secondary', 'gray'] as const
 // eslint-disable-next-line react/display-name
 const renderVariant = (variant: (typeof variants)[number]) => (props: any) => (
   <div className="flex items-center gap-2">
-    <Shortcut {...props} variant={variant} icon={CommandIcon} />
+    <Shortcut {...props} variant={variant} icon={<CommandIcon />} />
     <Shortcut {...props} variant={variant} symbol="K" />
   </div>
 )

--- a/packages/components/src/shortcut/shortcut.tsx
+++ b/packages/components/src/shortcut/shortcut.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { cloneElement, forwardRef } from 'react'
 
 import { match, P } from 'ts-pattern'
 
@@ -8,7 +8,7 @@ import type { IconElement } from '../types'
 import type { VariantProps } from '../utils/variants'
 
 const styles = cva({
-  base: 'flex size-4 flex-shrink-0 items-center justify-center rounded-6 border',
+  base: 'grid size-4 flex-shrink-0 place-items-center rounded-6 border',
   variants: {
     variant: {
       primary: [
@@ -43,17 +43,17 @@ type Props = VariantProps<typeof styles> &
   )
 
 const Shortcut = (props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { variant = 'primary', icon, symbol, ...rest } = props
+  const { variant = 'primary' } = props
 
   return (
-    <div className={styles({ variant })} ref={ref} {...rest}>
-      {match({ icon, symbol })
+    <div className={styles({ variant })} ref={ref}>
+      {match(props)
         .with({ symbol: P.string }, ({ symbol }) => (
           <span className="text-11 font-medium">{symbol}</span>
         ))
-        .with({ icon: P._ }, ({ icon }) => (
-          <span className="size-3">{icon}</span>
-        ))
+        .with({ icon: P._ }, ({ icon }) =>
+          cloneElement(icon, { className: 'size-3' }),
+        )
         .exhaustive()}
     </div>
   )

--- a/packages/components/src/shortcut/shortcut.tsx
+++ b/packages/components/src/shortcut/shortcut.tsx
@@ -4,6 +4,7 @@ import { match, P } from 'ts-pattern'
 
 import { cva } from '../utils/variants'
 
+import type { IconElement } from '../types'
 import type { VariantProps } from '../utils/variants'
 
 const styles = cva({
@@ -32,7 +33,7 @@ const styles = cva({
 type Props = VariantProps<typeof styles> &
   (
     | {
-        icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
+        icon: IconElement
         symbol?: never
       }
     | {
@@ -42,15 +43,17 @@ type Props = VariantProps<typeof styles> &
   )
 
 const Shortcut = (props: Props, ref: React.Ref<HTMLDivElement>) => {
-  const { variant = 'primary', ...rest } = props
+  const { variant = 'primary', icon, symbol, ...rest } = props
 
   return (
     <div className={styles({ variant })} ref={ref} {...rest}>
-      {match(props)
+      {match({ icon, symbol })
         .with({ symbol: P.string }, ({ symbol }) => (
           <span className="text-11 font-medium">{symbol}</span>
         ))
-        .with({ icon: P._ }, ({ icon: Icon }) => <Icon className="size-3" />)
+        .with({ icon: P._ }, ({ icon }) => (
+          <span className="size-3">{icon}</span>
+        ))
         .exhaustive()}
     </div>
   )


### PR DESCRIPTION
- unify how icon is passed with the rest of components
- fix error 
![image](https://github.com/user-attachments/assets/569289ce-67ca-4640-8396-df38bb843233)


Also the symbol placement is centered now:

![image](https://github.com/user-attachments/assets/545a5dfd-4cbd-4661-98a6-919d69523886)
![image](https://github.com/user-attachments/assets/2c18c59e-a6b8-41fe-93b9-d9a832addd88)

