### PR TITLE
jenkinsfile: filter stages based on path

### DIFF
--- a/apps/connector/Jenkinsfile
+++ b/apps/connector/Jenkinsfile
@@ -1,6 +1,8 @@
 #!/usr/bin/env groovy
 library 'status-jenkins-lib@v1.9.11'
 
+def changesDetected = false
+
 pipeline {
   agent { label 'linux' }
 
@@ -27,7 +29,41 @@ pipeline {
   }
 
   stages {
+    stage('Initial changelog checkout') {
+      when {
+          expression { currentBuild.previousCompletedBuild == null }
+      }
+      steps {
+        script {
+          checkout scmGit(
+              branches: scm.branches,
+              extensions: [
+                  cloneOption(depth: 100, noTags: true, reference: '', shallow: true),
+                  changelogToBranch(changelogBase(
+                      compareRemote: 'origin',
+                      compareTarget: CHANGE_TARGET
+                  ))
+              ],
+              userRemoteConfigs: scm.userRemoteConfigs
+          )
+        }
+      }
+    }
+
+    stage('Check changes') {
+      when {
+          changeset pattern: "apps/connector/**", comparator: "GLOB"
+      }
+      steps {
+        script {
+            changesDetected = true
+        }
+      }
+    }
     stage('Install') {
+      when {
+          expression { changesDetected }
+      }
       steps {
           dir("${env.WORKSPACE}/apps/connector") {
             script {
@@ -42,6 +78,9 @@ pipeline {
     }
 
     stage('Build') {
+      when {
+          expression { changesDetected }
+      }
       steps {
           dir("${env.WORKSPACE}/apps/connector") {
             script {
@@ -56,6 +95,9 @@ pipeline {
     }
 
     stage('Zip') {
+      when {
+          expression { changesDetected }
+      }
       steps {
         dir("${env.WORKSPACE}/apps/connector") {
           zip(
@@ -68,6 +110,9 @@ pipeline {
     }
 
     stage('Archive') {
+      when {
+          expression { changesDetected }
+      }
       steps {
         dir("${env.WORKSPACE}/apps/connector") {
           archiveArtifacts(
@@ -79,6 +124,9 @@ pipeline {
     }
 
     stage('Upload') {
+      when {
+          expression { changesDetected }
+      }
       steps {
         dir("${env.WORKSPACE}/apps/connector") {
           script {
@@ -90,8 +138,20 @@ pipeline {
   }
 
   post {
-    success { script { github.notifyPR(true) } }
-    failure { script { github.notifyPR(false) } }
+    success {
+      script {
+        if(changesDetected) {
+          github.notifyPR(true) 
+        } 
+      }
+    }
+    failure {
+      script {
+        if(changesDetected) {
+          github.notifyPR(false) 
+        } 
+      }
+    }
     cleanup { cleanWs() }
   }
 }


### PR DESCRIPTION
Ideally we would want to trigger Jenkins build based on the path where change occurred. Unfortunately this is not supported by Jenkins. As a workaround we are conditionally executing steps if the change occured in the apps/connector/ path. Prior to this we need to fetch the changelog diff between current branch and target branch to understand if there was a change present in the target dir and if we need to run all stages. The population of changelog is needed just the first time the PR is opened and in the subsequent steps we don't need this.

Referenced issue: https://github.com/status-im/status-web/issues/590