### PR TITLE
Icon only button - Fix color for all variants

### DIFF
--- a/.changeset/famous-news-fry.md
+++ b/.changeset/famous-news-fry.md
@@ -1,0 +1,5 @@
+---
+'@status-im/components': patch
+---
+
+updates icon color for missing compound variants

--- a/packages/components/src/button/button.stories.tsx
+++ b/packages/components/src/button/button.stories.tsx
@@ -1,3 +1,7 @@
+import { Fragment } from 'react'
+
+import { PlaceholderIcon } from '@status-im/icons/20'
+
 import { Button } from './button'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -51,7 +55,22 @@ const meta: Meta<
       ).map(variant => (
         <div key={variant} className="flex items-center gap-4">
           {(['40', '32', '24'] as const).map(size => (
-            <Button key={size} {...args} variant={variant} size={size} />
+            <Fragment key={size}>
+              <Button {...args} variant={variant} size={size} />
+              {/* With icon */}
+              <Button
+                {...args}
+                size={size}
+                variant={variant}
+                iconBefore={<PlaceholderIcon />}
+              />
+              <Button
+                aria-label="Button with icon only"
+                size={size}
+                variant={variant}
+                icon={<PlaceholderIcon />}
+              />
+            </Fragment>
           ))}
         </div>
       ))}

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -194,9 +194,39 @@ const iconStyles = cva({
       className: '-mr-0.5',
     },
     {
+      variant: 'grey',
+      iconOnly: true,
+      className: '!text-neutral-100 dark:!text-white-100',
+    },
+    {
       variant: 'outline',
       iconOnly: true,
       className: '!text-neutral-100 dark:!text-white-100',
+    },
+    {
+      variant: 'darkGrey',
+      iconOnly: true,
+      className: '!text-neutral-100 dark:!text-white-100',
+    },
+    {
+      variant: 'ghost',
+      iconOnly: true,
+      className: '!text-neutral-100 dark:!text-white-100',
+    },
+    {
+      variant: 'primary',
+      iconOnly: true,
+      className: '!text-white-100',
+    },
+    {
+      variant: 'positive',
+      iconOnly: true,
+      className: '!text-white-100',
+    },
+    {
+      variant: 'danger',
+      iconOnly: true,
+      className: '!text-white-100',
     },
   ],
 })


### PR DESCRIPTION
**Changes**

- Adds missing compound variants for icon styles for all use cases with iconOnly mode.
- Updated story to reflect icon use.

![image](https://github.com/user-attachments/assets/fb561e72-0ddc-4bdd-8e18-2a58763b9e34)
![image](https://github.com/user-attachments/assets/f00dbd40-66f1-4a9a-8f65-de0432f155d5)
