### PR TITLE
jenkinsfile: revert check for changed files

### DIFF
--- a/apps/connector/Jenkinsfile
+++ b/apps/connector/Jenkinsfile
@@ -30,25 +30,14 @@ pipeline {
 
   stages {
     stage('Check Changed Files') {
-        steps {
-          script {
-            // Get the list of changed files
-            def changedFiles = sh(
-                script: "git diff --name-only origin/main...HEAD",
-                returnStdout: true
-            ).trim()
-            
-            // Check if the changes are relevant
-            def isRelevant = changedFiles.split('\n').any { file ->
-                file.startsWith('apps/connector/')
-            }
-
-            // If no relevant changes, skip the build
-            if (isRelevant) {
-                changesDetected = true
-            }
-          }
+      when {
+          changeset pattern: "apps/connector/**", comparator: "GLOB"
+      }
+      steps {
+        script {
+            changesDetected = true
         }
+      }
     }
 
     stage('Install') {


### PR DESCRIPTION
Reverted the check for changes in the `apps/connector` directory.

What we were missing before with this kind of check is this setting in the Jenkins pipeline:
![Screenshot from 2024-10-17 11 00 14](https://github.com/user-attachments/assets/51d18662-3ce6-4043-83d5-9e07ccef9e0f)
and as explained here:
![Screenshot from 2024-10-17 11 00 25](https://github.com/user-attachments/assets/3f7e62d8-3bac-478c-a022-a5837708ff54)

This allows, when PR is opened, that changelog exists and we don't need to execute git commands manually within jenkinsfile which is prone to errors. 

The motivation for this was that previously the `Strategy` for `Discover pull requests from origin` was `Merging the pull request with the current target branch revision` and this caused the PR builds to happen when there were changes in the `main`:
```
Merging the pull request with the current target branch revision
    Discover each pull request once with the discovered revision corresponding to the result of merging with the current revision of the target branch. Note that pushes to the target branch will result in new pull request builds. 
```
I've changed this to:
```
The current pull request revision
    Discover each pull request once with the discovered revision corresponding to the pull request head revision without merging. 
```
But with this change a normal PR build would fail on our `Check Changed Files` stage with:
```
10:49:49  + git diff --name-only origin/main...HEAD
10:49:49  fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree.
10:49:49  Use '--' to separate paths from revisions, like this:
10:49:49  'git <command> [<revision>...] -- [<file>...]'
```
because there is an uncomplete fetch of changes.