### PR TITLE
fix `<DropdownMenu.SubTrigger>` icon; unknown network typo

### DIFF
--- a/.changeset/polite-cobras-accept.md
+++ b/.changeset/polite-cobras-accept.md
@@ -1,0 +1,5 @@
+---
+"@status-im/components": patch
+---
+
+fix <DropdownMenu.SubTrigger /> icon; unknown network typo

--- a/packages/colors/src/networks.ts
+++ b/packages/colors/src/networks.ts
@@ -4,7 +4,7 @@ export const networks = {
   hermez: 'rgba(235 132 98 / 100%)',
   optimism: 'rgba(231 110 110 / 100%)',
   polygon: 'rgba(173 113 243 / 100%)',
-  unknow: 'rgba(238 242 245 / 100%)',
+  unknown: 'rgba(238 242 245 / 100%)',
   'x-dai': 'rgba(63 192 189 / 100%)',
   'zk-sync': 'rgba(159 160 254 / 100%)',
 }

--- a/packages/components/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/components/src/dropdown-menu/dropdown-menu.tsx
@@ -2,8 +2,8 @@ import { cloneElement, forwardRef, useId } from 'react'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import {
-  ArrowRightIcon,
   CheckIcon,
+  ChevronRightIcon,
   ExternalIcon,
   SearchIcon,
 } from '@status-im/icons/20'
@@ -236,7 +236,7 @@ export const SubTrigger = (props: SubTriggerProps) => {
         <span className={iconStyles({ danger })}>{cloneElement(icon)}</span>
       )}
       <span className={labelStyles({ danger })}>{label}</span>
-      <ArrowRightIcon className="text-neutral-50" />
+      <ChevronRightIcon className="text-neutral-50" />
     </DropdownMenu.SubTrigger>
   )
 }


### PR DESCRIPTION
This PR:
- fixes incorrect icon in DropdownMenu.SubTrigger component.
- fixes typo in networks

Figma:
<img width="407" alt="Screenshot 2024-10-18 at 12 39 47" src="https://github.com/user-attachments/assets/d0162f3f-68b0-47b0-b16c-efb630a2077e">

Icon before:
<img width="237" alt="Screenshot 2024-10-18 at 12 37 52" src="https://github.com/user-attachments/assets/c42998a7-214f-452c-92d6-6dc1b9a82bbd">

Icon after:
<img width="286" alt="Screenshot 2024-10-18 at 12 37 37" src="https://github.com/user-attachments/assets/3505472f-7b71-4f17-bb41-ca4a15da6182">
