### PR TITLE
fix mnemonic validation & navbar route

### DIFF
--- a/apps/wallet/src/routes/__root.tsx
+++ b/apps/wallet/src/routes/__root.tsx
@@ -7,7 +7,6 @@ import { Navbar } from '@status-im/wallet/components'
 import {
   createRootRouteWithContext,
   HeadContent,
-  // Link,
   // Navigate,
   Outlet,
   redirect,
@@ -108,6 +107,7 @@ function RootComponent() {
                 hasFeedback={/^\/portfolio\/(assets|collectibles)\/[^/]+$/.test(
                   pathname ?? '',
                 )}
+                linkComponent={Link}
               />
             </div>
             <div className="px-1">

--- a/packages/wallet/src/components/import-recovery-phrase-form/index.tsx
+++ b/packages/wallet/src/components/import-recovery-phrase-form/index.tsx
@@ -9,9 +9,12 @@ import { z } from 'zod'
 import { RecoveryPhraseTextarea } from '../recovery-phrase-textarea'
 
 const mnemonicSchema = z.object({
-  mnemonic: z.string().refine(value => validateMnemonic(value, english), {
-    message: 'Invalid phrase. Check word count and spelling.',
-  }),
+  mnemonic: z
+    .string()
+    .trim()
+    .refine(value => validateMnemonic(value, english), {
+      message: 'Invalid phrase. Check word count and spelling.',
+    }),
 })
 
 type FormValues = z.infer<typeof mnemonicSchema>

--- a/packages/wallet/src/components/nav-bar/index.tsx
+++ b/packages/wallet/src/components/nav-bar/index.tsx
@@ -3,23 +3,33 @@
 import { FeedbackPopover } from '../feedback'
 import { Logo } from '../logo'
 
+import type { ReactNode } from 'react'
+
+type LinkComponentProps = {
+  href: string
+  children: ReactNode
+}
+
 type Props = {
   hasFeedback?: boolean
+  linkComponent?: React.ComponentType<LinkComponentProps>
 }
 
 const Navbar = (props: Props) => {
+  const { linkComponent: LinkComponent = 'a' } = props
+
   return (
     <div
       data-theme="dark"
       className="sticky top-0 z-20 flex h-14 flex-1 items-center justify-between bg-neutral-100 pr-1"
     >
       <div className="flex items-center pl-3 lg:pl-6">
-        <a
+        <LinkComponent
           href="/"
           className="flex w-[32px] min-w-[32px] overflow-hidden lg:w-auto"
         >
           <Logo isTopbarDesktop />
-        </a>
+        </LinkComponent>
       </div>
       {props.hasFeedback && <FeedbackPopover />}
     </div>


### PR DESCRIPTION
This PR fixes:
- mnemonic validation, which trims whitespace before and after recovery phrase - see https://github.com/status-im/status-web/issues/671#issuecomment-3010614936 1.
- link on logo in the navbar which currently routes to 404