### PR TITLE
ci: fix accessing CHANGE_ID env var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,8 +126,8 @@ pipeline {
   }
 
   post {
-    success { script { if (changesDetected && CHANGE_ID) { github.notifyPR(true) } } }
-    failure { script { if (changesDetected && CHANGE_ID) { github.notifyPR(false) } } }
+    success { script { if (changesDetected && env.CHANGE_ID) { github.notifyPR(true) } } }
+    failure { script { if (changesDetected && env.CHANGE_ID) { github.notifyPR(false) } } }
     cleanup { cleanWs() }
   }
 }


### PR DESCRIPTION
Otherwise we get errors like this at the end of a job:
```
groovy.lang.MissingPropertyException: No such property: CHANGE_ID for class: groovy.lang.Binding
```