### PR TITLE
Update analytics script to restrict data domains

### DIFF
--- a/apps/hub/src/app/layout.tsx
+++ b/apps/hub/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
           strategy="afterInteractive"
           src="https://umami.bi.status.im/script.js"
           data-website-id="5a1d3ceb-20f1-4808-b2c3-3414704740e5"
-          data-domains="hub.status.network,status-network-hub.vercel.app,status-network-hub-git-feat-add-analytics-status-im-web.vercel.app"
+          data-domains="hub.status.network"
         />
       </body>
     </html>


### PR DESCRIPTION
Restrict the data domain to `hub.status.network only`

and updated the domain at https://umami.bi.status.im/websites
<img width="1322" height="412" alt="Screenshot 2025-11-26 at 8 23 43 PM" src="https://github.com/user-attachments/assets/7291bc44-ad41-46af-a88e-441bc2896507" />

Relevant issue: https://github.com/status-im/status-web/issues/846