### PR TITLE
Update app metadata for iOS and Android with new app details

### DIFF
--- a/.changeset/bright-otters-link.md
+++ b/.changeset/bright-otters-link.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+Update Status app metadata and universal link configuration for the new iOS and Android app details.

--- a/apps/status.app/public/.well-known/apple-app-site-association
+++ b/apps/status.app/public/.well-known/apple-app-site-association
@@ -3,16 +3,188 @@
 		"details": [
 			{
 				"appIDs": [
+					"8B5X2M6H2Y.app.status.mobile"
+				],
+				"components": [
+					{
+						"/": "/",
+						"comment": "Root",
+						"exclude": true
+					},
+					{
+						"/": "/c/*",
+						"comment": "Community"
+					},
+					{
+						"/": "/cc/*",
+						"comment": "Community channel"
+					},
+					{
+						"/": "/u/*",
+						"comment": "User"
+					},
+					{
+						"/": "/p/*",
+						"comment": "Private chat"
+					},
+					{
+						"/": "/b/*",
+						"comment": "Browser"
+					},
+					{
+						"/": "/cr/*",
+						"comment": "Community request"
+					},
+					{
+						"/": "/g/*",
+						"comment": "Group chat"
+					},
+					{
+						"/": "/wallet/*",
+						"comment": "Wallet"
+					}
+				]
+			},
+			{
+				"appIDs": [
 					"DTX7Z4U3YA.im.status.ethereum",
+					"8B5X2M6H2Y.im.status.ethereum"
+				],
+				"components": [
+					{
+						"/": "/",
+						"comment": "Root",
+						"exclude": true
+					},
+					{
+						"/": "/c/*",
+						"comment": "Community"
+					},
+					{
+						"/": "/cc/*",
+						"comment": "Community channel"
+					},
+					{
+						"/": "/u/*",
+						"comment": "User"
+					},
+					{
+						"/": "/p/*",
+						"comment": "Private chat"
+					},
+					{
+						"/": "/b/*",
+						"comment": "Browser"
+					},
+					{
+						"/": "/cr/*",
+						"comment": "Community request"
+					},
+					{
+						"/": "/g/*",
+						"comment": "Group chat"
+					},
+					{
+						"/": "/wallet/*",
+						"comment": "Wallet"
+					}
+				]
+			},
+			{
+				"appIDs": [
+					"7JLRC79H5J.im.Status.NimStatusClient",
+					"8B5X2M6H2Y.im.Status.NimStatusClient"
+				],
+				"components": [
+					{
+						"/": "/",
+						"comment": "Root",
+						"exclude": true
+					},
+					{
+						"/": "/c/*",
+						"comment": "Community"
+					},
+					{
+						"/": "/cc/*",
+						"comment": "Community channel"
+					},
+					{
+						"/": "/u/*",
+						"comment": "User"
+					},
+					{
+						"/": "/p/*",
+						"comment": "Private chat"
+					},
+					{
+						"/": "/b/*",
+						"comment": "Browser"
+					},
+					{
+						"/": "/cr/*",
+						"comment": "Community request"
+					},
+					{
+						"/": "/g/*",
+						"comment": "Group chat"
+					},
+					{
+						"/": "/wallet/*",
+						"comment": "Wallet"
+					}
+				]
+			},
+			{
+				"appIDs": [
+					"8B5X2M6H2Y.app.status.mobile.pr"
+				],
+				"components": [
+					{
+						"/": "/",
+						"comment": "Root",
+						"exclude": true
+					},
+					{
+						"/": "/c/*",
+						"comment": "Community"
+					},
+					{
+						"/": "/cc/*",
+						"comment": "Community channel"
+					},
+					{
+						"/": "/u/*",
+						"comment": "User"
+					},
+					{
+						"/": "/p/*",
+						"comment": "Private chat"
+					},
+					{
+						"/": "/b/*",
+						"comment": "Browser"
+					},
+					{
+						"/": "/cr/*",
+						"comment": "Community request"
+					},
+					{
+						"/": "/g/*",
+						"comment": "Group chat"
+					},
+					{
+						"/": "/wallet/*",
+						"comment": "Wallet"
+					}
+				]
+			},
+			{
+				"appIDs": [
 					"DTX7Z4U3YA.im.status.ethereum.test",
 					"46H86FR76G.im.status.ethereum.test",
-					"7JLRC79H5J.im.Status.NimStatusClient",
-					"8B5X2M6H2Y.im.status.ethereum",
-					"8B5X2M6H2Y.im.Status.NimStatusClient",
 					"8B5X2M6H2Y.im.status.ethereum.pr",
-					"8B5X2M6H2Y.im.status.ethereum.debug",
-					"8B5X2M6H2Y.app.status.mobile",
-					"8B5X2M6H2Y.app.status.mobile.pr"
+					"8B5X2M6H2Y.im.status.ethereum.debug"
 				],
 				"components": [
 					{

--- a/apps/status.app/src/app/layout.tsx
+++ b/apps/status.app/src/app/layout.tsx
@@ -32,13 +32,13 @@ export const metadata = Metadata({
 
   appLinks: {
     ios: {
-      app_store_id: '1178893006',
-      app_name: 'Status — Ethereum. Anywhere',
+      app_store_id: '6754166924',
+      app_name: 'Status - privacy super app',
       url: 'https://status.app',
     },
     android: {
-      package: 'im.status.ethereum',
-      app_name: 'Status — Ethereum. Anywhere',
+      package: 'app.status.mobile',
+      app_name: 'Status - privacy super app',
       url: 'https://status.app',
     },
   },


### PR DESCRIPTION
## Summary
- update `apple-app-site-association` to separate app IDs into ordered `details` entries
- put the new iOS app `app.status.mobile` ahead of legacy app IDs for shared `status.app` link paths
- update `appLinks` metadata to use the new mobile app identifiers on iOS and Android

## Follow-up
- final behavior still needs on device verification on `status.app`, since preview domains cannot validate real universal link routing

## Issue
https://github.com/status-im/status-app/issues/20342#issuecomment-4191081311