### PR TITLE
chore: Hub - Disable new pre-deposits

### DIFF
--- a/.changeset/honest-steaks-yell.md
+++ b/.changeset/honest-steaks-yell.md
@@ -1,3 +1,3 @@
 ---
-prepare for predeposit unlock
+hub: patch
 ---

--- a/.changeset/honest-steaks-yell.md
+++ b/.changeset/honest-steaks-yell.md
@@ -1,0 +1,3 @@
+---
+prepare for predeposit unlock
+---

--- a/apps/hub/messages/en.json
+++ b/apps/hub/messages/en.json
@@ -712,6 +712,10 @@
     "disclaimer": {
       "translation": "disclaimer",
       "notes": "rewards::disclaimer"
+    },
+    "predeposit_end": {
+      "translation": "Pre-deposit period has now ended. Fund unlock and reward claiming will be available soon",
+      "notes": "rewards::predeposit_end"
     }
   },
   "pre_deposits": {
@@ -800,6 +804,10 @@
     "coming_soon": {
       "translation": "Coming soon",
       "notes": "vault::coming_soon"
+    },
+    "campaign_deposit_stopped": {
+      "translation": "Deposits Paused",
+      "notes": "vault::campaign_deposit_stopped"
     },
     "deposit_funds": {
       "translation": "Deposit funds",

--- a/apps/hub/messages/ko.json
+++ b/apps/hub/messages/ko.json
@@ -712,6 +712,10 @@
     "disclaimer": {
       "translation": "면책 조항",
       "notes": "rewards::disclaimer"
+    },
+    "predeposit_end": {
+      "translation": "입금 기간이 종료되었습니다. 자산 인출 및 보상 수령은 곧 가능해집니다.",
+      "notes": "rewards::predeposit_end"
     }
   },
   "pre_deposits": {
@@ -800,6 +804,10 @@
     "coming_soon": {
       "translation": "곧 출시 예정",
       "notes": "vault::coming_soon"
+    },
+    "campaign_deposit_stopped": {
+      "translation": "입금 일시 중단",
+      "notes": "vault::campaign_deposit_stopped"
     },
     "deposit_funds": {
       "translation": "자금 예치하기",

--- a/apps/hub/src/app/_components/rewards-section.tsx
+++ b/apps/hub/src/app/_components/rewards-section.tsx
@@ -44,6 +44,9 @@ const RewardsSection = () => {
           {t('rewards.disclaimer')}
         </Link>
         .
+        <br />
+        <br />
+        {t('rewards.predeposit_end')}
       </p>
     </div>
   )

--- a/apps/hub/src/app/_components/vault-card.tsx
+++ b/apps/hub/src/app/_components/vault-card.tsx
@@ -327,10 +327,11 @@ const VaultCardContent: FC<VaultCardContentProps> = ({
       <Button
         size="40"
         onClick={handleClick}
-        disabled={isDisabled}
+        disabled={true}
         className="mt-auto w-full justify-center lg:w-fit"
       >
-        {isDisabled ? t('vault.coming_soon') : t('vault.deposit')}
+        {/*{isDisabled ? t('vault.coming_soon') : t('vault.deposit')}*/}
+        {t('vault.campaign_deposit_stopped')}
       </Button>
     </div>
   )


### PR DESCRIPTION
Disable new pre-deposits to wrap up the predeposit campaign and prepare for unlock