### PR TITLE
fix(wallet): prevent env.server from loading in client bundle

### DIFF
--- a/apps/wallet/src/router.gen.ts
+++ b/apps/wallet/src/router.gen.ts
@@ -186,9 +186,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OnboardingLayoutRoute: typeof OnboardingLayoutRouteWithChildren
-  SettingsIndexRoute: typeof SettingsIndexRoute
   WalletFlowImportRoute: typeof WalletFlowImportRoute
   WalletFlowNewRoute: typeof WalletFlowNewRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
   PortfolioAssetsTickerRoute: typeof PortfolioAssetsTickerRoute
   PortfolioActivityIndexRoute: typeof PortfolioActivityIndexRoute
   PortfolioAssetsIndexRoute: typeof PortfolioAssetsIndexRoute
@@ -310,9 +310,9 @@ const OnboardingLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OnboardingLayoutRoute: OnboardingLayoutRouteWithChildren,
-  SettingsIndexRoute: SettingsIndexRoute,
   WalletFlowImportRoute: WalletFlowImportRoute,
   WalletFlowNewRoute: WalletFlowNewRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
   PortfolioAssetsTickerRoute: PortfolioAssetsTickerRoute,
   PortfolioActivityIndexRoute: PortfolioActivityIndexRoute,
   PortfolioAssetsIndexRoute: PortfolioAssetsIndexRoute,

--- a/apps/wallet/src/routes/portfolio/collectibles/-components/nft-helpers.ts
+++ b/apps/wallet/src/routes/portfolio/collectibles/-components/nft-helpers.ts
@@ -3,7 +3,7 @@ import {
   extractTxHash,
   isSupportedNftStandard,
 } from '@status-im/wallet/components'
-import { NETWORK_TO_CHAIN_ID } from '@status-im/wallet/data'
+import { NETWORK_TO_CHAIN_ID } from '@status-im/wallet/constants'
 import { Interface } from 'ethers'
 
 import {

--- a/packages/wallet/src/constants/index.ts
+++ b/packages/wallet/src/constants/index.ts
@@ -1,2 +1,4 @@
+export type { NetworkType } from '../data/api/types'
+export { NETWORK_TO_CHAIN_ID } from '../data/api/types'
 export { ERROR_MESSAGES } from './errors'
 export { GRADIENTS } from './gradients'


### PR DESCRIPTION
## Problem
Wallet extension onboarding page renders blank on `main`, after merging the [Implement NFT transfer](https://github.com/status-im/status-web/pull/1089) PR.
```
env.server.mjs:5 Uncaught Error: ❌ Attempted to access a server-side environment variable on the client
```

## Fix
Re-export `NETWORK_TO_CHAIN_ID` / `NetworkType` from `@status-im/wallet/constants` backed by `data/api/types.ts` which has no env.server dependency and switch the client import site to use it.
