### PR TITLE
fix(wallet): revalidate price chart cache on first stale read

### DIFF
--- a/.changeset/legal-books-wear.md
+++ b/.changeset/legal-books-wear.md
@@ -1,0 +1,5 @@
+---
+'@status-im/wallet': patch
+---
+
+fix(wallet): revalidate price chart cache on first stale read

--- a/packages/wallet/src/data/services/coingecko/index.ts
+++ b/packages/wallet/src/data/services/coingecko/index.ts
@@ -9,6 +9,7 @@ import retry from 'async-retry'
 
 import { serverEnv } from '../../../config/env.server.mjs'
 import erc20TokenList from '../../../constants/erc20.json'
+import { setRevalidationBucket } from '../../../utils'
 import { DEFAULT_TOKEN_IDS } from '../../api/routers/assets'
 import { markApiKeyAsRateLimited } from '../api-key-rotation'
 
@@ -347,6 +348,7 @@ export async function fetchTokenPriceHistory(
   const url = new URL(`${PROXY_BASE_URL}/v1/coins/${coinId}/market_chart`)
   url.searchParams.set('vs_currency', 'usd')
   url.searchParams.set('days', daysParam)
+  setRevalidationBucket(url, revalidate)
 
   return _fetchWithAuth<CoinGeckoMarketChartResponse>(
     url,
@@ -409,6 +411,7 @@ export async function fetchTokensPrice(
     url.searchParams.set('include_24hr_change', 'true')
     url.searchParams.set('include_market_cap', 'true')
     url.searchParams.set('include_24hr_vol', 'true')
+    setRevalidationBucket(url, revalidate)
 
     const priceData = await _fetchWithAuth<CoinGeckoSimplePriceResponse>(
       url,

--- a/packages/wallet/src/utils/index.ts
+++ b/packages/wallet/src/utils/index.ts
@@ -4,6 +4,7 @@ export {
   chartIntervalSeconds,
 } from './chart-timestamps'
 export { padHex } from './pad-hex'
+export { setRevalidationBucket } from './revalidation-bucket'
 export { toChecksumAddress } from './to-checksum-address'
 export {
   getTransactionHash,

--- a/packages/wallet/src/utils/revalidation-bucket.ts
+++ b/packages/wallet/src/utils/revalidation-bucket.ts
@@ -1,0 +1,13 @@
+/**
+ * Partition the Next.js fetch-cache key by the revalidate window so that the
+ * first request after the window expires is a cache MISS (synchronous fresh
+ * fetch) rather than a stale-while-revalidate hit. Without this, the route
+ * returns the previous snapshot — potentially many hours old after an idle
+ * period — while revalidation happens in the background.
+ */
+export function setRevalidationBucket(url: URL, revalidate: number): void {
+  url.searchParams.set(
+    '_bucket',
+    String(Math.floor(Date.now() / (revalidate * 1000))),
+  )
+}


### PR DESCRIPTION
#### Summary

Price chart routes (`assets.tokenPriceChart` / `assets.nativeTokenPriceChart`) returned stale data -- sometimes many hours old after an idle period -- on first load, only refreshing ~1 minute later.

- Root cause: Next.js's `fetch` cache uses stale-while-revalidate, so the first request after the revalidate window returns the previous snapshot immediately and only schedules a background refresh. React Query then locks that stale payload in for its 60 s `staleTime`.

- Fix: Partition the fetch URL by the revalidate window using a `_bucket` query param (`floor(Date.now() / (revalidate * 1000))`). Requests inside a window share a URL -> cache hit (caching preserved); the first request after a window rolls over gets a new URL -> cache miss -> synchronous fresh fetch. Applied to `fetchTokenPriceHistory` and `fetchTokensPrice` via a shared `setRevalidationBucket` util.

#### Test

- `pnpm install && pnpm build`; `pnpm turbo run dev --filter="./apps/api..." --filter="./apps/wallet..."`; reload extension if already loaded (turned on in your extensions' manager tab).
- Open the wallet extension, view a token's price chart on each time frame (24H / 7D / 1M / 3M / 1Y / All) -- data should reflect the latest price and show _fresh_ data (<1 hour ago).
- Verify the value charts as well.
- There should not be any unreasonably big time gap between points -- [see example here](https://github.com/status-im/status-web/pull/1135#issuecomment-4405017821)