### PR TITLE
ci(website): scope workspace build to hub

### DIFF
--- a/Jenkinsfile.website
+++ b/Jenkinsfile.website
@@ -77,7 +77,7 @@ pipeline {
       steps {
         script {
           nix.develop(
-            'pnpm build',
+            'pnpm turbo run build --filter=hub...',
             pure: false,
           )
         }


### PR DESCRIPTION
Avoid building unrelated apps in website pipeline so hub deploys are not blocked by failures in other workspaces.