### PR TITLE
feat(hub): reorder vaults, update rewards, fix ko translation

### DIFF
--- a/.changeset/chatty-maps-roll.md
+++ b/.changeset/chatty-maps-roll.md
@@ -1,0 +1,5 @@
+---
+"hub": patch
+---
+
+feat(hub): reorder vaults, update rewards, fix ko translation

--- a/apps/hub/messages/en.json
+++ b/apps/hub/messages/en.json
@@ -931,9 +931,21 @@
       "translation": "Unlock",
       "notes": "vault::unlock_label"
     },
-    "native_apps_points": {
-      "translation": "native apps points",
-      "notes": "vault::native_apps_points"
+    "rewards_eth": {
+      "translation": "SNT + LINEA rewards, accrued ETH yield",
+      "notes": "vault::rewards_eth"
+    },
+    "rewards_snt": {
+      "translation": "LINEA rewards",
+      "notes": "vault::rewards_snt"
+    },
+    "rewards_linea": {
+      "translation": "SNT rewards",
+      "notes": "vault::rewards_linea"
+    },
+    "rewards_gusd": {
+      "translation": "SNT + LINEA rewards, accrued GUSD yield",
+      "notes": "vault::rewards_gusd"
     },
     "eth_wrapped_success": {
       "translation": "ETH wrapped successfully. You can now proceed with deposit.",

--- a/apps/hub/messages/ko.json
+++ b/apps/hub/messages/ko.json
@@ -931,9 +931,21 @@
       "translation": "잠금 해제",
       "notes": "vault::unlock_label"
     },
-    "native_apps_points": {
-      "translation": "네이티브 앱 포인트",
-      "notes": "vault::native_apps_points"
+    "rewards_eth": {
+      "translation": "SNT + LINEA 보상, 누적 ETH 수익",
+      "notes": "vault::rewards_eth"
+    },
+    "rewards_snt": {
+      "translation": "LINEA 보상",
+      "notes": "vault::rewards_snt"
+    },
+    "rewards_linea": {
+      "translation": "SNT 보상",
+      "notes": "vault::rewards_linea"
+    },
+    "rewards_gusd": {
+      "translation": "SNT + LINEA 보상, 누적 GUSD 수익",
+      "notes": "vault::rewards_gusd"
     },
     "eth_wrapped_success": {
       "translation": "ETH 래핑이 완료되었습니다. 이제 예치를 진행할 수 있습니다.",
@@ -1018,6 +1030,10 @@
     "bridging": {
       "translation": "브리징 중…",
       "notes": "vault::bridging"
+    },
+    "sent_to_receiver": {
+      "translation": "{address}로 전송됨",
+      "notes": "vault::sent_to_receiver"
     },
     "claim": {
       "translation": "청구",

--- a/apps/hub/src/app/_components/vault-card.tsx
+++ b/apps/hub/src/app/_components/vault-card.tsx
@@ -29,13 +29,7 @@ import { useUnlockTxHash } from '~hooks/useUnlockTxHash'
 import { useVaultBalanceReadiness } from '~hooks/useVaultBalanceReadiness'
 import { useVaultCardCta, type VaultCardAction } from '~hooks/useVaultCardCta'
 
-import {
-  DollarIcon,
-  GusdIcon,
-  KarmaCircleIcon,
-  PlusIcon,
-  SumIcon,
-} from './icons'
+import { DollarIcon, GusdIcon, PlusIcon, SumIcon } from './icons'
 import { VaultImage } from './vault-image'
 
 type Props = {
@@ -206,13 +200,7 @@ const VaultCardContent: FC<VaultCardContentProps> = ({
     pendingActionRef.current = null
   }, [isConnected, onClaim, onUnlock, pendingActionRef, vault])
 
-  const rewardsLine = rewards
-    .map(reward =>
-      reward.startsWith('vault.')
-        ? t(reward as 'vault.native_apps_points')
-        : reward
-    )
-    .join(', ')
+  const rewardsLine = t(rewards as 'vault.rewards_eth')
 
   const vaultDisplay = isGUSD
     ? {
@@ -319,12 +307,6 @@ const VaultCardContent: FC<VaultCardContentProps> = ({
       )}
 
       <ul className="my-4 space-y-2">
-        <li className="flex items-center gap-2 text-15">
-          <span className="text-purple">
-            <KarmaCircleIcon />
-          </span>
-          <span className="text-neutral-100">KARMA</span>
-        </li>
         <li className="flex items-center gap-2 text-15">
           <span className="text-neutral-50">
             <PlusIcon />

--- a/apps/hub/src/app/_components/vault-card.tsx
+++ b/apps/hub/src/app/_components/vault-card.tsx
@@ -200,7 +200,7 @@ const VaultCardContent: FC<VaultCardContentProps> = ({
     pendingActionRef.current = null
   }, [isConnected, onClaim, onUnlock, pendingActionRef, vault])
 
-  const rewardsLine = t(rewards as 'vault.rewards_eth')
+  const rewardsLine = t(rewards)
 
   const vaultDisplay = isGUSD
     ? {

--- a/apps/hub/src/app/_constants/address.ts
+++ b/apps/hub/src/app/_constants/address.ts
@@ -41,12 +41,18 @@ export type GUSDConfig = {
   outputToken: Token
 }
 
+type VaultRewardsKey =
+  | 'vault.rewards_eth'
+  | 'vault.rewards_snt'
+  | 'vault.rewards_linea'
+  | 'vault.rewards_gusd'
+
 export type BaseVault = {
   id: string
   name: string
   address: Address
   apr: string
-  rewards: string
+  rewards: VaultRewardsKey
   icon: string
   token: Token
   chainId: number

--- a/apps/hub/src/app/_constants/address.ts
+++ b/apps/hub/src/app/_constants/address.ts
@@ -46,7 +46,7 @@ export type BaseVault = {
   name: string
   address: Address
   apr: string
-  rewards: string[]
+  rewards: string
   icon: string
   token: Token
   chainId: number
@@ -201,7 +201,7 @@ export const SNT_VAULT: Vault = {
   id: 'SNT',
   name: 'SNT Vault',
   apr: '',
-  rewards: ['LINEA', 'vault.native_apps_points'],
+  rewards: 'vault.rewards_snt',
   icon: 'SNT',
   address: '0x493957E168aCCdDdf849913C3d60988c652935Cd',
   token: SNT_TOKEN,
@@ -216,7 +216,7 @@ export const LINEA_VAULT: Vault = {
   id: 'LINEA',
   name: 'LINEA Vault',
   apr: '',
-  rewards: ['SNT', 'vault.native_apps_points'],
+  rewards: 'vault.rewards_linea',
   icon: 'LINEA',
   address: '0xb223cA53A53A5931426b601Fa01ED2425D8540fB',
   token: LINEA_TOKEN,
@@ -231,7 +231,7 @@ export const WETH_VAULT: Vault = {
   id: 'WETH',
   name: 'WETH vault',
   apr: '',
-  rewards: ['SNT, LINEA', 'vault.native_apps_points'],
+  rewards: 'vault.rewards_eth',
   icon: 'WETH',
   address: '0xc71Ec84Ee70a54000dB3370807bfAF4309a67a1f',
   token: WETH_TOKEN,
@@ -246,7 +246,7 @@ export const GUSD_VAULT: GUSDVault = {
   id: 'GUSD',
   name: 'GUSD Vault',
   apr: '',
-  rewards: ['SNT, LINEA', 'vault.native_apps_points'],
+  rewards: 'vault.rewards_gusd',
   icon: 'GUSD',
   address: GENERIC_DEPOSITOR.address,
   token: DEFAULT_GUSD_STABLECOIN,
@@ -265,7 +265,7 @@ export const GUSD_VAULT: GUSDVault = {
   },
 }
 
-export const VAULTS: Vault[] = [WETH_VAULT, GUSD_VAULT, SNT_VAULT, LINEA_VAULT]
+export const VAULTS: Vault[] = [WETH_VAULT, SNT_VAULT, LINEA_VAULT, GUSD_VAULT]
 
 export const KARMA = {
   address: '0x0700bE6f329cC48C38144f71c898b72795dB6C1b' as Address,


### PR DESCRIPTION
This PR:
- removes mentions of Karma and updates rewards in every vault
- fixes missing korean translation for `sent_to_receiver`
- reorders vaults