### PR TITLE
feat(vercel): add redirects for missing blog posts

### DIFF
--- a/.changeset/tidy-carrots-glow.md
+++ b/.changeset/tidy-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+'status.network': patch
+---
+
+redirect blog posts

--- a/apps/status.network/next.config.ts
+++ b/apps/status.network/next.config.ts
@@ -17,6 +17,24 @@ const nextConfig: NextConfig = {
       pathname: '/content/images/**',
     })),
   },
+  async redirects() {
+    return [
+      {
+        source:
+          '/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution',
+        destination:
+          'https://status.app/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution',
+        statusCode: 301,
+      },
+      {
+        source:
+          '/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream',
+        destination:
+          'https://status.app/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream',
+        statusCode: 301,
+      },
+    ]
+  },
 }
 
 export default withNextIntl(nextConfig)

--- a/apps/status.network/vercel.json
+++ b/apps/status.network/vercel.json
@@ -2,5 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ../../{patches,package.json,turbo.json} ../../packages/{colors,icons} ./",
   "installCommand": "pnpm install --dir ../../ --frozen-lockfile",
-  "buildCommand": "git submodule update --init --recursive && turbo run build --cwd ../../ --filter=./apps/status.network..."
+  "buildCommand": "git submodule update --init --recursive && turbo run build --cwd ../../ --filter=./apps/status.network...",
+  "redirects": [
+    { "source": "/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution", "destination": "https://status.app/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution" },
+    { "source": "/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream", "destination": "https://status.app/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream" }
+  ]
 }

--- a/apps/status.network/vercel.json
+++ b/apps/status.network/vercel.json
@@ -2,9 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ../../{patches,package.json,turbo.json} ../../packages/{colors,icons} ./",
   "installCommand": "pnpm install --dir ../../ --frozen-lockfile",
-  "buildCommand": "git submodule update --init --recursive && turbo run build --cwd ../../ --filter=./apps/status.network...",
-  "redirects": [
-    { "source": "/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution", "destination": "https://status.app/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution" },
-    { "source": "/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream", "destination": "https://status.app/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream" }
-  ]
+  "buildCommand": "git submodule update --init --recursive && turbo run build --cwd ../../ --filter=./apps/status.network..."
 }


### PR DESCRIPTION
what

- closes https://github.com/status-im/status-web/issues/1201

where

- https://status-network-website-git-add-redirects-status-im-web.vercel.app/blog/pre-deposit-vaults-withdrawal-timeline-and-rewards-distribution 
- https://status-network-website-git-add-redirects-status-im-web.vercel.app/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream 