### PR TITLE
Deleting unnecessary ref url "ref=our.status.im"

### DIFF
--- a/.changeset/flat-geckos-act.md
+++ b/.changeset/flat-geckos-act.md
@@ -1,0 +1,5 @@
+---
+"status.app": patch
+---
+
+Deleting unnecessary ref url "ref=our.status.im"

--- a/apps/status.app/src/config/routes.ts
+++ b/apps/status.app/src/config/routes.ts
@@ -20,7 +20,7 @@ export const STATUS_DESKTOP_DOWNLOAD_URL_LINUX = '/api/download/linux'
 export const STATUS_MOBILE_APP_STORE_URL =
   'https://apps.apple.com/us/app/status-privacy-super-app/id6754166924'
 export const STATUS_MOBILE_GOOGLE_PLAY_URL =
-  'https://play.google.com/store/apps/details?id=app.status.mobile&ref=our.status.im'
+  'https://play.google.com/store/apps/details?id=app.status.mobile'
 export const STATUS_MOBILE_F_DROID_URL =
   'https://f-droid.org/packages/im.status.ethereum'
 export const STATUS_MOBILE_APK_URL = '/api/download/android'


### PR DESCRIPTION
Its a ref from the ghost, which was already switch off. Shouldnt be on our internal CTAs as its overwrites first touch referral traffic.