### PR TITLE
fix(blog): style Ghost post tables and blockquotes

### DIFF
--- a/.changeset/mellow-pandas-shimmer.md
+++ b/.changeset/mellow-pandas-shimmer.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): style Ghost post tables and reduce blockquote size

--- a/apps/status.app/src/app/_components/content/index.tsx
+++ b/apps/status.app/src/app/_components/content/index.tsx
@@ -196,8 +196,15 @@ const baseComponents = {
       </h6>
     )
   },
-  blockquote: (props: ComponentProps<'blockquote'> & { size?: 19 | 27 }) => {
-    const { children, size = 27, ...rest } = props
+  blockquote: (
+    props: ComponentProps<'blockquote'> & { size?: 19 | 27; border?: string }
+  ) => {
+    const {
+      children,
+      size = 27,
+      border = 'border-l border-dashed border-neutral-30 pl-6',
+      ...rest
+    } = props
 
     const blockquoteChildren = Children.toArray(children).filter(
       child => child !== '\n'
@@ -206,10 +213,7 @@ const baseComponents = {
     return (
       <blockquote
         {...rest}
-        className={cx(
-          blockquoteParagraphTextSize[size],
-          'mt-5 border-l border-dashed border-neutral-30 !pt-0 pl-6'
-        )}
+        className={cx(blockquoteParagraphTextSize[size], border, 'mt-5 !pt-0')}
       >
         {/* {children} */}
         {/* {renderText({ children, size: paragraphTextSize[size] }))} */}
@@ -426,7 +430,11 @@ export const blogComponents = {
     return baseComponents.h2({ ...props, mb: 'mb-4', mt: 'mt-6' })
   },
   blockquote: (props: ComponentProps<'blockquote'>) => {
-    return baseComponents.blockquote({ ...props, size: 19 })
+    return baseComponents.blockquote({
+      ...props,
+      size: 19,
+      border: 'border-l-2 border-neutral-40 pl-4',
+    })
   },
   // note: Ghost posts contain raw HTML tables without classes
   table: (props: ComponentProps<'table'>) => {

--- a/apps/status.app/src/app/_components/content/index.tsx
+++ b/apps/status.app/src/app/_components/content/index.tsx
@@ -436,32 +436,29 @@ export const blogComponents = {
       border: 'border-l-2 border-neutral-40 pl-4',
     })
   },
-  // note: Ghost posts contain raw HTML tables without classes
-  table: (props: ComponentProps<'table'>) => {
+  table: (props: any) => {
+    const [head, body] = props.children
+    const headers = head.props.children.props.children
+    const rows = body.props.children
+
     return (
-      <div className="my-5 overflow-x-auto">
-        <div className="w-fit min-w-full overflow-hidden rounded-12 border border-neutral-20">
-          <table {...props} className="w-full" />
-        </div>
-      </div>
+      <Table>
+        <TableHead>
+          {headers.map((header: any, index: any) => (
+            <TableHeader key={index} {...header.props} />
+          ))}
+        </TableHead>
+        <TableContent>
+          {rows.map((row: any, index: any) => (
+            <TableRow key={index}>
+              {row.props.children.map((cell: any, index: any) => (
+                <TableCell key={index} {...cell.props} />
+              ))}
+            </TableRow>
+          ))}
+        </TableContent>
+      </Table>
     )
-  },
-  thead: (props: ComponentProps<'thead'>) => {
-    return <thead {...props} className="border-b border-neutral-10" />
-  },
-  tbody: (props: ComponentProps<'tbody'>) => {
-    return <tbody {...props} className="divide-y divide-neutral-10" />
-  },
-  th: (props: ComponentProps<'th'>) => {
-    return (
-      <th
-        {...props}
-        className="whitespace-nowrap bg-neutral-5 p-3 text-left text-15 font-medium text-neutral-50"
-      />
-    )
-  },
-  td: (props: ComponentProps<'td'>) => {
-    return <td {...props} className="p-3 align-top text-15" />
   },
 }
 

--- a/apps/status.app/src/app/_components/content/index.tsx
+++ b/apps/status.app/src/app/_components/content/index.tsx
@@ -425,6 +425,36 @@ export const blogComponents = {
   h2: (props: ComponentProps<'h2'>) => {
     return baseComponents.h2({ ...props, mb: 'mb-4', mt: 'mt-6' })
   },
+  blockquote: (props: ComponentProps<'blockquote'>) => {
+    return baseComponents.blockquote({ ...props, size: 19 })
+  },
+  // note: Ghost posts contain raw HTML tables without classes
+  table: (props: ComponentProps<'table'>) => {
+    return (
+      <div className="my-5 overflow-x-auto">
+        <div className="w-fit min-w-full overflow-hidden rounded-12 border border-neutral-20">
+          <table {...props} className="w-full" />
+        </div>
+      </div>
+    )
+  },
+  thead: (props: ComponentProps<'thead'>) => {
+    return <thead {...props} className="border-b border-neutral-10" />
+  },
+  tbody: (props: ComponentProps<'tbody'>) => {
+    return <tbody {...props} className="divide-y divide-neutral-10" />
+  },
+  th: (props: ComponentProps<'th'>) => {
+    return (
+      <th
+        {...props}
+        className="whitespace-nowrap bg-neutral-5 p-3 text-left text-15 font-medium text-neutral-50"
+      />
+    )
+  },
+  td: (props: ComponentProps<'td'>) => {
+    return <td {...props} className="p-3 align-top text-15" />
+  },
 }
 
 export const jobsComponents = {

--- a/apps/status.app/src/app/_components/content/table.tsx
+++ b/apps/status.app/src/app/_components/content/table.tsx
@@ -10,8 +10,8 @@ export function Table(props: {
   const { hasShadow = false, children } = props
 
   const table = (
-    <div className="w-min overflow-hidden rounded-12 border border-neutral-20">
-      <table className="w-[540px] group-[.group]:max-w-[calc(540px-2rem)]">
+    <div className="w-fit min-w-full overflow-hidden rounded-12 border border-neutral-20">
+      <table className="w-full group-[.group]:max-w-[calc(540px-2rem)]">
         {children}
       </table>
     </div>

--- a/apps/status.app/src/app/_components/content/table.tsx
+++ b/apps/status.app/src/app/_components/content/table.tsx
@@ -10,7 +10,7 @@ export function Table(props: {
   const { hasShadow = false, children } = props
 
   const table = (
-    <div className="w-fit min-w-full overflow-hidden rounded-12 border border-neutral-20">
+    <div className="overflow-hidden rounded-12 border border-neutral-20">
       <table className="w-full group-[.group]:max-w-[calc(540px-2rem)]">
         {children}
       </table>
@@ -19,9 +19,9 @@ export function Table(props: {
 
   return (
     <div className="overflow-x-auto">
-      <div className="w-fit max-[542px]:pb-4 max-[542px]:pr-12">
+      <div className="w-full max-[542px]:pb-4 max-[542px]:pr-12">
         {hasShadow ? (
-          <div className="w-min rounded-12 shadow-1">{table}</div>
+          <div className="w-full rounded-12 shadow-1">{table}</div>
         ) : (
           table
         )}


### PR DESCRIPTION
Closes [#1215](https://github.com/status-im/status-web/issues/1215)

Ghost posts render raw HTML through `blogComponents`, which had no `table` mappings, so tables appeared unstyled. Blockquotes also rendered at 27px, oversized compared to body text.

## Changes
- Add `table`, `thead`, `tbody`, `th`, `td` mappings to `blogComponents` (rounded border, header background, row dividers, horizontal scroll)
- Reduce blog blockquote size from 27 to 19, matching `helpComponents`/`specsComponents`