### PR TITLE
Remove empty sitemap line from robots.ts

### DIFF
--- a/apps/get.status.app/src/app/robots.ts
+++ b/apps/get.status.app/src/app/robots.ts
@@ -12,6 +12,6 @@ export default function robots(): MetadataRoute.Robots {
         allow: '/',
       },
     ],
-    sitemap: `${baseUrl}/sitemap.xml`,
+    // Remove the sitemap line since it's empty and shouldn't be advertised
   }
 }


### PR DESCRIPTION
Remove the sitemap line since it's empty and shouldn't be advertised.