### PR TITLE
Remove empty sitemap line from robots.md

### DIFF
--- a/.changeset/Remove empty sitemap line from robots.md
+++ b/.changeset/Remove empty sitemap line from robots.md
@@ -1,0 +1,1 @@
+Remove the sitemap line since it's empty and shouldn't be advertised.

--- a/apps/get.status.app/src/app/robots.ts
+++ b/apps/get.status.app/src/app/robots.ts
@@ -12,6 +12,5 @@ export default function robots(): MetadataRoute.Robots {
         allow: '/',
       },
     ],
-    sitemap: `${baseUrl}/sitemap.xml`,
   }
 }


### PR DESCRIPTION
Remove the sitemap line since it's empty and shouldn't be advertised.