### PR TITLE
Fix mobile overflow for blog tables

### DIFF
--- a/.changeset/calm-tables-scroll.md
+++ b/.changeset/calm-tables-scroll.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(blog): allow mobile tables to scroll

--- a/apps/status.app/src/app/_components/content/table.tsx
+++ b/apps/status.app/src/app/_components/content/table.tsx
@@ -10,24 +10,26 @@ export function Table(props: {
   const { hasShadow = false, children } = props
 
   const table = (
-    <div className="inline-block min-w-full overflow-hidden rounded-12 border border-neutral-20 align-top">
-      <table className="min-w-full group-[.group]:max-w-[calc(540px-2rem)]">
-        {children}
-      </table>
+    <table className="min-w-full group-[.group]:max-w-[calc(540px-2rem)]">
+      {children}
+    </table>
+  )
+
+  const tableFrame = (
+    <div className="w-full overflow-hidden rounded-12 border border-neutral-20">
+      <div className="overflow-x-auto">{table}</div>
     </div>
   )
 
   return (
-    <div className="overflow-x-auto">
-      <div className="w-full max-[542px]:pb-4 max-[542px]:pr-12">
-        {hasShadow ? (
-          <div className="inline-block min-w-full rounded-12 shadow-1">
-            {table}
-          </div>
-        ) : (
-          table
-        )}
-      </div>
+    <div className="w-full max-[542px]:pb-4">
+      {hasShadow ? (
+        <div className="inline-block min-w-full rounded-12 align-top shadow-1">
+          {tableFrame}
+        </div>
+      ) : (
+        tableFrame
+      )}
     </div>
   )
 }

--- a/apps/status.app/src/app/_components/content/table.tsx
+++ b/apps/status.app/src/app/_components/content/table.tsx
@@ -10,8 +10,8 @@ export function Table(props: {
   const { hasShadow = false, children } = props
 
   const table = (
-    <div className="overflow-hidden rounded-12 border border-neutral-20">
-      <table className="w-full group-[.group]:max-w-[calc(540px-2rem)]">
+    <div className="inline-block min-w-full overflow-hidden rounded-12 border border-neutral-20 align-top">
+      <table className="min-w-full group-[.group]:max-w-[calc(540px-2rem)]">
         {children}
       </table>
     </div>
@@ -21,7 +21,9 @@ export function Table(props: {
     <div className="overflow-x-auto">
       <div className="w-full max-[542px]:pb-4 max-[542px]:pr-12">
         {hasShadow ? (
-          <div className="w-full rounded-12 shadow-1">{table}</div>
+          <div className="inline-block min-w-full rounded-12 shadow-1">
+            {table}
+          </div>
         ) : (
           table
         )}


### PR DESCRIPTION
## Summary
- Update the shared content table wrapper so blog tables fill the mobile article width at minimum.
- Allow wide table content to expand beyond the visible column and scroll horizontally instead of being clipped.
- Keep the existing rounded border and shadow styling intact.

## Before
<img width="358" height="542" alt="Screenshot 2026-06-12 at 7 32 05 PM" src="https://github.com/user-attachments/assets/bdfd51f7-7bfe-43cf-8d67-09110af2018f" />

## After
<img width="364" height="393" alt="Screenshot 2026-06-12 at 7 32 49 PM" src="https://github.com/user-attachments/assets/3159a315-8358-4e59-96c4-9a0916172eb9" />


## Preview
https://status-website-git-statusapp-table-fix-status-im-web.vercel.app/learn