### PR TITLE
fix(sitemap): exclude blog tag pages from status.app sitemap

### DIFF
--- a/.changeset/tidy-falcons-drift.md
+++ b/.changeset/tidy-falcons-drift.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(sitemap): exclude blog tag pages from sitemap

--- a/apps/status.app/src/app/(website)/_lib/ghost/index.ts
+++ b/apps/status.app/src/app/(website)/_lib/ghost/index.ts
@@ -245,30 +245,6 @@ export const getTagSlugs = async (): Promise<string[]> => {
   }
 }
 
-export type TagSitemapEntry = {
-  slug: string
-}
-
-export const getTagsForSitemap = async (): Promise<TagSitemapEntry[]> => {
-  try {
-    const tags = await ghost.tags.browse({
-      limit: clientEnv.NEXT_PUBLIC_VERCEL_ENV === 'production' ? 'all' : 50,
-      fields: 'slug',
-      filter: `visibility:public`,
-    })
-
-    return tags
-      .filter(
-        (tag): tag is typeof tag & { slug: string } =>
-          !!tag.slug && !ALL_EXCLUDED_TAGS.includes(tag.slug)
-      )
-      .map(tag => ({ slug: tag.slug }))
-  } catch (error) {
-    console.error('Failed to fetch tags for sitemap from Ghost API:', error)
-    return []
-  }
-}
-
 type LearnParams = { page?: number; limit?: number }
 
 export const getLearnPosts = async (params: LearnParams = {}) => {

--- a/apps/status.app/src/app/sitemap.ts
+++ b/apps/status.app/src/app/sitemap.ts
@@ -2,7 +2,6 @@ import { allHelpDocs, allSpecsDocs } from '~content'
 import {
   getLearnPostsForSitemap,
   getPostsForSitemap,
-  getTagsForSitemap,
 } from '~website/_lib/ghost'
 
 import type { MetadataRoute } from 'next'
@@ -56,9 +55,8 @@ function toDate(value: string | Date | undefined): Date {
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const buildDate = new Date()
 
-  const [posts, tags, learnPosts] = await Promise.all([
+  const [posts, learnPosts] = await Promise.all([
     getPostsForSitemap(),
-    getTagsForSitemap(),
     getLearnPostsForSitemap(),
   ])
 
@@ -74,10 +72,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   for (const post of learnPosts) {
     entries.set(toUrl(`/blog/${post.slug}`), toDate(post.updatedAt))
-  }
-
-  for (const tag of tags) {
-    entries.set(toUrl(`/blog/tag/${tag.slug}`), buildDate)
   }
 
   for (const doc of allHelpDocs) {


### PR DESCRIPTION
## Summary
- Requested by Kamila
- Removes all `/blog/tag/{slug}` URLs from the status.app sitemap. Tag listing pages are low-value, near-duplicate index pages that don't need to be crawled, so they no longer belong in the sitemap.

<img width="550" height="555" alt="Screenshot 2026-06-15 at 10 22 57 PM" src="https://github.com/user-attachments/assets/39eaf306-753b-48d8-8f2e-432ee59861c7" />


## Changes
- `sitemap.ts`: drop the `getTagsForSitemap` fetch and the loop that emitted `/blog/tag/{slug}` entries.
- `_lib/ghost/index.ts`: remove the now-unused `getTagsForSitemap` function and `TagSitemapEntry` type (dead code after the change).

## Preview
https://status-website-git-statusapp-learn-fix-status-im-web.vercel.app/sitemap.xml