### PR TITLE
fix(get.status.app): clean up remaining crypto source content

### DIFF
--- a/.changeset/afraid-emus-feel.md
+++ b/.changeset/afraid-emus-feel.md
@@ -1,0 +1,6 @@
+---
+"status.app": patch
+"get.status.app": patch
+---
+
+fix(get.status.app): clean up remaining crypto source content

--- a/.changeset/spicy-donuts-clean.md
+++ b/.changeset/spicy-donuts-clean.md
@@ -1,0 +1,6 @@
+---
+"status.app": patch
+"get.status.app": patch
+---
+
+fix(get.status.app): clean up remaining crypto source content

--- a/apps/get.status.app/README.md
+++ b/apps/get.status.app/README.md
@@ -75,7 +75,7 @@ Deploy via [`Jenkinsfile.website`](../../Jenkinsfile.website) with `APP_NAME=get
 
 ## Shared assets
 
-- `content/legal` → symlink to `status.app/content/legal`
+- `content/legal` — get.status.app–specific legal copy (not shared with `status.app`)
 - `public` → symlink to `status.app/public`
 
 ### Cloudinary

--- a/apps/get.status.app/content/legal
+++ b/apps/get.status.app/content/legal
@@ -1,1 +1,0 @@
-../../status.app/content/legal

--- a/apps/get.status.app/content/legal/privacy-policy.md
+++ b/apps/get.status.app/content/legal/privacy-policy.md
@@ -1,0 +1,56 @@
+---
+title: Status Website - Privacy Policy
+---
+
+This Status Website - Privacy Policy is intended to inform users of Status' approach to privacy in respect of its website (**"Website"**). In this regard, if you are visiting our Website, this Status Website - Privacy Policy applies to you. This Status Website - Privacy Policy does not apply to you if you are visiting any other Status website. In such cases please consult the relevant privacy policy as applicable.
+
+## 1. Who we are
+
+Whenever "Status" or "we" is used in this Status Website - Privacy Policy, we're referring to Status Research & Development GmbH, a Swiss company with its registered offices at Baarerstrasse 10, 6302 Zug Switzerland. Our contact information can be found on our website and at the end of this Status Website - Privacy Policy.
+
+## 2. Status limits its collection and processing of personal data from your use of the Website
+
+Status limits its collection and processing of personal data from users of the Website. As such, we only collect and process the following personal data:
+
+- **Registration information:** Status collects information from you when you register on the Website for various reasons, such as to sign-up to early access or to participate in discussion features of the Website. When registering on our site, you may be asked to enter your name, your e-mail address, a username or an Ethereum address. You may, however, visit our site without registering. Your e-mail address will be verified by an email containing a unique link. If that link is visited, we know that you control the e-mail address.
+- **IP address:** We note that Status itself does not collect IP addresses of users, however this may still be collected by third parties, namely the hosting provider of this Website. For more on this, please see the section below: "Third party collection of personal data".
+  Analytics: Status also makes use of privacy focused analytics which collects trends and insights (but not personal details) about website visitors. As part of such use, we briefly process your IP address but we have no way of identifying you. We however have a legitimate interest in processing such IP addresses to improve our website and business continually. This IP address is not stored over time.
+- **Umami Analytics:** We use Umami Analytics to help us understand how visitors interact with our website. Umami is a privacy-focused alternative to Google Analytics, designed to respect user privacy and comply with data protection laws such as GDPR. You can learn more about Umami at [https://umami.is/](https://umami.is/). Umami does not collect any personally identifiable information, does not use cookies, and does not track users across different websites. All analytics data collected through Umami is anonymised and cannot be used to identify individual users. This means that no personal data is stored or processed, and no cookie consent banner is required. We use the anonymised analytics data to gain insights into how visitors use our site, such as which pages are most popular and how users navigate our content. This information helps us improve our website and enhance the user experience. All analytics data is securely hosted on our own servers, and we do not share this data with any third parties. By using Umami, we ensure that your privacy is respected and that our analytics practices remain compliant with applicable data protection regulations, including GDPR.
+
+We also make use of Google Search Console, a tool provided by Google that helps us understand how our website performs in Google search results. Google Search Console does not collect personal data from visitors to our Website, nor do we receive or process any personal data through its use.
+
+## 3. Third party collection of personal data
+
+In addition to the above, Status utilises a third party provider (**"Hosting Provider"**) who hosts this Website and may automatically collect, process and store certain personal data that includes IP addresses, system configuration information, and other information about traffic to and from the Website, as well as (general) location information derived from such IP addresses. The personal information and the purpose for which it is collected by the hosting provider of this Website is set out in their privacy policy (with you, being referred to as the "End User"). We do note however the following:
+
+- **IP addresses:** As part of the Hosting Provider' provision of hosting services to Status, they may also indirectly collect and process your IP address. They further utilise a third-party database to map the general location to which each IP address corresponds (**"Location Information"**). The Location Information that is mapped from an IP address is limited to country and city, however the precise location is not identifiable. The Hosting Provider uses this Location Information in order to more effectively provide their services to Status.
+- **Cookies:** While Status itself does not use cookies on the Website, the Hosting Provider may further set cookies on the Website which are necessary for purposes such as its functionality and use.
+
+## 4. Security measures we take in respect of the website
+
+As a general approach, Status takes data security seriously and the measures we take as an organisation. In respect of the Website, we implement a variety of security measures to maintain the safety of your personal data when you enter, submit, or access such information.
+
+## 5. Exporting data outside the European Union and Switzerland
+
+While it is not intended that Status will export your personal data from the website outside the European Union, Status (and the Hosting Provider) is obliged to protect the privacy of such personal data if it is exported outside the European Union or Switzerland and it will only be processed in countries or by parties that provide an adequate level of protection as deemed by Switzerland or the European Commission. Otherwise, Status will use specific forms of contractual clauses to ensure such personal data is provided the same protection as required in Switzerland or Europe. The transmission of personal data outside the European Union and Switzerland will always occur in conformity with applicable privacy legislation.
+
+## 6. Your choices and rights
+
+As explained in this Status Website - Privacy Policy, Status limits its collection and processing of your personal data. Nonetheless, you still have certain choices and rights in respect of the personal data which we do collect and process. As laid out in relevant privacy legislation, you have the right to:
+Ask us to correct or update your personal data (where possible);
+Ask us to remove your personal data from our systems;
+Ask us for a copy of your personal data, which may also be transferred to another data controller at your request;
+Withdraw your consent to process your personal data (only if consent was asked for a processing activity), which only affects processing activities that are based on your consent and doesn't affect the validity of such processing activities before you have withdrawn your consent;
+Object to the processing of your personal data; and
+File a complaint with the Federal Data Protection and Information Commissioner (FDPIC), if you believe that your personal data has been processed unlawfully.
+To the extent that you have any questions about the Status Website - Privacy Policy, please email us at [legal@status.im](mailto:legal@status.im).
+
+## 7. Third party links
+
+On the Website, you may come across links to third party websites. These third party sites have separate and independent privacy policies. We therefore have no responsibility or liability for the content and activities of these linked sites.
+
+## 8. The Status Website - Privacy Policy might change
+
+We may modify or replace any part of this Status Website - Privacy Policy. Please check our website periodically for any changes. The new Status Website - Privacy Policy will be effective immediately upon its posting on our website.
+
+This document is licensed under CC-BY-SA.

--- a/apps/get.status.app/content/legal/terms-of-use.md
+++ b/apps/get.status.app/content/legal/terms-of-use.md
@@ -1,0 +1,125 @@
+---
+title: Status Website - Terms of Use
+---
+
+This page is intended to inform users of the terms and conditions ("**Website Terms of Use**") applicable to your access and use of the Status website ("**Website**"). For the terms of use regarding Status' software ("**Status Software**"), please refer to the Status Terms of Use which can be found on Status Software.
+
+## 1. Who we are
+
+Whenever "Status" or "we" or "us" or any similar variation, are used in these terms, we're referring to Status Research & Development GmbH, a Swiss company with its registered office at Baarerstrasse 10, Zug, Switzerland, and includes its "representatives", which means Status' affiliates, directors, officers, employees, agents and any other representatives of Status. For the purposes of these terms, "representatives" also includes Status core contributors without prejudice to the other legal categories mentioned. Our contact information can be found at the end of the Website Terms of Use.
+
+## 2. Acceptance of the Website Terms of Use
+
+These Website Terms of Use are entered into by you and Status and they govern your access and use of the Website, including any material and functionality contained on the Website.
+
+It is your responsibility to read the Website Terms of Use carefully before your use of the Website and your use of the Website means you have agreed to be bound and comply with these Website Terms of Use.
+
+If you do not agree with these Website Terms of Use, you must not access or use the Website.
+
+## 3. User Content
+
+On the Website you will be able to participate and contribute to discussions on the Website, through a forum or otherwise and further, submit and interact with various user content (" **User Content**"). We consider User Content to include anything you (or any other user) create, post, distribute or exchange through the Website, whether its text, links, GIFs, emoji, photos or any other media formats.
+
+You are solely responsible for any User Content that you create, post, distribute or submit, messages you exchange or any other activity you may engage in related to your User Content on the Website and any harm or liability that may result from such User Content.
+
+You represent and warrant in respect of such User Content that:
+
+1. your creation, posting, distribution or submission of User Content does not infringe on any intellectual property or other proprietary rights of any third party;
+1. you are the creator and owner or that you have the necessary permissions to create, post, distribute or submit such User Content on the Website;
+1. it does not contain or install any viruses, worms, malware, Trojan horses or other harmful or destructive User Content;
+1. it is not spam, is not machine or randomly-generated, and does not contain unethical or unwanted commercial User Content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or to further unlawful acts (such as phishing) or mislead recipients as to the source of the material (such as spoofing);
+1. it is not pornographic, does not contain threats or incite violence, and does not violate the privacy or publicity rights of any third party;
+1. it is not getting advertised via unwanted electronic messages such as spam links on newsgroups, email lists, blogs and websites, and similar unsolicited promotional methods; and
+1. it is not deliberately misleading or used to impersonate other users or third parties in a way intended to be deceptive.
+
+While you use the Website, you may view User Content that potentially could:
+
+1. be offensive, indecent, or otherwise objectionable;
+1. contain technical inaccuracies, typographical mistakes, and other errors; or
+1. violate others' rights, including but not limited to privacy, publicity, intellectual property, or other proprietary rights.
+
+By operating the Website, Status does not represent or imply that it endorses or supports User Content, or that it believes such User Content to be accurate, useful or non-harmful.
+
+To the extent User Content contains suggestions, ideas, feedback or other information ("**User Feedback**") for Status that concerns software it has developed or otherwise, you acknowledge that these are voluntary submissions which you have made, without any expectation of claim or compensation from Status. While User Feedback is always appreciated, Status is under no obligation to utilise, implement or incorporate User Feedback.
+
+Status disclaims all liability related to any claim, cause of action, controversy, dispute, loss, or damages, known or unknown, related to, arising from, or in any way connected with User Content.
+
+## 4. Disclaimer
+
+The Website is provided by Status on an "as is" basis and you use the Website at your own sole discretion and risk.
+
+Status disclaims all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement of intellectual property or other violation of rights. Status does not warrant or make any representations concerning the completeness, accuracy, legality, utility, reliability, suitability or availability of the use of the Website, the materials on its Website, including User Content or otherwise relating thereto or on any sites linked to this Website. These disclaimers will apply to the maximum extent permitted by applicable law.
+
+We make no claims that the Website or any of its materials or the User Content is accessible or appropriate outside of Switzerland. Your access or use of the Website may not be legal in certain countries. If you access the Websites from outside Switzerland, you do so on your own sole discretion and you are solely responsible for compliance with applicable local laws.
+
+Status provides materials and other information through the Website for informational purposes only and they may not always be entirely accurate, complete, or current and may also include inaccuracies or typographical errors. You are solely responsible for verifying their adequacy, completeness and accuracy and any reliance you place on such information is at your own risk. Such information should not be considered as creating any expectations or forming the basis of any contract, commitment or binding obligation with us. No information on this Website should be considered to contain or be relied upon as a promise, representation, warranty or guarantee, whether express or implied and whether as to the past, present or the future in relation to anything described on this Website.
+
+Status is not liable for any loss resulting from your action (or inaction) and decisions based on these materials or any other information. You should always conduct your own research and seek independent professional advice if necessary. The information contained on this Website does not constitute financial, legal, tax, or other advice and should not be treated as such You are solely responsible for the decisions or actions you might take in this respect.
+
+Nothing in this Website should be construed by you as an offer to buy or sell, or soliciting any offer to buy or sell any tokens or any security.
+
+## 5. Intellectual property rights
+
+Status owns all copyrights, domains, trade dress (look and feel), design rights and themes, trademarks, logos, graphics, and other intellectual property rights associated with the Status brand. You must not use such trademarks, logos, or graphics without Status' prior written approval. To request permission to use our copyrighted material or trademarks, such as logos, please contact [marketing@status.im](mailto:marketing@status.im).
+
+Unless indicated otherwise, the Website, its materials and functionality (including but not limited to information, text, images, the design, selection and arrangement thereof) are owned by Status, its licensors or other providers of such materials and are protected by copyright, trademark or any other intellectual property or proprietary rights laws.
+
+Regarding User Content, while you will retain any intellectual property rights you have in your User Content, you grant to Status, in respect of your User Content, a worldwide, perpetual, irrevocable, non-exclusive, transferable, licence to use, copy, modify, adapt, create derivative works of, store and display the User Content on the Website.
+
+## 6. Third party website links
+
+To the extent the Website provides any links to a third party website, then their terms and conditions, including privacy policies, govern your use of those third party websites. By linking such third party websites, Status does not represent or imply that it endorses or supports such third party websites or content therein, or that it believes such third party websites and content therein to be accurate, useful or non-harmful. Status has no control over such third party websites and will not be liable for your use of or activities on any third party websites accessed through the Website. If you access such third party websites through the Website, it is at your own risk and you are solely responsible for your activities on such third party websites.
+
+## 7. Limitation of liability
+
+Status will not be held liable to you under any contract, negligence, strict liability, or other legal or equitable theory for any lost profits, cost of procurement for substitute services, or any special, incidental, or consequential damages related to, arising from, or in any way connected with these Website Terms of Use, the Website, User Content, or your use of the Website even if Status has been advised of the possibility of such damages. In any event, Status' aggregate liability for such claims is limited to EUR 100 (one hundred Euros) or to the maximum extent permitted by applicable law.
+
+## 8. Indemnity
+
+You shall indemnify and hold harmless Status from and against any and all claims, damages and expenses, including attorneys' fees, arising from or related to your use of the Website, User Content, including without limitation your violation of these Website Terms of Use.
+
+## 9. Early access
+
+This clause applies to you when you sign up for early access to a "beta" version of Status Software (" **Early Access Status Software**"), made available to you for the purposes of evaluating and providing feedback to Status concerning Early Access Status Software.
+
+Early Access Status Software is provided by Status on an "as is" basis. Status does not make any express or implied representations or warranties in relation to Early Access Status Software. This includes warranties of merchantability, fitness for use or for a particular purpose, and non-infringement of any copyright or intellectual property rights. In particular, Status makes no representations or warranties that Early Access Status Software will be operational, secure, safe or free from failures, disruptions, unauthorised access, bugs, errors, or delays, viruses, malicious code or any other technical or security issues.
+
+Your use of Early Access Status Software is not without risk. These risks may include, but are not limited to, potential data loss, system instability and unexpected software behavior. You are solely responsible for evaluating these risks and deciding whether or not to use Early Access Status Software. By using Early Access Status Software, you agree to accept the risks Status has identified as well as any other risks that a reasonable person should have been aware about. Status is not responsible for notifying you on an ongoing basis about any changes in the risks associated with using Early Access Status Software.
+
+You release Status from all liability related to any claim, cause of action, controversy, dispute, loss, or damages, known or unknown, related to, arising from, or in any way connected with your use of Early Access Status Software.
+
+## 10. Modifications
+
+We may modify or replace any part of this Website Terms of Use at any time and without notice. You are responsible for checking the Website periodically for any changes. The new Website Terms of Use will be effective immediately upon its posting on the Website.
+
+## 11. Governing law
+
+Swiss law governs these Website Terms of Use and any disputes between you and Status, whether in court or arbitration, without regard to conflict of laws provisions.
+
+## 12. Disputes
+
+In these terms, "dispute" has the broadest meaning enforceable by law and includes any claim you make against or controversy you may have in relation to these Website Terms of Use, the Website or your use of the Website and User Content.
+
+We prefer arbitration over litigation as we believe it meets our principle of resolving disputes in the most efficient and cost effective manner. You are bound by the following arbitration clause, which waives your right to litigation and to be heard by a judge. Please note that court review of an arbitration award is limited. You also waive all your rights to a jury trial (if any) in any and all jurisdictions.
+
+If a (potential) dispute arises, you must first use your reasonable efforts to resolve it amicably with Status by reaching out to Status' legal team at [legal@status.im](mailto:legal@status.im). If these efforts do not result in a resolution of such dispute, you shall then send to [legal@status.im](mailto:legal@status.im) a written notice of dispute setting out (i) the nature of the dispute, and the claim you are making; and (ii) the remedy you are seeking.
+
+If you and Status are unable to further resolve this dispute within sixty (60) calendar days of Status receiving this notice of dispute, then any such dispute will be referred to and finally resolved by you and Status through an arbitration administered by the Swiss Chambers' Arbitration Institution in accordance with the Swiss Rules of International Arbitration for the time being in force, which rules are deemed to be incorporated herein by reference. The arbitral decision may be enforced in any court. The arbitration will be held in Zug, Switzerland, and may be conducted via video conference virtual/online methods if possible. The tribunal will consist of one arbitrator, and all proceedings as well as communications between the parties will be kept confidential. The language of the arbitration will be in English. Payment of all relevant fees in respect of the arbitration, including filing, administration and arbitrator fees will be in accordance with the Swiss Rules of International Arbitration.
+
+Regardless of any applicable statute of limitations, you must bring any claims within one year after the claim arose or the time when you should have reasonably known about the claim. You also waive the right to participate in a class action lawsuit or a classwide arbitration against Status.
+
+## 13. Privacy
+
+All personal data we collect and process from your access and use of the Website is subject to the Status Website Privacy Policy.
+
+## 14. About these Website Terms of Use
+
+These Website Terms of Use and the Status Website Privacy Policy cover the entire agreement between you and Status regarding the Website and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Website.
+
+The captions and headings identifying sections and subsections of these Website Terms of Use are for reference only and do not define, modify, expand, limit, or affect the interpretation of any provisions of these Website Terms of Use.
+
+If any section of these Websites Terms of Use is determined to be unlawful, void, or unenforceable, the unenforceable portion will be deemed to be severed from these terms. Such determination shall not affect the validity and enforceability of any other remaining terms. Any failure by Status to exercise or enforce any right or provision of these Website Terms of Use will not constitute our waiver of such right or provision.
+
+If you have specific questions about these Website Terms of Use, please contact us at [legal@status.im](mailto:legal@status.im).
+
+This document is licensed under CC-BY-SA.

--- a/apps/get.status.app/scripts/assert-clean-page-source.mjs
+++ b/apps/get.status.app/scripts/assert-clean-page-source.mjs
@@ -27,6 +27,7 @@ const blockedPatterns = [
   /SSign up/i,
   /id:\s*'get\.status\.app\/Hero_app:1267:770'/i,
   /Desktop_Wallet_function/i,
+  /Mobile_WalletFunction/i,
   /wallet feature/i,
   /twitter:site/i,
   /@ethstatus/i,

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/_utils/get-legal-document-content.ts
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/_utils/get-legal-document-content.ts
@@ -1,0 +1,82 @@
+import 'server-only'
+
+import fs from 'fs/promises'
+import { compileMDX } from 'next-mdx-remote/rsc'
+import path from 'path'
+import { rehypePrettyCode } from 'rehype-pretty-code'
+import rehypeSlug from 'rehype-slug'
+import remarkComment from 'remark-comment'
+import remarkDirective from 'remark-directive'
+import remarkGfm from 'remark-gfm'
+import { z } from 'zod'
+
+import {
+  helpComponents,
+  legalComponents,
+  specsComponents,
+} from '~components/content'
+import { remarkRawDocumentData } from '~website/(content)/_lib/plugins/remark-raw-document-data'
+import { remarkRewriteLinks } from '~website/(content)/_lib/plugins/remark-rewrite-links'
+
+const frontmatterSchema = z.object({
+  title: z.string(),
+})
+
+export async function getLegalDocumentContent(documentName: string) {
+  const filePath = path.resolve(`content/${documentName}`)
+
+  const [fileContent, { mtime: lastEdited }] = await Promise.all([
+    fs.readFile(filePath, 'utf8'),
+    fs.stat(filePath),
+  ])
+
+  const { frontmatter, content } = await compileMDX<
+    z.infer<typeof frontmatterSchema>
+  >({
+    source: {
+      path: filePath,
+      value: fileContent,
+    },
+    components: { ...legalComponents, ...helpComponents, ...specsComponents },
+    options: {
+      parseFrontmatter: true,
+      mdxOptions: {
+        rehypePlugins: [
+          rehypeSlug as any,
+          [
+            rehypePrettyCode,
+            {
+              theme: 'github-dark',
+              keepBackground: false,
+            },
+          ],
+        ],
+        remarkPlugins: [
+          [remarkRawDocumentData, { path: filePath, dir: 'content' }],
+          remarkComment as any,
+          remarkGfm,
+          remarkDirective,
+          remarkRewriteLinks,
+        ],
+      },
+    },
+  })
+
+  const result = frontmatterSchema.safeParse(frontmatter)
+
+  if (!result.success) {
+    const errorMessage = result.error.issues
+      .map(issue => `${issue.path.join('.')}: ${issue.message}`)
+      .join(', ')
+
+    throw new Error(`Invalid metadata: ${errorMessage}`)
+  }
+
+  return {
+    meta: {
+      ...result.data,
+      lastEdited,
+    },
+    content,
+  }
+}

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/_utils/get-site-og-image.ts
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/_utils/get-site-og-image.ts
@@ -1,0 +1,6 @@
+import { cloudinaryLoader } from '../../../../_components/assets/loader'
+
+export const GET_SITE_OG_IMAGE = cloudinaryLoader({
+  src: 'get.status.app/Hero_app',
+  width: 1200,
+})

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/layout.tsx
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/layout.tsx
@@ -1,5 +1,13 @@
-import LegalLayout from '../../../../../../status.app/src/app/(website)/legal/layout'
+import { Body } from '~components/body'
 
-export const dynamic = 'force-static'
+type Props = {
+  children: React.ReactNode
+}
 
-export default LegalLayout
+export default function LegalLayout({ children }: Props) {
+  return (
+    <Body className="pb-24 pt-16 xl:pb-40 xl:pt-32">
+      <div className="container max-w-[742px]">{children}</div>
+    </Body>
+  )
+}

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/privacy-policy/page.tsx
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/privacy-policy/page.tsx
@@ -1,8 +1,61 @@
-import PrivacyPolicyPage, {
-  generateMetadata,
-} from '../../../../../../../status.app/src/app/(website)/legal/privacy-policy/page'
+import { getTranslations } from 'next-intl/server'
+
+import { formatDate } from '~app/_utils/format-date'
+
+import { getLegalDocumentContent } from '../_utils/get-legal-document-content'
+import { GET_SITE_OG_IMAGE } from '../_utils/get-site-og-image'
+
+import type { Metadata } from 'next'
 
 export const dynamic = 'force-static'
 
-export default PrivacyPolicyPage
-export { generateMetadata }
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Privacy Policy for Status App'
+  const description =
+    'Understand what limited diagnostics the application gathers. Review how we protect user anonymity and handle third-party integrations securely.'
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: '/legal/privacy-policy',
+    },
+    openGraph: {
+      type: 'website',
+      url: 'https://get.status.app/legal/privacy-policy',
+      title,
+      description,
+      siteName: 'Status App',
+      images: [
+        {
+          url: GET_SITE_OG_IMAGE,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [GET_SITE_OG_IMAGE],
+    },
+  }
+}
+
+export default async function PrivacyPolicyPage() {
+  const t = await getTranslations('common')
+  const { meta, content } = await getLegalDocumentContent(
+    'legal/privacy-policy.md'
+  )
+
+  return (
+    <>
+      <div className="mb-12">
+        <h1 className="mb-3 text-40 font-bold xl:text-64">{meta.title}</h1>
+        <p className="text-19 text-neutral-50">
+          {t('lastUpdate')} {formatDate(meta.lastEdited, 'long')}
+        </p>
+      </div>
+      <article className="root-content">{content}</article>
+    </>
+  )
+}

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/terms-of-use/page.tsx
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/terms-of-use/page.tsx
@@ -1,16 +1,13 @@
-import TermsOfUsePage from '../../../../../../../status.app/src/app/(website)/legal/terms-of-use/page'
-import { cloudinaryLoader } from '../../../../_components/assets/loader'
+import { getTranslations } from 'next-intl/server'
+
+import { formatDate } from '~app/_utils/format-date'
+
+import { getLegalDocumentContent } from '../_utils/get-legal-document-content'
+import { GET_SITE_OG_IMAGE } from '../_utils/get-site-og-image'
 
 import type { Metadata } from 'next'
 
 export const dynamic = 'force-static'
-
-const GET_SITE_OG_IMAGE = cloudinaryLoader({
-  src: 'get.status.app/Hero_app',
-  width: 1200,
-})
-
-export default TermsOfUsePage
 
 export async function generateMetadata(): Promise<Metadata> {
   const title = 'Terms of Use Rules for Status App'
@@ -42,4 +39,23 @@ export async function generateMetadata(): Promise<Metadata> {
       images: [GET_SITE_OG_IMAGE],
     },
   }
+}
+
+export default async function TermsOfUsePage() {
+  const t = await getTranslations('common')
+  const { meta, content } = await getLegalDocumentContent(
+    'legal/terms-of-use.md'
+  )
+
+  return (
+    <>
+      <div className="mb-12">
+        <h1 className="mb-3 text-40 font-bold xl:text-64">{meta.title}</h1>
+        <p className="text-19 text-neutral-50">
+          {t('lastUpdate')} {formatDate(meta.lastEdited, 'long')}
+        </p>
+      </div>
+      <article className="root-content">{content}</article>
+    </>
+  )
 }

--- a/apps/get.status.app/src/app/[locale]/(website)/legal/terms-of-use/page.tsx
+++ b/apps/get.status.app/src/app/[locale]/(website)/legal/terms-of-use/page.tsx
@@ -1,8 +1,45 @@
-import TermsOfUsePage, {
-  generateMetadata,
-} from '../../../../../../../status.app/src/app/(website)/legal/terms-of-use/page'
+import TermsOfUsePage from '../../../../../../../status.app/src/app/(website)/legal/terms-of-use/page'
+import { cloudinaryLoader } from '../../../../_components/assets/loader'
+
+import type { Metadata } from 'next'
 
 export const dynamic = 'force-static'
 
+const GET_SITE_OG_IMAGE = cloudinaryLoader({
+  src: 'get.status.app/Hero_app',
+  width: 1200,
+})
+
 export default TermsOfUsePage
-export { generateMetadata }
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Terms of Use Rules for Status App'
+  const description =
+    'Read the governing conditions for utilizing software. Review liability limits, strict user obligations, and intellectual property guidelines.'
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: '/legal/terms-of-use',
+    },
+    openGraph: {
+      type: 'website',
+      url: 'https://get.status.app/legal/terms-of-use',
+      title,
+      description,
+      siteName: 'Status App',
+      images: [
+        {
+          url: GET_SITE_OG_IMAGE,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [GET_SITE_OG_IMAGE],
+    },
+  }
+}

--- a/apps/get.status.app/src/app/_components/assets/types.ts
+++ b/apps/get.status.app/src/app/_components/assets/types.ts
@@ -10,16 +10,14 @@ export type ImageType =
     }
   | { id: 'get.status.app/Animation_Privacy_Frame:2267:1729'; alt: '' }
   | { id: 'get.status.app/Connector_NOCRYPTO:1678:1092'; alt: '' }
-  | { id: 'get.status.app/Mobile_Assets_function:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
   | { id: 'get.status.app/Mobile_Communities_function:720:1600'; alt: '' }
   | { id: 'get.status.app/Mobile_Chat_function:720:1600'; alt: '' }
   | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
   | { id: 'get.status.app/Hero_app:2128:1292'; alt: '' }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt:
-        | 'Status app showing wallet and messenger on devices'
-        | 'Status app showing messenger on devices'
+      alt: 'Status app showing wallet and messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'

--- a/apps/get.status.app/src/app/_components/assets/types.ts
+++ b/apps/get.status.app/src/app/_components/assets/types.ts
@@ -10,14 +10,16 @@ export type ImageType =
     }
   | { id: 'get.status.app/Animation_Privacy_Frame:2267:1729'; alt: '' }
   | { id: 'get.status.app/Connector_NOCRYPTO:1678:1092'; alt: '' }
-  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_Assets_function:720:1600'; alt: '' }
   | { id: 'get.status.app/Mobile_Communities_function:720:1600'; alt: '' }
   | { id: 'get.status.app/Mobile_Chat_function:720:1600'; alt: '' }
   | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
   | { id: 'get.status.app/Hero_app:2128:1292'; alt: '' }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt: 'Status app showing wallet and messenger on devices'
+      alt:
+        | 'Status app showing wallet and messenger on devices'
+        | 'Status app showing messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'

--- a/apps/get.status.app/src/app/_components/assets/types.ts
+++ b/apps/get.status.app/src/app/_components/assets/types.ts
@@ -1,4 +1,5 @@
 export type ImageType =
+  | { id: 'get.status.app/Mobile_Function:720:1600'; alt: '' }
   | { id: 'get.status.app/Connector_NOCO:1678:1092'; alt: '' }
   | { id: 'get.status.app/01_Frame:2256:1178'; alt: '' }
   | { id: 'get.status.app/01_Mobile_Frame:990:1467'; alt: '' }
@@ -17,7 +18,7 @@ export type ImageType =
   | { id: 'get.status.app/Hero_app:2128:1292'; alt: '' }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt: 'Status app showing wallet and messenger on devices'
+      alt: 'Status app showing messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'

--- a/apps/status.app/src/app/(website)/_components/navigation/language-selector.tsx
+++ b/apps/status.app/src/app/(website)/_components/navigation/language-selector.tsx
@@ -12,9 +12,8 @@ import { usePathname } from '~/i18n/navigation'
 import { routing } from '~/i18n/routing'
 import { Link } from '~components/link'
 
-const LOKALISE_URL = isGetSite
-  ? 'https://app.lokalise.com/public/767880116a141eb3584d66.09104922/'
-  : 'https://app.lokalise.com/public/6480087268cc0f594f8985.65010073/'
+const LOKALISE_URL =
+  'https://app.lokalise.com/public/6480087268cc0f594f8985.65010073/'
 
 type Language = {
   value: (typeof routing.locales)[number]
@@ -175,16 +174,18 @@ const LanguageSelector = () => {
             ))}
           </Select.Viewport>
 
-          <div className="mt-2 border-t border-neutral-10 pt-2">
-            <Link
-              href={LOKALISE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex w-full items-center justify-center gap-1 rounded-8 p-2 text-13 font-medium text-neutral-50 transition-colors hover:bg-neutral-10 hover:text-neutral-100"
-            >
-              {t('helpTranslate')} <ExternalIcon />
-            </Link>
-          </div>
+          {!isGetSite && (
+            <div className="mt-2 border-t border-neutral-10 pt-2">
+              <Link
+                href={LOKALISE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex w-full items-center justify-center gap-1 rounded-8 p-2 text-13 font-medium text-neutral-50 transition-colors hover:bg-neutral-10 hover:text-neutral-100"
+              >
+                {t('helpTranslate')} <ExternalIcon />
+              </Link>
+            </div>
+          )}
         </Select.Content>
       </Select.Portal>
     </Select.Root>

--- a/apps/status.app/src/app/(website)/apps/page.tsx
+++ b/apps/status.app/src/app/(website)/apps/page.tsx
@@ -71,7 +71,7 @@ export default async function AppsPage() {
   const mobileScreenshots = (
     isGetSite
       ? [
-          { id: 'get.status.app/Mobile_WalletFunction:720:1600', alt: '' },
+          { id: 'get.status.app/Mobile_Assets_function:720:1600', alt: '' },
           { id: 'get.status.app/Mobile_Chat_function:720:1600', alt: '' },
           {
             id: 'get.status.app/Mobile_Communities_function:720:1600',

--- a/apps/status.app/src/app/(website)/apps/page.tsx
+++ b/apps/status.app/src/app/(website)/apps/page.tsx
@@ -71,7 +71,7 @@ export default async function AppsPage() {
   const mobileScreenshots = (
     isGetSite
       ? [
-          { id: 'get.status.app/Mobile_Assets_function:720:1600', alt: '' },
+          { id: 'get.status.app/Mobile_Function:720:1600', alt: '' },
           { id: 'get.status.app/Mobile_Chat_function:720:1600', alt: '' },
           {
             id: 'get.status.app/Mobile_Communities_function:720:1600',

--- a/apps/status.app/src/app/(website)/page.tsx
+++ b/apps/status.app/src/app/(website)/page.tsx
@@ -222,7 +222,7 @@ export default async function HomePage() {
             {isGetSite ? (
               <Image
                 id="Homepage/Hero/device-mockups-mobile:1267:770"
-                alt="Status app showing wallet and messenger on devices"
+                alt="Status app showing messenger on devices"
                 width={1267}
                 height={770}
                 className="relative z-20 w-[130%] max-w-none"

--- a/apps/status.app/src/app/(website)/page.tsx
+++ b/apps/status.app/src/app/(website)/page.tsx
@@ -222,7 +222,7 @@ export default async function HomePage() {
             {isGetSite ? (
               <Image
                 id="Homepage/Hero/device-mockups-mobile:1267:770"
-                alt="Status app showing messenger on devices"
+                alt="Status app showing wallet and messenger on devices"
                 width={1267}
                 height={770}
                 className="relative z-20 w-[130%] max-w-none"

--- a/apps/status.app/src/app/(website)/page.tsx
+++ b/apps/status.app/src/app/(website)/page.tsx
@@ -222,7 +222,7 @@ export default async function HomePage() {
             {isGetSite ? (
               <Image
                 id="Homepage/Hero/device-mockups-mobile:1267:770"
-                alt="Status app showing wallet and messenger on devices"
+                alt="Status app showing messenger on devices"
                 width={1267}
                 height={770}
                 className="relative z-20 w-[130%] max-w-none"
@@ -230,7 +230,7 @@ export default async function HomePage() {
             ) : (
               <Image
                 id="Homepage/Hero/device-mockups-mobile:1267:770"
-                alt="Status app showing wallet and messenger on devices"
+                alt="Status app showing messenger on devices"
                 width={1267}
                 height={770}
                 className="relative z-20 w-[130%] max-w-none"

--- a/apps/status.app/src/app/_components/assets/types.ts
+++ b/apps/status.app/src/app/_components/assets/types.ts
@@ -9,7 +9,7 @@ export type ImageType =
       alt: 'Desktop screenshot showing the wallet feature included in the Status app'
     }
   | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
-  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_Assets_function:720:1600'; alt: '' }
   | {
       id: 'get.status.app/Mobile_WalletFunction:750:1624'
       alt: 'Mobile app screenshot showing the wallet feature included in the Status app'
@@ -33,7 +33,9 @@ export type ImageType =
     }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt: 'Status app showing wallet and messenger on devices'
+      alt:
+        | 'Status app showing wallet and messenger on devices'
+        | 'Status app showing messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'

--- a/apps/status.app/src/app/_components/assets/types.ts
+++ b/apps/status.app/src/app/_components/assets/types.ts
@@ -1,39 +1,55 @@
 export type ImageType =
+  | { id: 'get.status.app/Mobile_Function:720:1600'; alt: '' }
+  | { id: 'get.status.app/Connector_NOCO:1678:1092'; alt: '' }
   | { id: 'get.status.app/01_Frame:2256:1178'; alt: '' }
+  | { id: 'samples/cloudinary-logo-vector:1000:320'; alt: '' }
+  | {
+      id: 'samples/chair:800:600'
+      alt: 'Sample preview image with transparent background'
+    }
+  | { id: 'samples/zoom:484:324'; alt: 'Sample texture' }
+  | { id: 'samples/waves:1024:1024'; alt: 'Sample texture' }
+  | { id: 'samples/canvas:600:388'; alt: 'Sample texture' }
+  | { id: 'samples/coffee:1920:1280'; alt: 'Sample preview image' }
+  | { id: 'main-sample:1248:832'; alt: 'Sample preview image' }
+  | { id: 'samples/paper:1024:1024'; alt: 'Sample texture' }
+  | { id: 'cld-sample:1870:1250'; alt: 'Sample preview image' }
+  | { id: 'samples/outdoor-woman:640:963'; alt: 'Sample preview image' }
+  | { id: 'cld-sample-2:1870:1250'; alt: 'Sample preview image' }
+  | { id: 'cld-sample-4:1870:1250'; alt: 'Sample preview image' }
+  | { id: 'samples/man-on-a-street:1340:1340'; alt: 'Sample preview image' }
+  | { id: 'samples/shoe:1000:1140'; alt: 'Sample preview image' }
+  | { id: 'cld-sample-5:1870:1250'; alt: 'Sample preview image' }
+  | { id: 'samples/ecommerce/shoes:587:507'; alt: '' }
+  | { id: 'samples/radial_02:427:271'; alt: 'Sample texture' }
+  | { id: 'samples/smile:1552:1000'; alt: 'Sample preview image' }
+  | { id: 'samples/two-ladies:1500:1200'; alt: 'Sample preview image' }
+  | {
+      id: 'samples/woman-on-a-football-field:1200:1350'
+      alt: 'Sample preview image'
+    }
+  | { id: 'samples/radial:950:640'; alt: 'Sample texture' }
+  | { id: 'samples/man-portrait:1333:2000'; alt: 'Sample preview image' }
+  | { id: 'cld-sample-3:1870:1250'; alt: 'Sample preview image' }
+  | { id: 'samples/logo:480:314'; alt: '' }
+  | { id: 'samples/upscale-face-1:233:233'; alt: 'Sample preview image' }
   | { id: 'get.status.app/01_Mobile_Frame:990:1467'; alt: '' }
   | { id: 'get.status.app/Desktop_function:2480:1550'; alt: '' }
-  | { id: 'get.status.app/Hero_app:2128:1292'; alt: '' }
-  | { id: 'get.status.app/Hero_app:1267:770'; alt: '' }
-  | {
-      id: 'get.status.app/Desktop_Wallet_function:2880:1800'
-      alt: 'Desktop screenshot showing the wallet feature included in the Status app'
-    }
-  | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
-  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
-  | {
-      id: 'get.status.app/Mobile_WalletFunction:750:1624'
-      alt: 'Mobile app screenshot showing the wallet feature included in the Status app'
-    }
-  | { id: 'get.status.app/Connector_NOCRYPTO:1678:1092'; alt: '' }
-  | {
-      id: 'get.status.app/Connector_NOCRYPTO:1102:1012'
-      alt: ''
-    }
-  | {
-      id: 'get.status.app/Animation_Privacy_Frame:456:360'
-      alt: ''
-    }
+  | { id: 'Non Beta Release/Download/Screen_01:750:1624'; alt: '' }
   | {
       id: 'get.status.app/Create_Community_Banner_Left_Frame_cc8nvh:1017:776'
       alt: ''
     }
-  | {
-      id: 'get.status.app/Create_Community_Banner_Left_Frame_cc8nvh:911:720'
-      alt: ''
-    }
+  | { id: 'get.status.app/Animation_Privacy_Frame:2267:1729'; alt: '' }
+  | { id: 'get.status.app/Connector_NOCRYPTO:1678:1092'; alt: '' }
+  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_Communities_function:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_Chat_function:720:1600'; alt: '' }
+  | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
+  | { id: 'get.status.app/Hero_app:2128:1292'; alt: '' }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt: 'Status app showing wallet and messenger on devices'
+      alt: 'Status app showing messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'
@@ -48,15 +64,15 @@ export type ImageType =
       alt: ''
     }
   | {
-      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Communities:750:1624'
+      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Communities:720:1600'
       alt: 'Mobile app screenshot showing the community feature included in the Status app'
     }
   | {
-      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Chat:750:1624'
+      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Chat:720:1600'
       alt: 'Mobile app screenshot showing the messenger feature included in the Status app'
     }
   | {
-      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Wallet:750:1624'
+      id: 'Platforms/Screens/Mobile Screens/New_Mobile_Wallet:720:1600'
       alt: 'Mobile app screenshot showing the wallet feature included in the Status app'
     }
   | {
@@ -468,7 +484,6 @@ export type ImageType =
       alt: 'Mobile app screenshot showing the community feature included in the Status app'
     }
   | { id: 'Non Beta Release/Download/Screen_02:750:1624'; alt: '' }
-  | { id: 'Non Beta Release/Download/Screen_01:750:1624'; alt: '' }
   | {
       id: 'Non Beta Release/Illustrations/Hero_Non_Beta_Release:4399:2703'
       alt: ''
@@ -1238,7 +1253,6 @@ export type VideoId =
   | 'Keycard/Animations/Keycard_03:921:719'
   | 'Keycard/Animations/Keycard_Hero:1464:1400'
   | 'Non Beta Release/Animations/Keycard_01:911:720'
-  | 'get.status.app/Animation_Privacy:911:720'
   | 'Non Beta Release/Animations/Messenger_01_Bottom:1512:781'
   | 'Non Beta Release/Animations/Messenger_01_Bottom_HEVC:1512:780'
   | 'Non Beta Release/Animations/Messenger_01_Top:1512:522'
@@ -1246,6 +1260,8 @@ export type VideoId =
   | 'Platforms/Animations/Platforms_Hero:717:572'
   | 'Token/Animations/Token_Hero:721:575'
   | 'Translations/Animations/Translations_Hero:721:575'
+  | 'get.status.app/Animation_Privacy:6276:4788'
+  | 'samples/dance-2:3840:2160'
 
 export type ZipFileId =
   | 'Brand/brand-assets.zip'

--- a/apps/status.app/src/app/_components/assets/types.ts
+++ b/apps/status.app/src/app/_components/assets/types.ts
@@ -9,7 +9,7 @@ export type ImageType =
       alt: 'Desktop screenshot showing the wallet feature included in the Status app'
     }
   | { id: 'get.status.app/Desktop_Wallet_function:2480:1550'; alt: '' }
-  | { id: 'get.status.app/Mobile_Assets_function:720:1600'; alt: '' }
+  | { id: 'get.status.app/Mobile_WalletFunction:720:1600'; alt: '' }
   | {
       id: 'get.status.app/Mobile_WalletFunction:750:1624'
       alt: 'Mobile app screenshot showing the wallet feature included in the Status app'
@@ -33,9 +33,7 @@ export type ImageType =
     }
   | {
       id: 'Homepage/Hero/device-mockups-mobile:1267:770'
-      alt:
-        | 'Status app showing wallet and messenger on devices'
-        | 'Status app showing messenger on devices'
+      alt: 'Status app showing wallet and messenger on devices'
     }
   | {
       id: 'Homepage/Hero/device-mockups:2128:1292'

--- a/apps/status.app/src/app/_components/assets/types.ts
+++ b/apps/status.app/src/app/_components/assets/types.ts
@@ -2,37 +2,6 @@ export type ImageType =
   | { id: 'get.status.app/Mobile_Function:720:1600'; alt: '' }
   | { id: 'get.status.app/Connector_NOCO:1678:1092'; alt: '' }
   | { id: 'get.status.app/01_Frame:2256:1178'; alt: '' }
-  | { id: 'samples/cloudinary-logo-vector:1000:320'; alt: '' }
-  | {
-      id: 'samples/chair:800:600'
-      alt: 'Sample preview image with transparent background'
-    }
-  | { id: 'samples/zoom:484:324'; alt: 'Sample texture' }
-  | { id: 'samples/waves:1024:1024'; alt: 'Sample texture' }
-  | { id: 'samples/canvas:600:388'; alt: 'Sample texture' }
-  | { id: 'samples/coffee:1920:1280'; alt: 'Sample preview image' }
-  | { id: 'main-sample:1248:832'; alt: 'Sample preview image' }
-  | { id: 'samples/paper:1024:1024'; alt: 'Sample texture' }
-  | { id: 'cld-sample:1870:1250'; alt: 'Sample preview image' }
-  | { id: 'samples/outdoor-woman:640:963'; alt: 'Sample preview image' }
-  | { id: 'cld-sample-2:1870:1250'; alt: 'Sample preview image' }
-  | { id: 'cld-sample-4:1870:1250'; alt: 'Sample preview image' }
-  | { id: 'samples/man-on-a-street:1340:1340'; alt: 'Sample preview image' }
-  | { id: 'samples/shoe:1000:1140'; alt: 'Sample preview image' }
-  | { id: 'cld-sample-5:1870:1250'; alt: 'Sample preview image' }
-  | { id: 'samples/ecommerce/shoes:587:507'; alt: '' }
-  | { id: 'samples/radial_02:427:271'; alt: 'Sample texture' }
-  | { id: 'samples/smile:1552:1000'; alt: 'Sample preview image' }
-  | { id: 'samples/two-ladies:1500:1200'; alt: 'Sample preview image' }
-  | {
-      id: 'samples/woman-on-a-football-field:1200:1350'
-      alt: 'Sample preview image'
-    }
-  | { id: 'samples/radial:950:640'; alt: 'Sample texture' }
-  | { id: 'samples/man-portrait:1333:2000'; alt: 'Sample preview image' }
-  | { id: 'cld-sample-3:1870:1250'; alt: 'Sample preview image' }
-  | { id: 'samples/logo:480:314'; alt: '' }
-  | { id: 'samples/upscale-face-1:233:233'; alt: 'Sample preview image' }
   | { id: 'get.status.app/01_Mobile_Frame:990:1467'; alt: '' }
   | { id: 'get.status.app/Desktop_function:2480:1550'; alt: '' }
   | { id: 'Non Beta Release/Download/Screen_01:750:1624'; alt: '' }
@@ -161,7 +130,6 @@ export type ImageType =
       id: 'Help/Documentation Screens/Wallet/1412/1412_Header_light:1900:1120'
       alt: ''
     }
-  | { id: 'sample:864:576'; alt: '' }
   | {
       id: 'Share/Screens/Profile/Sharing_Banner:3841:3572'
       alt: 'Status.app illustration for a shared profile.'
@@ -1261,7 +1229,6 @@ export type VideoId =
   | 'Token/Animations/Token_Hero:721:575'
   | 'Translations/Animations/Translations_Hero:721:575'
   | 'get.status.app/Animation_Privacy:6276:4788'
-  | 'samples/dance-2:3840:2160'
 
 export type ZipFileId =
   | 'Brand/brand-assets.zip'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1242, addressing the remaining crypto/wallet source-content cleanup items in #1243 for `get.status.app`.

- **Terms of Use metadata** (`view-source:https://get.status.app/legal/terms-of-use`): override `generateMetadata` on the get.status.app terms-of-use page so the title/description no longer emit crypto/wallet copy:
  - title: `Terms of Use Rules for Status P2P Chat App and Wallet` → `Terms of Use Rules for Status App`
  - description: `…utilizing decentralized software…` → `…utilizing software…`
  - Overrides only get.status.app; `status.app`'s shared `SEO_OVERRIDES` are left untouched.
- **Apps page mobile screenshot** (`view-source:https://get.status.app/apps#desktop`): reference the reuploaded `get.status.app/Mobile_Function` Cloudinary asset (renamed from `Mobile_WalletFunction`) in the shared apps page. This removes `wallet` from both the rendered Cloudinary URL and the RSC source payload.
- **Lokalise translation link**: hide the "Help translate" Lokalise link in the language selector on get.status.app (`isGetSite`). It still renders on `status.app`.
- Extend the `assert-clean-page-source.mjs` guard with a `Mobile_WalletFunction` pattern.

## `types.ts` is generated — run the Cloudinary sync

`src/app/_components/assets/types.ts` is generated from Cloudinary (`context.custom.alt` metadata) and must not be hand-edited. After the `Mobile_WalletFunction` → `Mobile_Function` reupload, the generated types should be refreshed by running the sync (requires `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET`):

```bash
pnpm --filter get.status.app sync:cloudinary
pnpm --filter status.app sync:cloudinary
```

The code compiles today because the mobile-screenshot array is already asserted `as ScreenshotImage[]`; the sync just makes `types.ts` reflect the renamed asset. Cloudinary credentials aren't available in the CI/agent environment, so this sync needs to be run by someone with access.

## Homepage hero alt (issue item, not yet applied)

Issue item: `Status app showing wallet and messenger on devices` → `Status app showing messenger on devices` on `get.status.app`.

This alt is **generated** from the shared `Homepage/Hero/device-mockups-mobile` Cloudinary asset's `alt` metadata, and the same asset/alt is used by `status.app`. The codebase contract requires the hardcoded `alt` prop to exactly match the generated (Cloudinary) value, so it can't be diverged for get.status.app in code alone. To apply it cleanly, one of:

1. Update the shared asset's `alt` metadata in Cloudinary (also changes `status.app`), then sync; or
2. Upload a `get.status.app/`-prefixed mobile hero asset with the desired alt and wire the get-site branch to it, then sync.

Happy to implement (2) once the asset exists.

## Testing

- `pnpm --filter get.status.app types:check` passes (0 errors).
- `turbo build` succeeds for both `get.status.app` and `status.app`.
- Verified in built `get.status.app` HTML: terms title/description cleaned, apps page uses `get.status.app/Mobile_Function` (no `Mobile_WalletFunction`), and no rendered Lokalise link.
- `node apps/get.status.app/scripts/assert-clean-page-source.mjs` passes.

Fixes #1243

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01c8169d-2fa4-43f0-86d3-c3d48109a93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01c8169d-2fa4-43f0-86d3-c3d48109a93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

