### PR TITLE
fix(wallet): honor LiFi-quoted fees when signing swap transactions

### DIFF
--- a/.changeset/quiet-glasses-agree.md
+++ b/.changeset/quiet-glasses-agree.md
@@ -1,0 +1,6 @@
+---
+'wallet': patch
+'e2e': patch
+---
+
+fix(wallet): honor LiFi-quoted fees when signing swap transactions

--- a/apps/wallet/src/providers/signer-context.tsx
+++ b/apps/wallet/src/providers/signer-context.tsx
@@ -166,9 +166,18 @@ export function SignerProvider({ children }: { children: React.ReactNode }) {
 
       await ensureUnlocked()
 
-      let maxFeePerGas = tx.maxFeePerGas?.toString(16)
-      let maxPriorityFeePerGas = tx.maxPriorityFeePerGas?.toString(16)
-      let gasLimit = tx.gas?.toString(16)
+      const toHex = (value: bigint) => `0x${value.toString(16)}`
+
+      // Fee policy: transactions created by the wallet itself carry no fee
+      // fields and are priced entirely by the internal estimator. External
+      // callers (e.g. the LiFi widget for swaps) are trusted for every field
+      // they provide — only genuinely missing pieces are filled in.
+      let maxFeePerGas = tx.maxFeePerGas ? toHex(tx.maxFeePerGas) : undefined
+      let maxPriorityFeePerGas =
+        tx.maxPriorityFeePerGas !== undefined
+          ? toHex(tx.maxPriorityFeePerGas)
+          : undefined
+      let gasLimit = tx.gas ? toHex(tx.gas) : undefined
 
       if (!maxFeePerGas || !maxPriorityFeePerGas || !gasLimit) {
         const fees = await fetchGasFees({
@@ -177,9 +186,30 @@ export function SignerProvider({ children }: { children: React.ReactNode }) {
           value: tx.value.toString(16),
           data: tx.data,
         })
+
+        if (!maxFeePerGas && tx.maxPriorityFeePerGas !== undefined) {
+          // LiFi quotes carry a quote-time maxPriorityFeePerGas but the SDK
+          // strips maxFeePerGas, leaving the ceiling to the wallet. Building
+          // it from our own estimate alone can undercut the quoted priority
+          // (invalid EIP-1559 tx, rejected at broadcast), so honor the quoted
+          // priority and add the estimator's base-fee headroom on top
+          // (its maxFeePerGas = 2*baseFee + own priority).
+          const baseFeeHeadroom =
+            BigInt(fees.txParams.maxFeePerGas) -
+            BigInt(fees.txParams.maxPriorityFeePerGas)
+          maxFeePerGas = toHex(baseFeeHeadroom + tx.maxPriorityFeePerGas)
+        }
+
         maxFeePerGas ??= fees.txParams.maxFeePerGas
         maxPriorityFeePerGas ??= fees.txParams.maxPriorityFeePerGas
         gasLimit ??= fees.txParams.gasLimit
+      }
+
+      // EIP-1559 invariant: a tip above the fee ceiling is rejected by nodes.
+      // Only reachable when the caller pinned maxFeePerGas but left the
+      // priority fee to the (potentially higher) internal estimate.
+      if (BigInt(maxPriorityFeePerGas) > BigInt(maxFeePerGas)) {
+        maxPriorityFeePerGas = maxFeePerGas
       }
 
       if (tx.data) {

--- a/e2e/src/fixtures/wallet/lifi-mock.ts
+++ b/e2e/src/fixtures/wallet/lifi-mock.ts
@@ -11,10 +11,15 @@ import { CONTRACTS } from '@helpers/anvil-rpc.js'
  * background-SW -> broadcast path, and the output token lands 1:1 on-chain
  * (assertable via balanceOf). Only the quote/route/status plumbing is faked.
  *
- * Notes on fee realism: the transactionRequest deliberately carries only a
- * gasLimit — no maxFeePerGas — so the wallet's signer falls back to its own
+ * Notes on fee realism: by default the transactionRequest carries only a
+ * gasLimit — no fee fields — so the wallet's signer falls back to its own
  * fee estimation (nodes.getFeeRate -> fork eth_feeHistory). Congestion set on
  * Anvil is therefore still reflected in what the swap actually pays.
+ *
+ * Real li.quest, however, DOES include a quote-time `maxPriorityFeePerGas` in
+ * its transactionRequest, and @lifi/sdk forwards it to the wallet (while
+ * stripping gasPrice/maxFeePerGas). Use `setQuotedPriorityFee()` to reproduce
+ * that production shape and exercise the wallet's mixed-fee handling.
  */
 
 const NATIVE_ETH = '0x0000000000000000000000000000000000000000'
@@ -159,6 +164,12 @@ export interface LifiMock {
     method: string,
     postData: string | null,
   ) => LifiMockResponse
+  /**
+   * Include a quote-time `maxPriorityFeePerGas` (wei) in subsequent
+   * stepTransaction responses, like real li.quest does. Pass null to go back to
+   * the default fee-less transactionRequest.
+   */
+  setQuotedPriorityFee: (wei: bigint | null) => void
 }
 
 const isWeth = (address: unknown): boolean =>
@@ -170,6 +181,8 @@ export function createLifiMock(): LifiMock {
   // status poll only carries the txHash, not the amounts).
   let lastFromAmount = '0'
   let lastFromAddress = NATIVE_ETH
+  // Quote-time priority fee for the stepTransaction response (null = omit).
+  let quotedPriorityFeeWei: bigint | null = null
 
   const handle = (
     rawUrl: string,
@@ -252,6 +265,9 @@ export function createLifiMock(): LifiMock {
             data: WETH_DEPOSIT_CALLDATA,
             value: '0x' + BigInt(fromAmount).toString(16),
             gasLimit: '0xea60', // 60k — deposit() uses ~28k
+            ...(quotedPriorityFeeWei !== null && {
+              maxPriorityFeePerGas: '0x' + quotedPriorityFeeWei.toString(16),
+            }),
           },
         },
       }
@@ -298,5 +314,9 @@ export function createLifiMock(): LifiMock {
     return { status: 404, body: { message: `not mocked: ${path}` } }
   }
 
-  return { handle }
+  const setQuotedPriorityFee = (wei: bigint | null) => {
+    quotedPriorityFeeWei = wei
+  }
+
+  return { handle, setQuotedPriorityFee }
 }

--- a/e2e/src/fixtures/wallet/wallet-extension.fixture.ts
+++ b/e2e/src/fixtures/wallet/wallet-extension.fixture.ts
@@ -21,7 +21,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createLifiMock } from './lifi-mock.js'
+import { createLifiMock, type LifiMock } from './lifi-mock.js'
 import {
   installWalletDataSeam,
   type WalletDataSeamController,
@@ -53,11 +53,14 @@ let baseSnapshot: string | null = null
 // Seam controller per context, so the `dataSeam` fixture can expose the same
 // controller installed once by `walletContext` (avoids double-registering routes).
 const seamControllers = new WeakMap<BrowserContext, WalletDataSeamController>()
+const lifiMocks = new WeakMap<BrowserContext, LifiMock>()
 
 export interface WalletFixtures {
   anvilRpc: AnvilRpcHelper
   walletContext: BrowserContext
   dataSeam: WalletDataSeamController
+  /** li.quest mock installed on the context — mutate to shape swap quotes. */
+  lifiMock: LifiMock
   /** Onboarded extension page sitting on /portfolio/assets. */
   walletPage: Page
   portfolio: WalletPortfolioPage
@@ -131,13 +134,15 @@ export const test = base.extend<WalletFixtures>({
 
     // Install the data seam once, before any page loads, so the extension's
     // first portfolio/token reads are served from it.
+    const lifi = createLifiMock()
     const controller = await installWalletDataSeam(context, {
       ethBalance: WALLET_FUND_ETH,
       nativeTokenBody,
-      lifi: createLifiMock(),
+      lifi,
       logUnmocked: false,
     })
     seamControllers.set(context, controller)
+    lifiMocks.set(context, lifi)
 
     await use(context)
 
@@ -151,6 +156,12 @@ export const test = base.extend<WalletFixtures>({
     const controller = seamControllers.get(walletContext)
     if (!controller) throw new Error('data seam was not installed on context')
     await use(controller)
+  },
+
+  lifiMock: async ({ walletContext }, use) => {
+    const lifi = lifiMocks.get(walletContext)
+    if (!lifi) throw new Error('lifi mock was not installed on context')
+    await use(lifi)
   },
 
   // --- Onboarded page on the portfolio ---------------------------------------

--- a/e2e/tests/wallet/swap/swap-quoted-priority-fee.spec.ts
+++ b/e2e/tests/wallet/swap/swap-quoted-priority-fee.spec.ts
@@ -1,0 +1,65 @@
+import { WALLET_TEST_PASSWORD } from '@constants/wallet.js'
+import { expect, test } from '@fixtures/wallet/wallet-extension.fixture.js'
+import { CONTRACTS } from '@helpers/anvil-rpc.js'
+
+/**
+ * Regression: swap with a LiFi quote that carries its own priority fee.
+ *
+ * Real li.quest stepTransaction responses include a quote-time
+ * `maxPriorityFeePerGas`, and @lifi/sdk forwards it to the wallet while
+ * stripping gasPrice/maxFeePerGas. The wallet's signer must honor the quoted
+ * priority (LiFi owns the swap fee estimate) and build a maxFeePerGas ceiling
+ * ABOVE it — filling the missing ceiling from its own estimator verbatim used
+ * to sign an invalid EIP-1559 tx (priority > maxFee) whenever the quote was
+ * priced under hotter conditions than the current base fee, and the node
+ * rejected the broadcast ("max priority fee per gas higher than max fee per
+ * gas") — a routine mainnet failure (low base fee + quote from a gas spike).
+ *
+ * Reproduced deterministically here: calm fork fees (base 1 gwei -> internal
+ * ceiling ~3 gwei) + a 50 gwei quoted priority. The swap must still execute
+ * as a valid tx that pays the quoted priority.
+ */
+const SWAP_AMOUNT = '1'
+const ONE_ETH = 10n ** 18n
+const GWEI = 10n ** 9n
+
+test.describe('Wallet — swap with quote-time LiFi priority fee', () => {
+  test.beforeEach(async ({ anvilRpc }) => {
+    // Localize the wallet's WETH balance slot (non-archive fork upstream).
+    await anvilRpc.fundErc20ViaStorage(CONTRACTS.WETH, 0n, anvilRpc.mainnetRpc)
+  })
+
+  test(
+    'quoted priority fee above the wallet max-fee ceiling still yields a valid tx',
+    { tag: '@wallet-swap' },
+    async ({ portfolio, swapDrawer, anvilRpc, lifiMock }) => {
+      // Calm fees on the fork: base 1 gwei. The wallet's own estimate would
+      // put the maxFeePerGas ceiling at 2*base + its priority (~3 gwei).
+      await anvilRpc.setNextBlockBaseFee(GWEI)
+      await anvilRpc.mineBlock()
+
+      // The quote was priced under different (spiked) conditions: 50 gwei
+      // priority — far above the wallet's internal ceiling.
+      const quotedPriority = 50n * GWEI
+      lifiMock.setQuotedPriorityFee(quotedPriority)
+
+      const ethBefore = await anvilRpc.getEthBalance()
+
+      await portfolio.openAsset('Ethereum', 'ETH')
+      await swapDrawer.completeSwap('WETH', SWAP_AMOUNT, WALLET_TEST_PASSWORD)
+
+      // The swap executes as a valid tx regardless of the quoted priority:
+      // WETH credited 1:1, ETH debited by amount + gas.
+      expect(await anvilRpc.getErc20Balance(CONTRACTS.WETH)).toBe(ONE_ETH)
+      const spent = ethBefore - (await anvilRpc.getEthBalance())
+      expect(spent).toBeGreaterThanOrEqual(ONE_ETH)
+
+      // LiFi's estimation is actually used: the tx pays the quoted 50 gwei
+      // priority on top of the ~1 gwei base (~28k gas -> >0.001 ETH), instead
+      // of the wallet's ~3 gwei internal quote (~0.0001 ETH).
+      const gasPaid = spent - ONE_ETH
+      const minExpectedGasPaid = 20_000n * quotedPriority
+      expect(gasPaid).toBeGreaterThan(minExpectedGasPaid)
+    },
+  )
+})


### PR DESCRIPTION
Stacked on https://github.com/status-im/status-web/pull/1246.

#### Problem

Swaps fail at broadcast with "max priority fee per gas higher than max fee
per gas". LiFi quotes include a quote-time `maxPriorityFeePerGas`, but
@lifi/sdk strips `maxFeePerGas`. The signer filled only the missing fields
from its own estimator, mixing LiFi's priority fee with an internally
computed ceiling -- an invalid EIP-1559 pair whenever the quote was priced
under hotter conditions than the current base fee.

#### Fix

- Wallet-originated txs (no fee fields): full internal estimation, unchanged.
- Externally priced txs (LiFi swaps): use every field the caller provides;
  derive the missing `maxFeePerGas` from the quoted priority plus the
  estimator's base-fee headroom, guaranteeing `priority <= maxFee`.
- Safety clamp for the inverse partial case (caller pins `maxFeePerGas` only).

#### Tests

- New e2e regression: swap with a 50 gwei quoted priority against a 1 gwei
  base fee signs a valid tx and pays the quoted priority (quoted-priority
  knob added to the LiFi mock, exposed as a fixture).
  
---

#### Test

- E2E test CI passes
- Local tests pass: `cd e2e && pnpm test:all && pnpm test:wallet-send && pnpm test:wallet-swap`
- You can do a real swap transaction on the wallet through the LiFi widget
  