### PR TITLE
Fix blog crawler 5xx errors

### DIFF
--- a/apps/status.app/package.json
+++ b/apps/status.app/package.json
@@ -19,6 +19,7 @@
     "start:standalone": "node .next/standalone/apps/status.app/server.js",
     "start:docker": "bash -c 'set -a && . .env.local && set +a && docker run --rm -p 3001:3001 -e SITE_URL -e NEXT_PUBLIC_GHOST_API_URL -e NEXT_PUBLIC_GHOST_API_KEY -e NEXT_PUBLIC_INFURA_API_KEY -e NEXT_PUBLIC_HASURA_API_URL -e INFURA_API_KEY -e GREENHOUSE_API_KEY -e GREENHOUSE_STATUS_BOARD_ID -e GREENHOUSE_LOGOS_BOARD_ID -e GITHUB_TOKEN -e POSTGRES_URL -e KEYCLOAK_API_URL -e KEYCLOAK_REALM -e KEYCLOAK_ISSUER -e KEYCLOAK_CLIENT_ID -e KEYCLOAK_CLIENT_SECRET -e BAMBOOHR_API_KEY -e UMAMI_WEBSITE_ID -e UMAMI_API_URL status-web/status.app:dev'",
     "preview:docker": "pnpm build:docker && pnpm start:docker",
+    "test": "vitest",
     "prelint": "contentlayer2 build",
     "lint": "pnpm lint:remark && pnpm lint:next",
     "lint:next": "next lint --dir=src --ext=.ts --ext=.tsx",

--- a/apps/status.app/src/app/_components/content/index.test.tsx
+++ b/apps/status.app/src/app/_components/content/index.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { blogComponents } from './index'
+
+vi.mock('~/i18n/navigation', () => ({
+  Link: ({ href, children, ...props }: React.ComponentProps<'a'>) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('blogComponents.table', () => {
+  it('renders Ghost tables that do not include a thead', () => {
+    const table = blogComponents.table({
+      children: React.createElement(
+        'tbody',
+        null,
+        React.createElement(
+          'tr',
+          null,
+          React.createElement('td', null, 'Metric'),
+          React.createElement('td', null, 'Value')
+        )
+      ),
+    })
+
+    expect(renderToStaticMarkup(table)).toContain('Metric')
+    expect(renderToStaticMarkup(table)).toContain('Value')
+  })
+})

--- a/apps/status.app/src/app/_components/content/index.tsx
+++ b/apps/status.app/src/app/_components/content/index.tsx
@@ -1,5 +1,13 @@
 // note: primarily uses margin, not padding, to create space between elements
-import { Children, cloneElement, type ComponentProps, type JSX } from 'react'
+import {
+  Children,
+  cloneElement,
+  type ComponentProps,
+  isValidElement,
+  type JSX,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
 
 import { ContextTag, Step, Tabs, Tooltip } from '@status-im/components'
 import { BulletIcon, CheckIcon } from '@status-im/icons/20'
@@ -424,6 +432,31 @@ const SpaceDivider = (props: React.ComponentPropsWithoutRef<'div'>) => {
   )
 }
 
+type ContentElement = ReactElement<{ children?: ReactNode }>
+
+const toElementArray = (children: ReactNode): ContentElement[] =>
+  Children.toArray(children).filter((child): child is ContentElement =>
+    isValidElement<{ children?: ReactNode }>(child)
+  )
+
+const isHtmlElement = (element: ContentElement, tagName: string) =>
+  element.type === tagName
+
+const getTableRows = (element?: ContentElement) => {
+  if (!element) {
+    return []
+  }
+
+  return toElementArray(element.props.children).filter(row =>
+    isHtmlElement(row, 'tr')
+  )
+}
+
+const getTableCells = (row: ContentElement) =>
+  toElementArray(row.props.children).filter(
+    cell => isHtmlElement(cell, 'td') || isHtmlElement(cell, 'th')
+  )
+
 export const blogComponents = {
   ...baseComponents,
   h2: (props: ComponentProps<'h2'>) => {
@@ -437,22 +470,34 @@ export const blogComponents = {
     })
   },
   table: (props: any) => {
-    const [head, body] = props.children
-    const headers = head.props.children.props.children
-    const rows = body.props.children
+    const children = toElementArray(props.children)
+    const head = children.find(child => isHtmlElement(child, 'thead'))
+    const bodies = children.filter(child => isHtmlElement(child, 'tbody'))
+    const directRows = children.filter(child => isHtmlElement(child, 'tr'))
+    const footer = children.find(child => isHtmlElement(child, 'tfoot'))
+    const headerRows = getTableRows(head)
+    const headerCells = headerRows[0] ? getTableCells(headerRows[0]) : []
+    const bodyRows = [
+      ...headerRows.slice(1),
+      ...bodies.flatMap(getTableRows),
+      ...directRows,
+      ...getTableRows(footer),
+    ]
 
     return (
       <Table>
-        <TableHead>
-          {headers.map((header: any, index: any) => (
-            <TableHeader key={index} {...header.props} />
-          ))}
-        </TableHead>
+        {headerCells.length > 0 && (
+          <TableHead>
+            {headerCells.map((header, index) => (
+              <TableHeader key={index}>{header.props.children}</TableHeader>
+            ))}
+          </TableHead>
+        )}
         <TableContent>
-          {rows.map((row: any, index: any) => (
+          {bodyRows.map((row, index) => (
             <TableRow key={index}>
-              {row.props.children.map((cell: any, index: any) => (
-                <TableCell key={index} {...cell.props} />
+              {getTableCells(row).map((cell, index) => (
+                <TableCell key={index}>{cell.props.children}</TableCell>
               ))}
             </TableRow>
           ))}

--- a/apps/status.app/src/app/_components/content/table.tsx
+++ b/apps/status.app/src/app/_components/content/table.tsx
@@ -2,10 +2,7 @@ import { renderText } from '~app/_utils/render-text'
 
 export function Table(props: {
   hasShadow?: boolean
-  children: [
-    React.ReactElement<typeof TableHead>,
-    React.ReactElement<typeof TableContent>,
-  ]
+  children: React.ReactNode
 }) {
   const { hasShadow = false, children } = props
 
@@ -34,9 +31,7 @@ export function Table(props: {
   )
 }
 
-export function TableHead(props: {
-  children: React.ReactElement<typeof TableCell>[]
-}) {
+export function TableHead(props: { children: React.ReactNode }) {
   const { children } = props
 
   return (
@@ -46,17 +41,13 @@ export function TableHead(props: {
   )
 }
 
-export function TableContent(props: {
-  children: React.ReactElement<typeof TableRow>[]
-}) {
+export function TableContent(props: { children: React.ReactNode }) {
   const { children } = props
 
   return <tbody>{children}</tbody>
 }
 
-export function TableRow(props: {
-  children: React.ReactElement<typeof TableCell>
-}) {
+export function TableRow(props: { children: React.ReactNode }) {
   const { children } = props
 
   return <tr>{children}</tr>

--- a/apps/status.app/vitest.config.ts
+++ b/apps/status.app/vitest.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+const resolvePath = (path: string) => fileURLToPath(new URL(path, import.meta.url))
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
+  resolve: {
+    alias: {
+      '~components': resolvePath('./src/app/_components'),
+      '~hooks': resolvePath('./src/app/_hooks'),
+      '~website': resolvePath('./src/app/(website)'),
+      '~sharing': resolvePath('./src/app/(sharing)'),
+      '~admin': resolvePath('./src/app/admin'),
+      '~server': resolvePath('./src/server'),
+      '~app': resolvePath('./src/app'),
+      '~public': resolvePath('./public'),
+      '~': resolvePath('./src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
Fix blog rendering for older Ghost tables that caused some crawled blog URLs to return 500.

## Testing
- corepack pnpm --filter status.app test -- --run
- corepack pnpm --filter status.app types:check
- corepack pnpm --filter status.app lint:next
- corepack pnpm --filter status.app exec next build