### PR TITLE
feat(wallet): mnemonic account discovery and selection

### DIFF
--- a/.changeset/proud-adults-grow.md
+++ b/.changeset/proud-adults-grow.md
@@ -1,0 +1,6 @@
+---
+'wallet': patch
+'e2e': patch
+---
+
+feat(wallet): mnemonic account discovery and selection

--- a/apps/wallet/src/components/onboarding/import-wallet-flow.tsx
+++ b/apps/wallet/src/components/onboarding/import-wallet-flow.tsx
@@ -8,13 +8,16 @@ import {
 } from '@status-im/wallet/components'
 
 import { Link } from '@/components/link'
+import { useDiscoverAccounts } from '@/hooks/use-discover-accounts'
 import { useImportWallet } from '@/hooks/use-import-wallet'
 import { useWalletFlowSuccess } from '@/hooks/use-wallet-flow-success'
 import { usePassword } from '@/providers/password-context'
 
 import { BackButton } from './back-button'
 import { CreatePasswordStep } from './create-password-step'
+import { SelectAccountsStep } from './select-accounts-step'
 
+import type { AccountPreview } from './select-accounts-step'
 import type { SubmitHandler } from 'react-hook-form'
 
 type Props = {
@@ -26,7 +29,8 @@ type Props = {
 
 type ImportFlowStep =
   | { step: 'enter-mnemonic'; mnemonic: string }
-  | { step: 'create-password'; mnemonic: string }
+  | { step: 'select-accounts'; mnemonic: string }
+  | { step: 'create-password'; mnemonic: string; derivationPaths: string[] }
 
 export function ImportWalletFlow({
   backHref,
@@ -35,6 +39,16 @@ export function ImportWalletFlow({
   hardwareWalletHref,
 }: Props) {
   const { importWalletAsync } = useImportWallet()
+  // Discovery lives in the flow and is triggered from the mnemonic submit
+  // handler. Do not move it into a mount effect of the select-accounts step:
+  // calling mutate() during the initial effect detaches the mutation observer
+  // under StrictMode's remount and the result never reaches the UI.
+  const {
+    discoverAccounts,
+    data: discoveredAccounts,
+    isPending: isDiscovering,
+    isError: discoveryFailed,
+  } = useDiscoverAccounts()
   const { requestPassword } = usePassword()
   const onSuccess = useWalletFlowSuccess(successHref)
   const [isLoading, setIsLoading] = useState(false)
@@ -42,17 +56,39 @@ export function ImportWalletFlow({
     step: 'enter-mnemonic',
     mnemonic: '',
   })
+  // Lifted so custom paths survive navigating back from the password step
+  const [customAccounts, setCustomAccounts] = useState<AccountPreview[]>([])
 
-  const completeImport = async (mnemonic: string, password?: string) => {
-    const wallet = await importWalletAsync({ mnemonic, password })
+  const completeImport = async (
+    mnemonic: string,
+    derivationPaths: string[],
+    password?: string,
+  ) => {
+    const wallet = await importWalletAsync({
+      mnemonic,
+      password,
+      derivationPaths,
+    })
     await onSuccess(wallet, `Imported ${wallet.name}`)
   }
 
   const handleMnemonicSubmit: SubmitHandler<
     ImportRecoveryPhraseFormValues
   > = async data => {
+    setCustomAccounts([])
+    discoverAccounts({ mnemonic: data.mnemonic })
+    setFlowStep({ step: 'select-accounts', mnemonic: data.mnemonic })
+  }
+
+  const handleAccountsSubmit = async (derivationPaths: string[]) => {
+    if (flowStep.step !== 'select-accounts') return
+
     if (requiresPasswordCreation) {
-      setFlowStep({ step: 'create-password', mnemonic: data.mnemonic })
+      setFlowStep({
+        step: 'create-password',
+        mnemonic: flowStep.mnemonic,
+        derivationPaths,
+      })
       return
     }
 
@@ -64,7 +100,7 @@ export function ImportWalletFlow({
         requireFreshPassword: true,
       })
       if (!isUnlocked) return
-      await completeImport(data.mnemonic)
+      await completeImport(flowStep.mnemonic, derivationPaths)
     } catch (error) {
       console.error(error)
     } finally {
@@ -75,9 +111,15 @@ export function ImportWalletFlow({
   const handlePasswordSubmit: SubmitHandler<
     CreatePasswordFormValues
   > = async data => {
+    if (flowStep.step !== 'create-password') return
+
     setIsLoading(true)
     try {
-      await completeImport(flowStep.mnemonic, data.password)
+      await completeImport(
+        flowStep.mnemonic,
+        flowStep.derivationPaths,
+        data.password,
+      )
     } catch (error) {
       console.error(error)
     } finally {
@@ -90,13 +132,34 @@ export function ImportWalletFlow({
       <CreatePasswordStep
         onBack={() =>
           setFlowStep({
-            step: 'enter-mnemonic',
+            step: 'select-accounts',
             mnemonic: flowStep.mnemonic,
           })
         }
         onSubmit={handlePasswordSubmit}
         isLoading={isLoading}
         confirmButtonLabel="Import Wallet"
+      />
+    )
+  }
+
+  if (flowStep.step === 'select-accounts') {
+    return (
+      <SelectAccountsStep
+        mnemonic={flowStep.mnemonic}
+        discoveredAccounts={discoveredAccounts}
+        isDiscovering={isDiscovering}
+        discoveryFailed={discoveryFailed}
+        customAccounts={customAccounts}
+        onCustomAccountsChange={setCustomAccounts}
+        onBack={() =>
+          setFlowStep({
+            step: 'enter-mnemonic',
+            mnemonic: flowStep.mnemonic,
+          })
+        }
+        onContinue={handleAccountsSubmit}
+        isLoading={isLoading}
       />
     )
   }

--- a/apps/wallet/src/components/onboarding/select-accounts-step.tsx
+++ b/apps/wallet/src/components/onboarding/select-accounts-step.tsx
@@ -129,7 +129,7 @@ export function SelectAccountsStep({
       )}
 
       {rows.length > 0 && (
-        <div className="mb-4 flex flex-col gap-2">
+        <div className="mb-4 flex max-h-[336px] flex-col gap-2 overflow-y-auto pr-1">
           {rows.map(row => (
             <div
               key={row.derivationPath}

--- a/apps/wallet/src/components/onboarding/select-accounts-step.tsx
+++ b/apps/wallet/src/components/onboarding/select-accounts-step.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react'
+
+import { Button, Input, Text } from '@status-im/components'
+import { CloseIcon } from '@status-im/icons/20'
+
+import { usePreviewAccount } from '@/hooks/use-preview-account'
+
+import { BackButton } from './back-button'
+
+export type AccountPreview = {
+  address: string
+  derivationPath: string
+  active: boolean
+}
+
+const DERIVATION_PATH_REGEX = /^m(\/\d+'?)+$/
+const DEFAULT_ETHEREUM_PATH = "m/44'/60'/0'/0/0"
+
+type Props = {
+  mnemonic: string
+  discoveredAccounts: AccountPreview[] | undefined
+  isDiscovering: boolean
+  discoveryFailed: boolean
+  customAccounts: AccountPreview[]
+  onCustomAccountsChange: (accounts: AccountPreview[]) => void
+  onBack: () => void
+  onContinue: (derivationPaths: string[]) => void
+  isLoading: boolean
+}
+
+export function SelectAccountsStep({
+  mnemonic,
+  discoveredAccounts,
+  isDiscovering,
+  discoveryFailed,
+  customAccounts,
+  onCustomAccountsChange,
+  onBack,
+  onContinue,
+  isLoading,
+}: Props) {
+  const { previewAccountAsync, isPending: isAddingPath } = usePreviewAccount()
+
+  const [customPath, setCustomPath] = useState('')
+  const [customPathError, setCustomPathError] = useState<string | null>(null)
+
+  const rows = [
+    ...(discoveredAccounts ?? []).map(account => ({
+      address: account.address,
+      derivationPath: account.derivationPath,
+      status: account.active ? 'Active' : 'Default',
+      custom: false,
+    })),
+    ...customAccounts.map(account => ({
+      address: account.address,
+      derivationPath: account.derivationPath,
+      status: account.active ? 'Active' : 'No activity',
+      custom: true,
+    })),
+  ]
+
+  const handleAddPath = async () => {
+    const derivationPath = customPath.trim()
+    setCustomPathError(null)
+
+    if (!DERIVATION_PATH_REGEX.test(derivationPath)) {
+      setCustomPathError("Enter a valid derivation path, e.g. m/44'/60'/0'/0/1")
+      return
+    }
+    if (rows.some(row => row.derivationPath === derivationPath)) {
+      setCustomPathError('This derivation path is already in the list')
+      return
+    }
+
+    try {
+      const account = await previewAccountAsync({ mnemonic, derivationPath })
+      onCustomAccountsChange([...customAccounts, account])
+      setCustomPath('')
+    } catch (error) {
+      console.error('failed to derive custom path', error)
+      setCustomPathError('Unable to derive an address for this path')
+    }
+  }
+
+  const handleRemovePath = (derivationPath: string) => {
+    onCustomAccountsChange(
+      customAccounts.filter(
+        account => account.derivationPath !== derivationPath,
+      ),
+    )
+  }
+
+  const handleContinue = () => {
+    // Fall back to the default derivation path if the scan found nothing
+    // (e.g. it failed); the wallet always imports at least account 0.
+    const discoveredPaths = (discoveredAccounts ?? []).map(
+      account => account.derivationPath,
+    )
+    const basePaths =
+      discoveredPaths.length > 0 ? discoveredPaths : [DEFAULT_ETHEREUM_PATH]
+    const customPaths = customAccounts.map(account => account.derivationPath)
+    onContinue([...new Set([...basePaths, ...customPaths])])
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-1">
+      <div className="flex items-center pb-4">
+        <BackButton onClick={onBack} />
+      </div>
+      <Text size={27} weight="semibold">
+        Accounts to import
+      </Text>
+      <Text size={15} color="$neutral-50" className="mb-4">
+        We scanned your recovery phrase for addresses with on-chain activity.
+        All addresses below will be imported.
+      </Text>
+
+      {isDiscovering && (
+        <Text size={13} color="$neutral-50" className="mb-4">
+          Scanning for active addresses…
+        </Text>
+      )}
+
+      {discoveryFailed && (
+        <p className="mb-4 text-13 text-danger-50">
+          We could not scan for active addresses. The default address will be
+          imported.
+        </p>
+      )}
+
+      {rows.length > 0 && (
+        <div className="mb-4 flex flex-col gap-2">
+          {rows.map(row => (
+            <div
+              key={row.derivationPath}
+              className="flex items-center justify-between gap-2 rounded-12 border border-neutral-10 bg-neutral-2.5 p-3"
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <Text size={13} color="$neutral-50">
+                  {row.derivationPath} · {row.status}
+                </Text>
+                <Text size={13} weight="medium" className="break-all">
+                  {row.address}
+                </Text>
+              </div>
+              {row.custom && (
+                <Button
+                  onClick={() => handleRemovePath(row.derivationPath)}
+                  variant="grey"
+                  icon={<CloseIcon color="$neutral-100" />}
+                  aria-label={`Remove ${row.derivationPath}`}
+                  size="32"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-col gap-2">
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <Input
+              label="Custom derivation path"
+              value={customPath}
+              onChange={setCustomPath}
+              placeholder="m/44'/60'/0'/0/1"
+            />
+          </div>
+          <Button
+            onClick={handleAddPath}
+            variant="grey"
+            disabled={isAddingPath || customPath.trim() === ''}
+          >
+            {isAddingPath ? 'Adding…' : 'Add'}
+          </Button>
+        </div>
+        {customPathError && (
+          <p className="text-13 text-danger-50">{customPathError}</p>
+        )}
+      </div>
+
+      <Button onClick={handleContinue} disabled={isLoading || isDiscovering}>
+        {isLoading ? 'Importing…' : 'Continue'}
+      </Button>
+    </div>
+  )
+}

--- a/apps/wallet/src/components/wallet-selector.tsx
+++ b/apps/wallet/src/components/wallet-selector.tsx
@@ -1,9 +1,4 @@
-import {
-  Avatar,
-  Button,
-  DropdownMenu,
-  /*Tooltip*/
-} from '@status-im/components'
+import { Avatar, Button, DropdownMenu, Tooltip } from '@status-im/components'
 import {
   AddIcon,
   ChevronDownIcon,
@@ -11,7 +6,7 @@ import {
   KeycardIcon,
   WalletIcon,
 } from '@status-im/icons/20'
-// import { shortenAddress } from '@status-im/wallet/components'
+import { shortenAddress } from '@status-im/wallet/components'
 import { useNavigate } from '@tanstack/react-router'
 
 import { useWallet } from '@/providers/wallet-context'
@@ -25,16 +20,29 @@ type Props = {
 const DEFAULT_ACCOUNT_EMOJI = '🍑'
 const DEFAULT_ACCOUNT_NAME = 'Account 1'
 
+// SLIP-44 coin type for Ethereum. The account switcher only surfaces EVM
+// accounts because the current account drives the (EVM-only) portfolio views.
+const ETHEREUM_COIN_TYPE = 60
+
 export function WalletSelector(props: Props) {
   const { className } = props
   const navigate = useNavigate()
-  const { wallets, currentWallet /*, currentAccount*/, setCurrentWallet } =
-    useWallet()
+  const {
+    wallets,
+    currentWallet,
+    currentAccount,
+    setCurrentWallet,
+    setCurrentAccount,
+  } = useWallet()
   const isWatchOnly = currentWallet?.type === 'hardware-qr'
 
   if (!currentWallet) {
     return null
   }
+
+  const selectableAccounts = currentWallet.accounts.filter(
+    account => account.coin === ETHEREUM_COIN_TYPE,
+  )
 
   return (
     <div
@@ -46,7 +54,7 @@ export function WalletSelector(props: Props) {
         <Avatar
           type="account"
           size="24"
-          // TODO: Use currently selected account name instead when multi-account support is implemented.
+          // TODO: Use currently selected account name instead when named accounts are supported.
           name={currentWallet.name ?? DEFAULT_ACCOUNT_NAME}
           emoji={DEFAULT_ACCOUNT_EMOJI}
           bgOpacity="20"
@@ -56,15 +64,13 @@ export function WalletSelector(props: Props) {
             {currentWallet.name}
           </div>
           {isWatchOnly && <WatchOnlyTag />}
-          {/* TODO: Uncomment to display current account's name
-          when multi-account support is implemented */}
-          {/* {currentAccount?.address ? (
-            <Tooltip content={DEFAULT_ACCOUNT_NAME} side="top">
+          {currentAccount?.address ? (
+            <Tooltip content={currentAccount.address} side="top">
               <div className="text-13 font-medium text-neutral-50">
                 {shortenAddress(currentAccount.address)}
               </div>
             </Tooltip>
-          ) : null} */}
+          ) : null}
         </div>
       </div>
 
@@ -87,6 +93,23 @@ export function WalletSelector(props: Props) {
               onClick={() => setCurrentWallet(wallet.id)}
             />
           ))}
+
+          {selectableAccounts.length > 0 && (
+            <>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Label>Accounts</DropdownMenu.Label>
+              {selectableAccounts.map(account => (
+                <DropdownMenu.Item
+                  key={account.address}
+                  icon={<WalletIcon />}
+                  label={shortenAddress(account.address)}
+                  selected={account.address === currentAccount?.address}
+                  onClick={() => setCurrentAccount(account.address)}
+                />
+              ))}
+            </>
+          )}
+
           <DropdownMenu.Separator />
           <DropdownMenu.Item
             icon={<AddIcon />}

--- a/apps/wallet/src/data/account-discovery.test.ts
+++ b/apps/wallet/src/data/account-discovery.test.ts
@@ -1,0 +1,129 @@
+import { expect, test, vi } from 'vitest'
+
+import {
+  ACCOUNT_DISCOVERY_GAP_LIMIT,
+  discoverAccounts,
+} from './account-discovery'
+import { getWalletCore } from './wallet'
+
+const MNEMONIC = 'test test test test test test test test test test test junk'
+
+// First addresses derived from MNEMONIC at m/44'/60'/0'/0/{index}
+const ADDRESSES = [
+  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+  '0x90F79bf6EB2c4f870365E785982E1f101E93b906',
+  '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65',
+  '0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc',
+]
+
+function activeAt(...addresses: string[]) {
+  const active = new Set(addresses)
+  return vi.fn(async (address: string) => active.has(address))
+}
+
+test('imports only account 0 when no address has activity', async () => {
+  const walletCore = await getWalletCore()
+  const isAddressActive = activeAt()
+
+  const accounts = await discoverAccounts({
+    walletCore,
+    mnemonic: MNEMONIC,
+    isAddressActive,
+  })
+
+  expect(accounts.map(a => a.address)).toEqual([ADDRESSES[0]])
+  expect(accounts[0].derivationPath).toBe("m/44'/60'/0'/0/0")
+  expect(accounts[0].active).toBe(false)
+  // the scanned gap plus the informational check of account 0
+  expect(isAddressActive).toHaveBeenCalledTimes(ACCOUNT_DISCOVERY_GAP_LIMIT + 1)
+}, 15000)
+
+test('imports consecutive active accounts', async () => {
+  const walletCore = await getWalletCore()
+
+  const accounts = await discoverAccounts({
+    walletCore,
+    mnemonic: MNEMONIC,
+    gapLimit: 5,
+    isAddressActive: activeAt(ADDRESSES[1], ADDRESSES[2]),
+  })
+
+  expect(accounts.map(a => a.address)).toEqual(ADDRESSES.slice(0, 3))
+  expect(accounts.map(a => a.derivationPath)).toEqual([
+    "m/44'/60'/0'/0/0",
+    "m/44'/60'/0'/0/1",
+    "m/44'/60'/0'/0/2",
+  ])
+  expect(accounts.map(a => a.active)).toEqual([false, true, true])
+}, 15000)
+
+test('skips inactive addresses within the gap but imports active ones past them', async () => {
+  const walletCore = await getWalletCore()
+
+  const accounts = await discoverAccounts({
+    walletCore,
+    mnemonic: MNEMONIC,
+    gapLimit: 5,
+    isAddressActive: activeAt(ADDRESSES[5]),
+  })
+
+  expect(accounts.map(a => a.address)).toEqual([ADDRESSES[0], ADDRESSES[5]])
+  expect(accounts[1].derivationPath).toBe("m/44'/60'/0'/0/5")
+}, 15000)
+
+test('stops after the gap limit of consecutive inactive addresses', async () => {
+  const walletCore = await getWalletCore()
+  const isAddressActive = activeAt(ADDRESSES[1])
+
+  const accounts = await discoverAccounts({
+    walletCore,
+    mnemonic: MNEMONIC,
+    gapLimit: 3,
+    isAddressActive,
+  })
+
+  expect(accounts.map(a => a.address)).toEqual([ADDRESSES[0], ADDRESSES[1]])
+  // account 0, then indices 1 (active) and 2, 3, 4 (inactive) close the gap of 3
+  expect(isAddressActive).toHaveBeenCalledTimes(5)
+}, 15000)
+
+test('stops at the max index when every address is active', async () => {
+  const walletCore = await getWalletCore()
+  const isAddressActive = vi.fn(async () => true)
+
+  const accounts = await discoverAccounts({
+    walletCore,
+    mnemonic: MNEMONIC,
+    gapLimit: 3,
+    maxIndex: 7,
+    isAddressActive,
+  })
+
+  // indices 0 through 7, all active
+  expect(accounts).toHaveLength(8)
+  expect(accounts.at(-1)?.derivationPath).toBe("m/44'/60'/0'/0/7")
+  // indices 1..7 plus the informational check of account 0
+  expect(isAddressActive).toHaveBeenCalledTimes(8)
+}, 15000)
+
+test('falls back to the accounts found so far when activity checks fail', async () => {
+  const walletCore = await getWalletCore()
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  try {
+    const accounts = await discoverAccounts({
+      walletCore,
+      mnemonic: MNEMONIC,
+      isAddressActive: async () => {
+        throw new Error('network down')
+      },
+    })
+
+    expect(accounts.map(a => a.address)).toEqual([ADDRESSES[0]])
+    expect(warn).toHaveBeenCalled()
+  } finally {
+    warn.mockRestore()
+  }
+}, 15000)

--- a/apps/wallet/src/data/account-discovery.ts
+++ b/apps/wallet/src/data/account-discovery.ts
@@ -1,0 +1,126 @@
+import { getRpcProxyUrl } from '../lib/rpc-proxy'
+import { deriveAccounts } from './derive'
+
+import type { WalletAccount } from './wallet-metadata'
+import type { WalletCore } from '@trustwallet/wallet-core'
+
+// Stop scanning once this many consecutive addresses show no on-chain
+// activity (BIP-44 address gap limit).
+export const ACCOUNT_DISCOVERY_GAP_LIMIT = 20
+
+// Upper bound on scanned indices so wallets with very long runs of active
+// addresses (e.g. widely-known test mnemonics) still finish in bounded time.
+export const ACCOUNT_DISCOVERY_MAX_INDEX = 100
+
+// note: rpc.proxy expects a plain JSON-RPC body with chainId as a query
+// param; tRPC-formatted POST bodies are rejected by the API route handler
+async function rpcCall(method: string, params: unknown[]): Promise<unknown> {
+  const response = await fetch(getRpcProxyUrl(1), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }),
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to query RPC proxy: ${response.status}`)
+  }
+
+  const body = (await response.json()) as {
+    result?: unknown
+    error?: { message: string }
+  }
+
+  if (body.error) {
+    throw new Error(body.error.message)
+  }
+
+  return body.result
+}
+
+export type DiscoveredAccount = WalletAccount & { active: boolean }
+
+// An address counts as active when it sent at least one transaction or holds
+// a balance; the balance covers addresses with only incoming transfers, which
+// eth_getTransactionCount does not reflect.
+export async function hasActivity(address: string): Promise<boolean> {
+  const [transactionCount, balance] = await Promise.all([
+    rpcCall('eth_getTransactionCount', [address, 'latest']),
+    rpcCall('eth_getBalance', [address, 'latest']),
+  ])
+
+  return (
+    BigInt((transactionCount as string | null) ?? 0) > 0n ||
+    BigInt((balance as string | null) ?? 0) > 0n
+  )
+}
+
+/**
+ * Derives the Ethereum accounts of a mnemonic that have on-chain activity.
+ *
+ * Account 0 is always included. Subsequent indices are scanned until
+ * `gapLimit` consecutive addresses show no activity (up to `maxIndex`);
+ * addresses within a gap are skipped, active ones past a gap are included.
+ *
+ * Discovery is best effort: when activity checks fail (e.g. the RPC proxy is
+ * unreachable) the accounts found so far are returned instead of failing the
+ * import.
+ */
+export async function discoverAccounts({
+  walletCore,
+  mnemonic,
+  gapLimit = ACCOUNT_DISCOVERY_GAP_LIMIT,
+  maxIndex = ACCOUNT_DISCOVERY_MAX_INDEX,
+  isAddressActive = hasActivity,
+}: {
+  walletCore: WalletCore
+  mnemonic: string
+  gapLimit?: number
+  maxIndex?: number
+  isAddressActive?: (address: string) => Promise<boolean>
+}): Promise<DiscoveredAccount[]> {
+  const derive = (indices: number[]) =>
+    deriveAccounts(
+      walletCore,
+      mnemonic,
+      walletCore.CoinType.ethereum,
+      walletCore.Derivation.default,
+      indices,
+    )
+
+  const [firstAccount] = derive([0])
+  // Account 0 is imported regardless of activity; its check runs alongside
+  // the scan and only informs the UI, not the gap counting.
+  const firstActive = isAddressActive(firstAccount.address).catch(() => false)
+  const accounts: DiscoveredAccount[] = []
+
+  try {
+    let index = 1
+    let inactiveStreak = 0
+    while (inactiveStreak < gapLimit && index <= maxIndex) {
+      // Check in parallel only as many addresses as could exhaust the gap.
+      const batch = derive(
+        Array.from(
+          { length: Math.min(gapLimit - inactiveStreak, maxIndex - index + 1) },
+          (_, i) => index + i,
+        ),
+      )
+      const activity = await Promise.all(
+        batch.map(account => isAddressActive(account.address)),
+      )
+      for (const [i, active] of activity.entries()) {
+        if (active) {
+          accounts.push({ ...batch[i], active: true })
+          inactiveStreak = 0
+        } else {
+          inactiveStreak++
+        }
+      }
+      index += batch.length
+    }
+  } catch (error) {
+    console.warn('account discovery stopped early:', error)
+  }
+
+  return [{ ...firstAccount, active: await firstActive }, ...accounts]
+}

--- a/apps/wallet/src/data/api.test.ts
+++ b/apps/wallet/src/data/api.test.ts
@@ -67,6 +67,14 @@ const createChromeMock = () => {
 
 beforeEach(async () => {
   vi.stubGlobal('chrome', createChromeMock())
+  // Keep account discovery during wallet import off the network; it falls
+  // back to importing account 0 only.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network disabled in tests')
+    }),
+  )
   await storage.clear('local')
   await storage.clear('session')
   // vi.stubGlobal('browser', createChromeMock())
@@ -109,6 +117,113 @@ test('should import wallet', async () => {
 
   expect(importedWallet.mnemonic).toBe(mnemonic)
 }, 7000)
+
+test('should discover active accounts when importing a wallet', async () => {
+  // Addresses at m/44'/60'/0'/0/{0,1} of the mnemonic below
+  const firstAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+  const activeAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+  // Emulates the JSON-RPC rpc.proxy endpoint: only activeAddress has
+  // transactions
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string)
+      const isActive =
+        body.method === 'eth_getTransactionCount' &&
+        body.params[0] === activeAddress
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: isActive ? '0x1' : '0x0',
+        }),
+      )
+    }),
+  )
+
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+  })
+
+  const accounts = await apiClient.wallet.account.all.query({
+    walletId: importedWallet.id,
+  })
+
+  expect(accounts.map(a => a.address)).toEqual([firstAddress, activeAddress])
+  expect(accounts.map(a => a.derivationPath)).toEqual([
+    "m/44'/60'/0'/0/0",
+    "m/44'/60'/0'/0/1",
+  ])
+}, 15000)
+
+test('should import wallet with explicit derivation paths', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0", "m/44'/60'/0'/0/5"],
+  })
+
+  const accounts = await apiClient.wallet.account.all.query({
+    walletId: importedWallet.id,
+  })
+
+  expect(accounts.map(a => a.address)).toEqual([
+    '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    '0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc',
+  ])
+  expect(accounts.map(a => a.derivationPath)).toEqual([
+    "m/44'/60'/0'/0/0",
+    "m/44'/60'/0'/0/5",
+  ])
+}, 15000)
+
+test('should preview an account at a custom derivation path', async () => {
+  const activeAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string)
+      const isActive =
+        body.method === 'eth_getTransactionCount' &&
+        body.params[0] === activeAddress
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: isActive ? '0x1' : '0x0',
+        }),
+      )
+    }),
+  )
+
+  await createAPI()
+  const apiClient = createAPIClient()
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  const active = await apiClient.wallet.previewAccount.mutate({
+    mnemonic,
+    derivationPath: "m/44'/60'/0'/0/1",
+  })
+  const inactive = await apiClient.wallet.previewAccount.mutate({
+    mnemonic,
+    derivationPath: "m/44'/60'/0'/0/2",
+  })
+
+  expect(active).toMatchObject({ address: activeAddress, active: true })
+  expect(inactive).toMatchObject({
+    address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    active: false,
+  })
+}, 15000)
 
 test('should get wallet', async () => {
   await createAPI()

--- a/apps/wallet/src/data/api.ts
+++ b/apps/wallet/src/data/api.ts
@@ -321,6 +321,19 @@ const apiRouter = router({
           return wallet.accounts
         }),
 
+      // Persists which account is currently selected for a wallet.
+      select: procedure
+        .input(
+          z.object({
+            walletId: z.string(),
+            address: z.string(),
+          }),
+        )
+        .mutation(async ({ input }) => {
+          await walletMetadata.setSelectedAccount(input.walletId, input.address)
+          return { address: input.address }
+        }),
+
       ethereum: router({
         add: procedure
           .input(

--- a/apps/wallet/src/data/api.ts
+++ b/apps/wallet/src/data/api.ts
@@ -9,10 +9,12 @@ import {
 } from 'viem/accounts'
 import { z } from 'zod'
 
+import { discoverAccounts, hasActivity } from './account-discovery'
 import * as bitcoin from './bitcoin/bitcoin'
 import { chromeLinkWithRetries } from './chromeLink'
 import {
   deriveAccount,
+  deriveAccountsAtPaths,
   deriveNextAccountIndex,
   derivePrivateKey,
   privateKeyFromData,
@@ -182,12 +184,51 @@ const apiRouter = router({
         return { id: meta.id, name: meta.name, mnemonic }
       }),
 
+    // Derives the accounts of a mnemonic with on-chain activity so the user
+    // can review them before importing. Does not persist anything.
+    discoverAccounts: procedure
+      .input(z.object({ mnemonic: z.string() }))
+      .mutation(async ({ input, ctx }) => {
+        return discoverAccounts({
+          walletCore: ctx.walletCore,
+          mnemonic: input.mnemonic,
+        })
+      }),
+
+    // Derives the account of a mnemonic at a custom derivation path and
+    // reports whether it has on-chain activity. Does not persist anything.
+    previewAccount: procedure
+      .input(
+        z.object({
+          mnemonic: z.string(),
+          derivationPath: derivationPathSchema,
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const { walletCore } = ctx
+        const [account] = deriveAccountsAtPaths(
+          walletCore,
+          input.mnemonic,
+          walletCore.CoinType.ethereum,
+          walletCore.Derivation.default,
+          [input.derivationPath],
+        )
+        let active = false
+        try {
+          active = await hasActivity(account.address)
+        } catch {
+          // Activity check is informational only; ignore RPC failures
+        }
+        return { ...account, active }
+      }),
+
     import: procedure
       .input(
         z.object({
           mnemonic: z.string(),
           name: z.string().optional(),
           password: z.string().optional(),
+          derivationPaths: z.array(derivationPathSchema).max(100).optional(),
         }),
       )
       .mutation(async ({ input, ctx }) => {
@@ -195,13 +236,25 @@ const apiRouter = router({
         const walletCount = (await walletMetadata.getAll()).length
         const walletName = input.name ?? `Wallet ${walletCount + 1}`
         const id = crypto.randomUUID()
-        const account = deriveAccount(
-          walletCore,
-          input.mnemonic,
-          walletCore.CoinType.ethereum,
-          walletCore.Derivation.default,
-          0,
-        )
+        const accounts = input.derivationPaths?.length
+          ? deriveAccountsAtPaths(
+              walletCore,
+              input.mnemonic,
+              walletCore.CoinType.ethereum,
+              walletCore.Derivation.default,
+              [...new Set(input.derivationPaths)],
+            )
+          : (
+              await discoverAccounts({
+                walletCore,
+                mnemonic: input.mnemonic,
+              })
+            ).map(account => ({
+              address: account.address,
+              coin: account.coin,
+              derivationPath: account.derivationPath,
+              derivation: account.derivation,
+            }))
         if (await hasVault()) {
           await session.addWalletToVault(id, 'mnemonic', input.mnemonic)
         } else {
@@ -217,8 +270,8 @@ const apiRouter = router({
           id,
           name: walletName,
           type: 'mnemonic',
-          accounts: [account],
-          selectedAccountAddress: account.address,
+          accounts,
+          selectedAccountAddress: accounts[0].address,
         })
         return { id, name: walletName, mnemonic: input.mnemonic }
       }),

--- a/apps/wallet/src/data/derive.ts
+++ b/apps/wallet/src/data/derive.ts
@@ -19,6 +19,51 @@ export function deriveNextAccountIndex(
   return Math.max(...indices) + 1
 }
 
+export function deriveAccountsAtPaths(
+  walletCore: WalletCore,
+  mnemonic: string,
+  coin: InstanceType<WalletCore['CoinType']>,
+  derivation: InstanceType<WalletCore['Derivation']>,
+  paths: string[],
+): WalletAccount[] {
+  const hd = walletCore.HDWallet.createWithMnemonic(mnemonic, '')
+  try {
+    return paths.map(path => {
+      const privateKey = hd.getKey(coin, path)
+      try {
+        const address = walletCore.CoinTypeExt.deriveAddress(coin, privateKey)
+        return {
+          address,
+          coin: coin.value,
+          derivationPath: path,
+          derivation: derivation.value,
+        }
+      } finally {
+        privateKey.delete()
+      }
+    })
+  } finally {
+    hd.delete()
+  }
+}
+
+export function deriveAccounts(
+  walletCore: WalletCore,
+  mnemonic: string,
+  coin: InstanceType<WalletCore['CoinType']>,
+  derivation: InstanceType<WalletCore['Derivation']>,
+  indices: number[],
+): WalletAccount[] {
+  const basePath = walletCore.CoinTypeExt.derivationPathWithDerivation(
+    coin,
+    derivation,
+  )
+  const paths = indices.map(index =>
+    index === 0 ? basePath : basePath.replace(/\/[^/]+$/, `/${index}`),
+  )
+  return deriveAccountsAtPaths(walletCore, mnemonic, coin, derivation, paths)
+}
+
 export function deriveAccount(
   walletCore: WalletCore,
   mnemonic: string,
@@ -26,29 +71,7 @@ export function deriveAccount(
   derivation: InstanceType<WalletCore['Derivation']>,
   index: number = 0,
 ): WalletAccount {
-  const hd = walletCore.HDWallet.createWithMnemonic(mnemonic, '')
-  try {
-    const basePath = walletCore.CoinTypeExt.derivationPathWithDerivation(
-      coin,
-      derivation,
-    )
-    const path =
-      index === 0 ? basePath : basePath.replace(/\/[^/]+$/, `/${index}`)
-    const privateKey = hd.getKey(coin, path)
-    try {
-      const address = walletCore.CoinTypeExt.deriveAddress(coin, privateKey)
-      return {
-        address,
-        coin: coin.value,
-        derivationPath: path,
-        derivation: derivation.value,
-      }
-    } finally {
-      privateKey.delete()
-    }
-  } finally {
-    hd.delete()
-  }
+  return deriveAccounts(walletCore, mnemonic, coin, derivation, [index])[0]
 }
 
 export function derivePrivateKey(

--- a/apps/wallet/src/data/wallet-metadata.ts
+++ b/apps/wallet/src/data/wallet-metadata.ts
@@ -142,6 +142,19 @@ export async function addAccount(
   await save(wallet)
 }
 
+export async function setSelectedAccount(
+  walletId: string,
+  address: string,
+): Promise<void> {
+  const wallet = await get(walletId)
+  if (!wallet) throw new Error(`Wallet ${walletId} not found`)
+  if (!wallet.accounts.some(a => a.address === address)) {
+    throw new Error(`Account ${address} not found in wallet ${walletId}`)
+  }
+  wallet.selectedAccountAddress = address
+  await save(wallet)
+}
+
 export async function remove(walletId: string): Promise<void> {
   const store = await getStore()
   delete store[walletId]

--- a/apps/wallet/src/hooks/use-discover-accounts.ts
+++ b/apps/wallet/src/hooks/use-discover-accounts.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { useAPI } from '../providers/api-client'
+
+export const useDiscoverAccounts = () => {
+  const api = useAPI()
+
+  const { mutate, mutateAsync, ...result } = useMutation({
+    mutationKey: ['discover-accounts'],
+    mutationFn: async ({ mnemonic }: { mnemonic: string }) => {
+      return api.wallet.discoverAccounts.mutate({ mnemonic })
+    },
+  })
+
+  return {
+    discoverAccounts: mutate,
+    discoverAccountsAsync: mutateAsync,
+    ...result,
+  }
+}

--- a/apps/wallet/src/hooks/use-import-wallet.ts
+++ b/apps/wallet/src/hooks/use-import-wallet.ts
@@ -11,13 +11,16 @@ export const useImportWallet = () => {
     mutationFn: async ({
       mnemonic,
       password,
+      derivationPaths,
     }: {
       mnemonic: string
       password?: string
+      derivationPaths?: string[]
     }) => {
       return api.wallet.import.mutate({
         mnemonic,
         password,
+        derivationPaths,
       })
     },
     onSuccess: () => {

--- a/apps/wallet/src/hooks/use-preview-account.ts
+++ b/apps/wallet/src/hooks/use-preview-account.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { useAPI } from '../providers/api-client'
+
+export const usePreviewAccount = () => {
+  const api = useAPI()
+
+  const { mutate, mutateAsync, ...result } = useMutation({
+    mutationKey: ['preview-account'],
+    mutationFn: async ({
+      mnemonic,
+      derivationPath,
+    }: {
+      mnemonic: string
+      derivationPath: string
+    }) => {
+      return api.wallet.previewAccount.mutate({ mnemonic, derivationPath })
+    },
+  })
+
+  return {
+    previewAccount: mutate,
+    previewAccountAsync: mutateAsync,
+    ...result,
+  }
+}

--- a/apps/wallet/src/hooks/use-select-account.ts
+++ b/apps/wallet/src/hooks/use-select-account.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { useAPI } from '../providers/api-client'
+
+import type { WalletMeta } from '../data/wallet-metadata'
+
+export const useSelectAccount = () => {
+  const api = useAPI()
+  const queryClient = useQueryClient()
+
+  const { mutate, mutateAsync, ...result } = useMutation({
+    mutationKey: ['select-account'],
+    mutationFn: async ({
+      walletId,
+      address,
+    }: {
+      walletId: string
+      address: string
+    }) => {
+      return api.wallet.account.select.mutate({ walletId, address })
+    },
+    // Flip the selection instantly; account switching is a frequent action
+    // and waiting on the refetch would lag the UI.
+    onMutate: async ({ walletId, address }) => {
+      await queryClient.cancelQueries({ queryKey: ['wallets'] })
+      const previousWallets = queryClient.getQueryData<WalletMeta[]>([
+        'wallets',
+      ])
+      queryClient.setQueryData<WalletMeta[]>(['wallets'], wallets =>
+        wallets?.map(wallet =>
+          wallet.id === walletId
+            ? { ...wallet, selectedAccountAddress: address }
+            : wallet,
+        ),
+      )
+      return { previousWallets }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousWallets) {
+        queryClient.setQueryData(['wallets'], context.previousWallets)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['wallets'] })
+    },
+  })
+
+  return {
+    selectAccount: mutate,
+    selectAccountAsync: mutateAsync,
+    ...result,
+  }
+}

--- a/apps/wallet/src/lib/tx-monitor.ts
+++ b/apps/wallet/src/lib/tx-monitor.ts
@@ -8,6 +8,7 @@ import {
   notifyTransactionConfirmed,
   notifyTransactionFailed,
 } from './notifications'
+import { getRpcProxyUrl } from './rpc-proxy'
 import { PENDING_TXS_KEY, TX_NOTIFIED_KEY } from './storage-keys'
 
 type PendingTx = {
@@ -21,23 +22,22 @@ async function fetchReceipt(
   txHash: string,
 ): Promise<{ status: string } | null> {
   try {
-    const url = `${import.meta.env.WXT_STATUS_API_URL}/api/trpc/rpc.proxy`
-    const res = await fetch(url, {
+    // note: rpc.proxy expects a plain JSON-RPC body with chainId as a query
+    // param; tRPC-formatted POST bodies are rejected by the API route handler
+    const res = await fetch(getRpcProxyUrl(1), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        json: {
-          method: 'eth_getTransactionReceipt',
-          params: [txHash],
-          id: 1,
-          chainId: 1,
-        },
+        jsonrpc: '2.0',
+        method: 'eth_getTransactionReceipt',
+        params: [txHash],
+        id: 1,
       }),
     })
     const body = (await res.json()) as {
-      result: { data: { json: { result: { status: string } | null } } }
+      result?: { status: string } | null
     }
-    return body.result.data.json.result
+    return body.result ?? null
   } catch {
     return null
   }

--- a/apps/wallet/src/providers/wallet-context.tsx
+++ b/apps/wallet/src/providers/wallet-context.tsx
@@ -10,6 +10,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { storage } from '@wxt-dev/storage'
 
+import { useSelectAccount } from '../hooks/use-select-account'
 import { useSynchronizedRefetch } from '../hooks/use-synchronized-refetch'
 import { apiClient } from './api-client'
 
@@ -28,6 +29,7 @@ type WalletContext = {
   isLoading: boolean
   hasWallets: boolean
   setCurrentWallet: (id: Wallet['id']) => void
+  setCurrentAccount: (address: WalletAccount['address']) => void
 }
 
 const WalletContext = createContext<WalletContext | undefined>(undefined)
@@ -69,8 +71,10 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
 
   const currentAccount = useMemo(() => {
     if (!currentWallet) return null
-    // TODO: Use currently selected account when multi-account support is implemented. See ^^^
-    return currentWallet.accounts[0] ?? null
+    const selectedAccount = currentWallet.accounts.find(
+      account => account.address === currentWallet.selectedAccountAddress,
+    )
+    return selectedAccount ?? currentWallet.accounts[0] ?? null
   }, [currentWallet])
 
   useEffect(() => {
@@ -128,6 +132,17 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setSelectedWalletId(id)
   }, [])
 
+  const { selectAccount } = useSelectAccount()
+
+  const setCurrentAccount = useCallback(
+    (address: string) => {
+      if (!currentWallet) return
+      if (currentWallet.selectedAccountAddress === address) return
+      selectAccount({ walletId: currentWallet.id, address })
+    },
+    [currentWallet, selectAccount],
+  )
+
   // Auto-refresh
   useSynchronizedRefetch(currentAccount?.address ?? '')
 
@@ -138,6 +153,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     isLoading,
     hasWallets,
     setCurrentWallet,
+    setCurrentAccount,
   }
 
   return (

--- a/e2e/src/pages/wallet/onboarding.page.ts
+++ b/e2e/src/pages/wallet/onboarding.page.ts
@@ -7,8 +7,9 @@ import { BasePage } from '../base.page.js'
  *
  * Flow (see apps/wallet/src/components/onboarding + routes/onboarding):
  *   landing ("Import wallet") -> recovery phrase (aria-label "Recovery phrase")
- *   -> "Continue" -> create password ("Password" / "Confirm password")
- *   -> "Import Wallet" -> lands on /portfolio/assets.
+ *   -> "Continue" -> accounts to import (activity scan; Continue re-enables
+ *   when it settles) -> "Continue" -> create password ("Password" /
+ *   "Confirm password") -> "Import Wallet" -> lands on /portfolio/assets.
  *
  * Selectors are text/role/aria-based — the wallet has few data-testids.
  */
@@ -18,6 +19,7 @@ export class WalletOnboardingPage extends BasePage {
   })
   readonly recoveryPhraseInput = this.page.getByLabel('Recovery phrase')
   readonly continueButton = this.page.getByRole('button', { name: 'Continue' })
+  readonly accountsToImportTitle = this.page.getByText('Accounts to import')
   readonly passwordInput = this.page.getByLabel('Password', { exact: true })
   readonly confirmPasswordInput = this.page.getByLabel('Confirm password')
   readonly importButton = this.page.getByRole('button', {
@@ -43,6 +45,12 @@ export class WalletOnboardingPage extends BasePage {
     await expect(this.recoveryPhraseInput).toBeVisible()
     await this.recoveryPhraseInput.fill(seedPhrase)
     await expect(this.continueButton).toBeEnabled()
+    await this.continueButton.click()
+
+    // Account-discovery step: wait for the activity scan to settle (Continue
+    // re-enables), then continue with the discovered accounts.
+    await expect(this.accountsToImportTitle).toBeVisible()
+    await expect(this.continueButton).toBeEnabled({ timeout: 60_000 })
     await this.continueButton.click()
 
     await expect(this.passwordInput).toBeVisible()


### PR DESCRIPTION
closes https://github.com/status-im/status-web/issues/1094

Discovers a mnemonic's active accounts on import and lets users pick which
accounts to import and which is active.

- Scan a recovery phrase for on-chain-active accounts (BIP-44 gap limit),
  best-effort with fallback to account 0.
- Account selection step in the import flow, with custom derivation paths.
- Persist the selected account per wallet (wallet.account.select) and expose
  an account switcher in the wallet selector dropdown.
- Send plain JSON-RPC to rpc.proxy in the tx monitor.
- E2E: handle the account selection step in onboarding.

---

#### How to test

- Import a wallet using a mnemonic (best with activity on several accounts)
- On the account selection step, confirm active accounts are listed automatically; add a custom derivation path (e.g. `m/44'/60'/0'/0/5`), then Continue.
- Open the wallet selector dropdown -> verify the imported accounts appear under "Accounts" and the selected one is checked.
- Switch accounts -> the header address updates and portfolio (assets, activity, collectibles) reloads for the new address.
- Reload the extension -> the selected account persists.