### PR TITLE
Fix robots.txt path matching

### DIFF
--- a/apps/status.app/src/app/robots.ts
+++ b/apps/status.app/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: '*',
         allow: '/',
         disallow: [
-          '/admin',
+          '/admin$',
           '/admin/*',
           '/api/*',
           '/u$',

--- a/apps/status.app/src/app/robots.ts
+++ b/apps/status.app/src/app/robots.ts
@@ -8,7 +8,17 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin', '/admin/*', '/api/*', '/u', '/c', '/cc'],
+        disallow: [
+          '/admin',
+          '/admin/*',
+          '/api/*',
+          '/u$',
+          '/u/*',
+          '/c$',
+          '/c/*',
+          '/cc$',
+          '/cc/*',
+        ],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,


### PR DESCRIPTION
Fixes #1260

Google Search Console reports legacy `/communities/*` URLs as blocked by `robots.txt`, preventing Googlebot from following their 301 redirects to `/help/communities/*`.

| Path | Production (`status.app`) | Preview (this PR) |
|---|---|---|
| [/communities/understand-throwaway-profiles-in-status-web](https://status.app/communities/understand-throwaway-profiles-in-status-web) | Blocked by the broad `/c` rule before the redirect can be crawled | [301 → /help/communities/understand-throwaway-profiles-in-status-web](https://status-website-git-robots-txt-review-status-im-web.vercel.app/communities/understand-throwaway-profiles-in-status-web) |
| `/u`, `/c`, and `/cc` sharing routes | Blocked | Still blocked |
| `/admin` and `/admin/*` | Blocked | Still blocked |

## Cause & fix

Google matches `robots.txt` rules from the beginning of the URL path, so `Disallow: /c` also matches paths such as `/communities/*`.

This PR narrows the sharing and admin rules to their exact routes and subpaths using `$` and `/*`. The `/api/*` rule remains unchanged.
