### PR TITLE
feat(wallet): create account from the wallet selector

### DIFF
--- a/.changeset/brave-planes-build.md
+++ b/.changeset/brave-planes-build.md
@@ -1,0 +1,5 @@
+---
+'wallet': patch
+---
+
+feat(wallet): create accounts from within an imported wallet by deriving the next sequential or a custom derivation path

--- a/apps/wallet/src/components/onboarding/add-account-flow.tsx
+++ b/apps/wallet/src/components/onboarding/add-account-flow.tsx
@@ -221,7 +221,11 @@ export function AddAccountFlow({ backHref, successHref }: Props) {
       )}
 
       <div className="mt-auto">
-        <Button onClick={handleCreate} disabled={!canCreate}>
+        <Button
+          onClick={handleCreate}
+          disabled={!canCreate}
+          style={{ width: '100%' }}
+        >
           {isCreating ? 'Creating…' : 'Create account'}
         </Button>
       </div>

--- a/apps/wallet/src/components/onboarding/add-account-flow.tsx
+++ b/apps/wallet/src/components/onboarding/add-account-flow.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { Button, Input, Text } from '@status-im/components'
+import { useNavigate } from '@tanstack/react-router'
+
+import { useAddAccount } from '@/hooks/use-add-account'
+import { usePreviewWalletAccount } from '@/hooks/use-preview-wallet-account'
+import { useWalletFlowSuccess } from '@/hooks/use-wallet-flow-success'
+import { usePassword } from '@/providers/password-context'
+import { useWallet } from '@/providers/wallet-context'
+
+import { BackButton } from './back-button'
+
+const DERIVATION_PATH_REGEX = /^m(\/\d+'?)+$/
+const PREVIEW_DEBOUNCE_MS = 400
+
+type AccountPreview = {
+  address: string
+  derivationPath: string
+  active: boolean
+  alreadyImported: boolean
+}
+
+type Props = {
+  backHref: string
+  successHref: string
+}
+
+export function AddAccountFlow({ backHref, successHref }: Props) {
+  const navigate = useNavigate()
+  const { currentWallet } = useWallet()
+  const { requestPassword } = usePassword()
+  const { previewWalletAccountAsync } = usePreviewWalletAccount()
+  const { addAccountAsync } = useAddAccount()
+  const onSuccess = useWalletFlowSuccess(successHref)
+
+  // null until the initial preview prefills the next sequential path
+  const [path, setPath] = useState<string | null>(null)
+  const [pathError, setPathError] = useState<string | null>(null)
+  const [preview, setPreview] = useState<AccountPreview | null>(null)
+  const [isPreviewing, setIsPreviewing] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isCreating, setIsCreating] = useState(false)
+
+  const walletId = currentWallet?.id
+  const canDerive = currentWallet?.type === 'mnemonic'
+
+  // Preview results are tracked in local state via mutateAsync instead of the
+  // mutation hook's state: mutations observed from a mount effect hang forever
+  // under StrictMode (see the note in import-wallet-flow.tsx).
+  const previewSeq = useRef(0)
+  const runPreview = async (derivationPath?: string) => {
+    if (!walletId) return
+    const seq = ++previewSeq.current
+    setIsPreviewing(true)
+    try {
+      const result = await previewWalletAccountAsync({
+        walletId,
+        derivationPath,
+      })
+      if (seq !== previewSeq.current) return
+      setPreview(result)
+      if (derivationPath === undefined) setPath(result.derivationPath)
+    } catch (error) {
+      if (seq !== previewSeq.current) return
+      console.error('failed to preview account', error)
+      setPreview(null)
+      setPathError('Unable to derive an address for this path')
+    } finally {
+      if (seq === previewSeq.current) setIsPreviewing(false)
+    }
+  }
+  const runPreviewRef = useRef(runPreview)
+  runPreviewRef.current = runPreview
+
+  useEffect(() => {
+    if (!currentWallet || !canDerive) {
+      navigate({ to: backHref })
+    }
+  }, [backHref, canDerive, currentWallet, navigate])
+
+  // Unlock the session, then prefill with the next sequential path. Ref-guarded
+  // so StrictMode's double effect doesn't cancel its own password modal.
+  const hasInitialized = useRef(false)
+  useEffect(() => {
+    if (!walletId || !canDerive || hasInitialized.current) return
+    hasInitialized.current = true
+
+    const initialize = async () => {
+      const isUnlocked = await requestPassword({
+        title: 'Enter password',
+        description: 'To create a new account',
+      })
+      if (!isUnlocked) {
+        navigate({ to: backHref })
+        return
+      }
+      await runPreviewRef.current()
+    }
+
+    initialize().catch(error => console.error(error))
+  }, [backHref, canDerive, navigate, requestPassword, walletId])
+
+  // Re-preview (debounced) when the user edits the path.
+  useEffect(() => {
+    if (path === null) return
+    const derivationPath = path.trim()
+
+    if (!DERIVATION_PATH_REGEX.test(derivationPath)) {
+      previewSeq.current++
+      setIsPreviewing(false)
+      setPreview(null)
+      setPathError("Enter a valid derivation path, e.g. m/44'/60'/0'/0/1")
+      return
+    }
+    setPathError(null)
+    if (preview?.derivationPath === derivationPath) return
+
+    const timeout = setTimeout(() => {
+      void runPreviewRef.current(derivationPath)
+    }, PREVIEW_DEBOUNCE_MS)
+    return () => clearTimeout(timeout)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path])
+
+  if (!currentWallet || !canDerive) {
+    return null
+  }
+
+  const handleCreate = async () => {
+    if (!walletId || path === null) return
+    setIsCreating(true)
+    setSubmitError(null)
+    try {
+      await addAccountAsync({
+        walletId,
+        derivationPath: path.trim(),
+      })
+      await onSuccess(
+        { id: currentWallet.id, name: currentWallet.name },
+        'Account created',
+      )
+    } catch (error) {
+      console.error('failed to create account', error)
+      setSubmitError(
+        error instanceof Error &&
+          error.message.includes('ACCOUNT_ALREADY_EXISTS')
+          ? 'This account is already imported'
+          : 'Unable to create the account. Please try again.',
+      )
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const handlePathChange = (value: string) => {
+    setPath(value)
+    setSubmitError(null)
+  }
+
+  const isDuplicate = preview?.alreadyImported === true
+  const canCreate =
+    path !== null &&
+    !isPreviewing &&
+    !isCreating &&
+    !pathError &&
+    preview !== null &&
+    !isDuplicate
+
+  return (
+    <div className="flex flex-1 flex-col gap-1">
+      <div className="flex items-center pb-4">
+        <BackButton href={backHref} />
+      </div>
+      <Text size={27} weight="semibold">
+        Create account
+      </Text>
+      <Text size={15} color="$neutral-50" className="mb-4">
+        Derive a new account from the recovery phrase of {currentWallet.name}.
+        Use the suggested derivation path or enter a custom one.
+      </Text>
+
+      <div className="mb-4 flex flex-col gap-2">
+        <Input
+          label="Derivation path"
+          value={path ?? ''}
+          onChange={handlePathChange}
+          placeholder="m/44'/60'/0'/0/1"
+          isDisabled={path === null}
+        />
+        {pathError && <p className="text-13 text-danger-50">{pathError}</p>}
+      </div>
+
+      {path === null || isPreviewing ? (
+        <Text size={13} color="$neutral-50" className="mb-4">
+          Deriving address…
+        </Text>
+      ) : (
+        preview && (
+          <div className="mb-4 flex items-center justify-between gap-2 rounded-12 border border-neutral-10 bg-neutral-2.5 p-3">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <Text size={13} color="$neutral-50">
+                {preview.derivationPath} ·{' '}
+                {preview.active ? 'Active' : 'No activity'}
+              </Text>
+              <Text size={13} weight="medium" className="break-all">
+                {preview.address}
+              </Text>
+            </div>
+          </div>
+        )
+      )}
+
+      {isDuplicate && (
+        <p className="mb-4 text-13 text-danger-50">
+          This account is already imported
+        </p>
+      )}
+      {submitError && (
+        <p className="mb-4 text-13 text-danger-50">{submitError}</p>
+      )}
+
+      <div className="mt-auto">
+        <Button onClick={handleCreate} disabled={!canCreate}>
+          {isCreating ? 'Creating…' : 'Create account'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/wallet/src/components/wallet-selector.tsx
+++ b/apps/wallet/src/components/wallet-selector.tsx
@@ -107,6 +107,15 @@ export function WalletSelector(props: Props) {
                   onClick={() => setCurrentAccount(account.address)}
                 />
               ))}
+              {currentWallet.type === 'mnemonic' && (
+                <DropdownMenu.Item
+                  icon={<AddIcon />}
+                  label="Create account"
+                  onClick={() => {
+                    navigate({ to: '/wallet-flow/add-account' })
+                  }}
+                />
+              )}
             </>
           )}
 

--- a/apps/wallet/src/data/api.test.ts
+++ b/apps/wallet/src/data/api.test.ts
@@ -323,3 +323,173 @@ test('should require a password when importing the first hardware wallet', async
     }),
   ).rejects.toThrow()
 }, 7000)
+
+test('should add the next sequential account to a wallet', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0"],
+  })
+
+  const account = await apiClient.wallet.account.ethereum.add.mutate({
+    walletId: importedWallet.id,
+  })
+
+  expect(account).toMatchObject({
+    address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+    derivationPath: "m/44'/60'/0'/0/1",
+  })
+
+  const wallets = await apiClient.wallet.all.query()
+  const wallet = wallets.find(w => w.id === importedWallet.id)
+  expect(wallet?.accounts).toHaveLength(2)
+  expect(wallet?.selectedAccountAddress).toBe(account.address)
+}, 15000)
+
+test('should add an account at a custom derivation path', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0"],
+  })
+
+  const custom = await apiClient.wallet.account.ethereum.add.mutate({
+    walletId: importedWallet.id,
+    derivationPath: "m/44'/60'/0'/0/5",
+  })
+  expect(custom.address).toBe('0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc')
+
+  // The next sequential account continues after the highest imported index
+  const next = await apiClient.wallet.account.ethereum.add.mutate({
+    walletId: importedWallet.id,
+  })
+  expect(next.derivationPath).toBe("m/44'/60'/0'/0/6")
+}, 15000)
+
+test('should reject adding an already imported account', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0"],
+  })
+
+  await expect(
+    apiClient.wallet.account.ethereum.add.mutate({
+      walletId: importedWallet.id,
+      derivationPath: "m/44'/60'/0'/0/0",
+    }),
+  ).rejects.toThrow(/ACCOUNT_ALREADY_EXISTS/)
+
+  await expect(
+    apiClient.wallet.account.ethereum.add.mutate({
+      walletId: importedWallet.id,
+      derivationPath: 'not-a-path',
+    }),
+  ).rejects.toThrow()
+
+  const accounts = await apiClient.wallet.account.all.query({
+    walletId: importedWallet.id,
+  })
+  expect(accounts).toHaveLength(1)
+}, 15000)
+
+test('should reject adding an account to a non-mnemonic wallet', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.importHardware.mutate({
+    name: 'Keystone Wallet',
+    vendor: 'Keystone',
+    password: 'hardware-password',
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    derivationPath: "m/44'/60'/0'/0/7",
+    publicKey: 'xpub661MyMwAqRbcF7FakePublicKey',
+  })
+
+  await expect(
+    apiClient.wallet.account.ethereum.add.mutate({
+      walletId: importedWallet.id,
+    }),
+  ).rejects.toThrow(/WALLET_CANNOT_DERIVE/)
+}, 7000)
+
+test('should reject adding an account when the session is locked', async () => {
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0"],
+  })
+
+  await apiClient.session.lock.mutate()
+
+  await expect(
+    apiClient.wallet.account.ethereum.add.mutate({
+      walletId: importedWallet.id,
+    }),
+  ).rejects.toThrow()
+}, 15000)
+
+test('should preview an account of an existing wallet', async () => {
+  const activeAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string)
+      const isActive =
+        body.method === 'eth_getTransactionCount' &&
+        body.params[0] === activeAddress
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: isActive ? '0x1' : '0x0',
+        }),
+      )
+    }),
+  )
+
+  await createAPI()
+  const apiClient = createAPIClient()
+
+  const importedWallet = await apiClient.wallet.import.mutate({
+    mnemonic: 'test test test test test test test test test test test junk',
+    password: 'password',
+    derivationPaths: ["m/44'/60'/0'/0/0"],
+  })
+
+  // Without a path, previews the next sequential account
+  const next = await apiClient.wallet.account.ethereum.preview.mutate({
+    walletId: importedWallet.id,
+  })
+  expect(next).toMatchObject({
+    address: activeAddress,
+    derivationPath: "m/44'/60'/0'/0/1",
+    active: true,
+    alreadyImported: false,
+  })
+
+  const imported = await apiClient.wallet.account.ethereum.preview.mutate({
+    walletId: importedWallet.id,
+    derivationPath: "m/44'/60'/0'/0/0",
+  })
+  expect(imported.alreadyImported).toBe(true)
+
+  // Preview does not persist anything
+  const accounts = await apiClient.wallet.account.all.query({
+    walletId: importedWallet.id,
+  })
+  expect(accounts).toHaveLength(1)
+}, 15000)

--- a/apps/wallet/src/data/api.ts
+++ b/apps/wallet/src/data/api.ts
@@ -1,6 +1,6 @@
 import { createTRPCProxyClient } from '@trpc/client'
 import { initTRPC } from '@trpc/server'
-import superjson from 'superjson'
+import superjson, { serialize } from 'superjson'
 import { createChromeHandler } from 'trpc-chrome/adapter'
 import { getAddress, isAddress } from 'viem'
 import {
@@ -86,6 +86,12 @@ const t = initTRPC.context<Context>().create({
   transformer: superjson,
   isServer: false,
   allowOutsideOfServer: true,
+  // trpc-chrome's handler posts this shape verbatim while its link runs it
+  // through the transformer's deserialize; serialize here so error messages
+  // survive the chrome transport instead of collapsing to "Unknown error"
+  errorFormatter({ shape }) {
+    return serialize(shape) as unknown as typeof shape
+  },
 })
 
 const { createCallerFactory, router } = t

--- a/apps/wallet/src/data/api.ts
+++ b/apps/wallet/src/data/api.ts
@@ -1,5 +1,5 @@
 import { createTRPCProxyClient } from '@trpc/client'
-import { initTRPC } from '@trpc/server'
+import { initTRPC, TRPCError } from '@trpc/server'
 import superjson, { serialize } from 'superjson'
 import { createChromeHandler } from 'trpc-chrome/adapter'
 import { getAddress, isAddress } from 'viem'
@@ -17,6 +17,7 @@ import {
   deriveAccountsAtPaths,
   deriveNextAccountIndex,
   derivePrivateKey,
+  nextDerivationPath,
   privateKeyFromData,
 } from './derive'
 import * as ethereum from './ethereum/ethereum'
@@ -60,6 +61,38 @@ const hardwareWalletImportSchema = z.object({
     .regex(/^\S+$/, 'Invalid public key'),
   sourceFingerprint: z.number().int().nonnegative().max(0xffffffff).optional(),
 })
+
+// Loads a wallet that can derive new accounts (mnemonic only) and resolves
+// the derivation path to use: the provided one, or the next sequential
+// Ethereum path after the wallet's existing accounts.
+async function resolveEthereumDerivation(
+  walletCore: Context['walletCore'],
+  walletId: string,
+  derivationPath: string | undefined,
+): Promise<{ wallet: WalletMeta; derivationPath: string }> {
+  const wallet = await walletMetadata.get(walletId)
+  if (!wallet) throw new Error('Wallet not found')
+  // TRPCError so the message survives the chrome transport; trpc-chrome
+  // replaces other error types with a generic "Internal server error"
+  if (wallet.type !== 'mnemonic') {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message:
+        'WALLET_CANNOT_DERIVE: only mnemonic wallets support deriving new accounts',
+    })
+  }
+  return {
+    wallet,
+    derivationPath:
+      derivationPath ??
+      nextDerivationPath(
+        walletCore,
+        wallet.accounts,
+        walletCore.CoinType.ethereum,
+        walletCore.Derivation.default,
+      ),
+  }
+}
 
 async function getSigningKey(
   ctx: Context,
@@ -345,27 +378,82 @@ const apiRouter = router({
           .input(
             z.object({
               walletId: z.string(),
-              name: z.string(),
+              name: z.string().optional(),
+              derivationPath: derivationPathSchema.optional(),
             }),
           )
           .mutation(async ({ input, ctx }) => {
             const { walletCore } = ctx
-            const wallet = await walletMetadata.get(input.walletId)
-            if (!wallet) throw new Error('Wallet not found')
-            const mnemonic = await ctx.session.getMnemonic(input.walletId)
-            const index = deriveNextAccountIndex(
-              wallet.accounts,
-              walletCore.CoinType.ethereum.value,
+            const { wallet, derivationPath } = await resolveEthereumDerivation(
+              walletCore,
+              input.walletId,
+              input.derivationPath,
             )
-            const account = deriveAccount(
+            if (wallet.accounts.some(a => a.derivationPath === derivationPath))
+              throw new TRPCError({
+                code: 'CONFLICT',
+                message:
+                  'ACCOUNT_ALREADY_EXISTS: derivation path already imported',
+              })
+            const mnemonic = await ctx.session.getMnemonic(input.walletId)
+            const [account] = deriveAccountsAtPaths(
               walletCore,
               mnemonic,
               walletCore.CoinType.ethereum,
               walletCore.Derivation.default,
-              index,
+              [derivationPath],
             )
+            if (wallet.accounts.some(a => a.address === account.address))
+              throw new TRPCError({
+                code: 'CONFLICT',
+                message: 'ACCOUNT_ALREADY_EXISTS: address already imported',
+              })
             await walletMetadata.addAccount(input.walletId, account)
-            return { id: account.address }
+            await walletMetadata.setSelectedAccount(
+              input.walletId,
+              account.address,
+            )
+            return account
+          }),
+
+        // Derives the account of an existing wallet at a derivation path (or
+        // the next sequential path) and reports whether it has on-chain
+        // activity and is already imported. Does not persist anything. Unlike
+        // wallet.previewAccount, the mnemonic never leaves the background.
+        preview: procedure
+          .input(
+            z.object({
+              walletId: z.string(),
+              derivationPath: derivationPathSchema.optional(),
+            }),
+          )
+          .mutation(async ({ input, ctx }) => {
+            const { walletCore } = ctx
+            const { wallet, derivationPath } = await resolveEthereumDerivation(
+              walletCore,
+              input.walletId,
+              input.derivationPath,
+            )
+            const mnemonic = await ctx.session.getMnemonic(input.walletId)
+            const [account] = deriveAccountsAtPaths(
+              walletCore,
+              mnemonic,
+              walletCore.CoinType.ethereum,
+              walletCore.Derivation.default,
+              [derivationPath],
+            )
+            let active = false
+            try {
+              active = await hasActivity(account.address)
+            } catch {
+              // Activity check is informational only; ignore RPC failures
+            }
+            const alreadyImported = wallet.accounts.some(
+              a =>
+                a.derivationPath === account.derivationPath ||
+                a.address === account.address,
+            )
+            return { ...account, active, alreadyImported }
           }),
 
         // note: our first tx https://holesky.etherscan.io/tx/0xdc2aa244933260c50e665aa816767dce6b76d5d498e6358392d5f79bfc9626d5

--- a/apps/wallet/src/data/derive.test.ts
+++ b/apps/wallet/src/data/derive.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+
+import { deriveNextAccountIndex, pathAtIndex } from './derive'
+
+import type { WalletAccount } from './wallet-metadata'
+
+const ethereumAccount = (derivationPath: string): WalletAccount => ({
+  address: '0x0000000000000000000000000000000000000000',
+  coin: 60,
+  derivationPath,
+  derivation: 0,
+})
+
+test('pathAtIndex keeps the base path at index 0', () => {
+  expect(pathAtIndex("m/44'/60'/0'/0/0", 0)).toBe("m/44'/60'/0'/0/0")
+})
+
+test('pathAtIndex replaces the last segment for other indices', () => {
+  expect(pathAtIndex("m/44'/60'/0'/0/0", 3)).toBe("m/44'/60'/0'/0/3")
+  expect(pathAtIndex("m/44'/501'/0'", 2)).toBe("m/44'/501'/2")
+})
+
+test('deriveNextAccountIndex starts at 0 without matching accounts', () => {
+  expect(deriveNextAccountIndex([], 60)).toBe(0)
+  expect(
+    deriveNextAccountIndex(
+      [{ ...ethereumAccount("m/44'/0'/0'/0/4"), coin: 0 }],
+      60,
+    ),
+  ).toBe(0)
+})
+
+test('deriveNextAccountIndex continues after the highest index of the coin', () => {
+  const accounts = [
+    ethereumAccount("m/44'/60'/0'/0/0"),
+    ethereumAccount("m/44'/60'/0'/0/5"),
+    { ...ethereumAccount("m/44'/0'/0'/0/9"), coin: 0 },
+  ]
+  expect(deriveNextAccountIndex(accounts, 60)).toBe(6)
+})

--- a/apps/wallet/src/data/derive.ts
+++ b/apps/wallet/src/data/derive.ts
@@ -19,6 +19,26 @@ export function deriveNextAccountIndex(
   return Math.max(...indices) + 1
 }
 
+export function pathAtIndex(basePath: string, index: number): string {
+  return index === 0 ? basePath : basePath.replace(/\/[^/]+$/, `/${index}`)
+}
+
+export function nextDerivationPath(
+  walletCore: WalletCore,
+  existingAccounts: WalletAccount[],
+  coin: InstanceType<WalletCore['CoinType']>,
+  derivation: InstanceType<WalletCore['Derivation']>,
+): string {
+  const basePath = walletCore.CoinTypeExt.derivationPathWithDerivation(
+    coin,
+    derivation,
+  )
+  return pathAtIndex(
+    basePath,
+    deriveNextAccountIndex(existingAccounts, coin.value),
+  )
+}
+
 export function deriveAccountsAtPaths(
   walletCore: WalletCore,
   mnemonic: string,
@@ -58,9 +78,7 @@ export function deriveAccounts(
     coin,
     derivation,
   )
-  const paths = indices.map(index =>
-    index === 0 ? basePath : basePath.replace(/\/[^/]+$/, `/${index}`),
-  )
+  const paths = indices.map(index => pathAtIndex(basePath, index))
   return deriveAccountsAtPaths(walletCore, mnemonic, coin, derivation, paths)
 }
 

--- a/apps/wallet/src/hooks/use-add-account.ts
+++ b/apps/wallet/src/hooks/use-add-account.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { useAPI } from '../providers/api-client'
+
+export const useAddAccount = () => {
+  const api = useAPI()
+  const queryClient = useQueryClient()
+
+  const { mutate, mutateAsync, ...result } = useMutation({
+    mutationKey: ['add-account'],
+    mutationFn: async ({
+      walletId,
+      derivationPath,
+    }: {
+      walletId: string
+      derivationPath?: string
+    }) => {
+      return api.wallet.account.ethereum.add.mutate({
+        walletId,
+        derivationPath,
+      })
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['wallets'] })
+    },
+  })
+
+  return {
+    addAccount: mutate,
+    addAccountAsync: mutateAsync,
+    ...result,
+  }
+}

--- a/apps/wallet/src/hooks/use-preview-wallet-account.ts
+++ b/apps/wallet/src/hooks/use-preview-wallet-account.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { useAPI } from '../providers/api-client'
+
+export const usePreviewWalletAccount = () => {
+  const api = useAPI()
+
+  const { mutate, mutateAsync, ...result } = useMutation({
+    mutationKey: ['preview-wallet-account'],
+    mutationFn: async ({
+      walletId,
+      derivationPath,
+    }: {
+      walletId: string
+      derivationPath?: string
+    }) => {
+      return api.wallet.account.ethereum.preview.mutate({
+        walletId,
+        derivationPath,
+      })
+    },
+  })
+
+  return {
+    previewWalletAccount: mutate,
+    previewWalletAccountAsync: mutateAsync,
+    ...result,
+  }
+}

--- a/apps/wallet/src/router.gen.ts
+++ b/apps/wallet/src/router.gen.ts
@@ -16,6 +16,7 @@ import { Route as OnboardingIndexRouteImport } from './routes/onboarding/index'
 import { Route as WalletFlowNewRouteImport } from './routes/wallet-flow/new'
 import { Route as WalletFlowImportHardwareRouteImport } from './routes/wallet-flow/import-hardware'
 import { Route as WalletFlowImportRouteImport } from './routes/wallet-flow/import'
+import { Route as WalletFlowAddAccountRouteImport } from './routes/wallet-flow/add-account'
 import { Route as OnboardingNewRouteImport } from './routes/onboarding/new'
 import { Route as OnboardingImportHardwareRouteImport } from './routes/onboarding/import-hardware'
 import { Route as OnboardingImportRouteImport } from './routes/onboarding/import'
@@ -59,6 +60,11 @@ const WalletFlowImportHardwareRoute =
 const WalletFlowImportRoute = WalletFlowImportRouteImport.update({
   id: '/wallet-flow/import',
   path: '/wallet-flow/import',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WalletFlowAddAccountRoute = WalletFlowAddAccountRouteImport.update({
+  id: '/wallet-flow/add-account',
+  path: '/wallet-flow/add-account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnboardingNewRoute = OnboardingNewRouteImport.update({
@@ -111,6 +117,7 @@ export interface FileRoutesByFullPath {
   '/onboarding/import': typeof OnboardingImportRoute
   '/onboarding/import-hardware': typeof OnboardingImportHardwareRoute
   '/onboarding/new': typeof OnboardingNewRoute
+  '/wallet-flow/add-account': typeof WalletFlowAddAccountRoute
   '/wallet-flow/import': typeof WalletFlowImportRoute
   '/wallet-flow/import-hardware': typeof WalletFlowImportHardwareRoute
   '/wallet-flow/new': typeof WalletFlowNewRoute
@@ -127,6 +134,7 @@ export interface FileRoutesByTo {
   '/onboarding/import': typeof OnboardingImportRoute
   '/onboarding/import-hardware': typeof OnboardingImportHardwareRoute
   '/onboarding/new': typeof OnboardingNewRoute
+  '/wallet-flow/add-account': typeof WalletFlowAddAccountRoute
   '/wallet-flow/import': typeof WalletFlowImportRoute
   '/wallet-flow/import-hardware': typeof WalletFlowImportHardwareRoute
   '/wallet-flow/new': typeof WalletFlowNewRoute
@@ -145,6 +153,7 @@ export interface FileRoutesById {
   '/onboarding/import': typeof OnboardingImportRoute
   '/onboarding/import-hardware': typeof OnboardingImportHardwareRoute
   '/onboarding/new': typeof OnboardingNewRoute
+  '/wallet-flow/add-account': typeof WalletFlowAddAccountRoute
   '/wallet-flow/import': typeof WalletFlowImportRoute
   '/wallet-flow/import-hardware': typeof WalletFlowImportHardwareRoute
   '/wallet-flow/new': typeof WalletFlowNewRoute
@@ -164,6 +173,7 @@ export interface FileRouteTypes {
     | '/onboarding/import'
     | '/onboarding/import-hardware'
     | '/onboarding/new'
+    | '/wallet-flow/add-account'
     | '/wallet-flow/import'
     | '/wallet-flow/import-hardware'
     | '/wallet-flow/new'
@@ -180,6 +190,7 @@ export interface FileRouteTypes {
     | '/onboarding/import'
     | '/onboarding/import-hardware'
     | '/onboarding/new'
+    | '/wallet-flow/add-account'
     | '/wallet-flow/import'
     | '/wallet-flow/import-hardware'
     | '/wallet-flow/new'
@@ -197,6 +208,7 @@ export interface FileRouteTypes {
     | '/onboarding/import'
     | '/onboarding/import-hardware'
     | '/onboarding/new'
+    | '/wallet-flow/add-account'
     | '/wallet-flow/import'
     | '/wallet-flow/import-hardware'
     | '/wallet-flow/new'
@@ -212,6 +224,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OnboardingLayoutRoute: typeof OnboardingLayoutRouteWithChildren
+  WalletFlowAddAccountRoute: typeof WalletFlowAddAccountRoute
   WalletFlowImportRoute: typeof WalletFlowImportRoute
   WalletFlowImportHardwareRoute: typeof WalletFlowImportHardwareRoute
   WalletFlowNewRoute: typeof WalletFlowNewRoute
@@ -272,6 +285,13 @@ declare module '@tanstack/react-router' {
       path: '/wallet-flow/import'
       fullPath: '/wallet-flow/import'
       preLoaderRoute: typeof WalletFlowImportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/wallet-flow/add-account': {
+      id: '/wallet-flow/add-account'
+      path: '/wallet-flow/add-account'
+      fullPath: '/wallet-flow/add-account'
+      preLoaderRoute: typeof WalletFlowAddAccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/onboarding/new': {
@@ -353,6 +373,7 @@ const OnboardingLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OnboardingLayoutRoute: OnboardingLayoutRouteWithChildren,
+  WalletFlowAddAccountRoute: WalletFlowAddAccountRoute,
   WalletFlowImportRoute: WalletFlowImportRoute,
   WalletFlowImportHardwareRoute: WalletFlowImportHardwareRoute,
   WalletFlowNewRoute: WalletFlowNewRoute,

--- a/apps/wallet/src/routes/wallet-flow/add-account.tsx
+++ b/apps/wallet/src/routes/wallet-flow/add-account.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AddAccountFlow } from '@/components/onboarding/add-account-flow'
+import { OnboardingFlowLayout } from '@/components/onboarding/flow-layout'
+
+export const Route = createFileRoute('/wallet-flow/add-account')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <OnboardingFlowLayout>
+      <AddAccountFlow
+        backHref="/portfolio/assets"
+        successHref="/portfolio/assets"
+      />
+    </OnboardingFlowLayout>
+  )
+}

--- a/packages/wallet/src/components/sticky-header-container/index.tsx
+++ b/packages/wallet/src/components/sticky-header-container/index.tsx
@@ -9,8 +9,9 @@ const backgroundStyles = cva(
   {
     variants: {
       collapsed: {
-        false: 'max-h-[48px] min-h-[48px] border-transparent bg-transparent',
-        true: 'max-h-[64px] min-h-[64px] border-neutral-20 bg-blur-white/70 backdrop-blur-[20px]',
+        false:
+          'pointer-events-none max-h-[48px] min-h-[48px] border-transparent bg-transparent',
+        true: 'pointer-events-auto max-h-[64px] min-h-[64px] border-neutral-20 bg-blur-white/70 backdrop-blur-[20px]',
       },
       size: {
         default: '',


### PR DESCRIPTION
Part of https://github.com/status-im/status-web/issues/1127

Adds account creation on an already-imported mnemonic wallet: derive the next
sequential derivation path or a custom one, preview the address and activity,
and switch to the new account on creation.

- `wallet.account.ethereum.add`: optional custom derivation path, mnemonic-only
  guard, duplicate rejection, selects the new account.
- `wallet.account.ethereum.preview`: derives by wallet id without persisting;
  the mnemonic stays in the background session.
- New `/wallet-flow/add-account` route, reached from a "Create account" item in
  the wallet selector dropdown (hidden for private-key and hardware wallets).
- Fix: tRPC error messages survive the chrome transport (previously every error
  surfaced as "Unknown error").
  
---

#### How to test

- Import a mnemonic wallet, open the wallet selector dropdown -> "Create
  account" under Accounts.
- Confirm the prefilled next path (e.g. `m/44'/60'/0'/0/1`) shows an address
  preview; create -> header and dropdown show the new account selected.
- Enter a custom path (e.g. `m/44'/60'/0'/0/5`) -> preview updates; create
  works and the next sequential path continues after it.
- Enter an already-imported path -> inline error, button disabled.
- Private-key / hardware wallet -> no "Create account" item.