### PR TITLE
fix(status.app): prevent desktop navbar overflow

### DIFF
--- a/.changeset/whole-coats-do.md
+++ b/.changeset/whole-coats-do.md
@@ -2,4 +2,4 @@
 'status.app': patch
 ---
 
-fix(status.app): prevent desktop navbar overflow
+fix(status.app): prevent desktop navbar overflow, including the floating scroll-up navbar, and make the floating navbar reliably appear in local (Turbopack) dev

--- a/.changeset/whole-coats-do.md
+++ b/.changeset/whole-coats-do.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): prevent desktop navbar overflow

--- a/apps/status.app/src/app/(website)/_components/download-desktop-button.tsx
+++ b/apps/status.app/src/app/(website)/_components/download-desktop-button.tsx
@@ -36,6 +36,8 @@ type ButtonProps = React.ComponentProps<typeof DropdownButton>
 type Props = Pick<ButtonProps, 'variant' | 'size'> & {
   show?: 'single' | 'all'
   source?: 'sharing'
+  // Render icon-only triggers (no text labels).
+  iconOnly?: boolean
 }
 
 const getDesktopEquivalent = (platform: string | null) => {
@@ -154,10 +156,11 @@ type DownloadButtonProps = Pick<
   'children' | 'variant' | 'size'
 > & {
   source: string | null
+  iconOnly?: boolean
 }
 
 const LinuxDownloadButton = (props: DownloadButtonProps) => {
-  const { source, ...buttonProps } = props
+  const { source, iconOnly, ...buttonProps } = props
   const latestReleaseTags = useLatestReleaseTags()
   const t = useTranslations('download')
 
@@ -174,6 +177,25 @@ const LinuxDownloadButton = (props: DownloadButtonProps) => {
       source,
     })
   }
+
+  if (iconOnly) {
+    return (
+      <DownloadConnectorDialog>
+        <Button
+          {...buttonProps}
+          href={
+            isGetSite
+              ? STATUS_RELEASES_LATEST_URL
+              : STATUS_DESKTOP_DOWNLOAD_URL_LINUX
+          }
+          icon={<LinuxIcon />}
+          aria-label={t('downloadForLinux')}
+          onClick={handleClick}
+        />
+      </DownloadConnectorDialog>
+    )
+  }
+
   return (
     <>
       <div className="hidden macos:contents windows:contents ios:contents android:contents">
@@ -212,7 +234,7 @@ const LinuxDownloadButton = (props: DownloadButtonProps) => {
 }
 
 const WindowsDownloadButton = (props: DownloadButtonProps) => {
-  const { source, ...buttonProps } = props
+  const { source, iconOnly, ...buttonProps } = props
   const latestReleaseTags = useLatestReleaseTags()
   const t = useTranslations('download')
 
@@ -228,6 +250,24 @@ const WindowsDownloadButton = (props: DownloadButtonProps) => {
       version: latestReleaseTags.desktop ?? 'unknown',
       source,
     })
+  }
+
+  if (iconOnly) {
+    return (
+      <DownloadConnectorDialog>
+        <Button
+          {...buttonProps}
+          href={
+            isGetSite
+              ? STATUS_RELEASES_LATEST_URL
+              : STATUS_DESKTOP_DOWNLOAD_URL_WINDOWS
+          }
+          icon={<WindowsIcon />}
+          aria-label={t('downloadForWindows')}
+          onClick={handleClick}
+        />
+      </DownloadConnectorDialog>
+    )
   }
 
   return (
@@ -268,7 +308,7 @@ const WindowsDownloadButton = (props: DownloadButtonProps) => {
 }
 
 const MacOSDownloadButton = (props: DownloadButtonProps) => {
-  const { source, ...buttonProps } = props
+  const { source, iconOnly, ...buttonProps } = props
   const latestReleaseTags = useLatestReleaseTags()
   const t = useTranslations('download')
 
@@ -284,6 +324,24 @@ const MacOSDownloadButton = (props: DownloadButtonProps) => {
       store: 'direct',
       source,
     })
+  }
+
+  if (iconOnly) {
+    return (
+      <DownloadConnectorDialog>
+        <Button
+          {...buttonProps}
+          href={
+            isGetSite
+              ? STATUS_RELEASES_LATEST_URL
+              : STATUS_DESKTOP_DOWNLOAD_URL_MACOS_SILICON
+          }
+          icon={<AppleIcon />}
+          aria-label={t('downloadForMacOS')}
+          onClick={handleClick}
+        />
+      </DownloadConnectorDialog>
+    )
   }
 
   return (

--- a/apps/status.app/src/app/(website)/_components/download-mobile-button.tsx
+++ b/apps/status.app/src/app/(website)/_components/download-mobile-button.tsx
@@ -28,6 +28,8 @@ import { startLatestDownload } from '~website/_lib/download-latest'
 
 type Props = Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'> & {
   children?: React.ReactElement<React.ComponentProps<typeof Button>>
+  // Render an icon-only trigger (no text label).
+  iconOnly?: boolean
 }
 
 export const DownloadMobileButton = (props: Props) => {
@@ -35,7 +37,7 @@ export const DownloadMobileButton = (props: Props) => {
   const latestReleaseTags = useLatestReleaseTags()
   const t = useTranslations('download')
 
-  const { children } = props
+  const { children, iconOnly, variant, size } = props
 
   const renderLabel = () => {
     return (
@@ -52,21 +54,43 @@ export const DownloadMobileButton = (props: Props) => {
 
   return (
     <Dialog>
-      {children ?? (
-        <Button
-          {...props}
-          iconBefore={
-            <MobileIcon
-              className={match(props.variant)
-                .with('outline', () => 'text-neutral-100 dark:text-neutral-40')
-                .with('grey', () => 'text-neutral-80 dark:text-neutral-50')
-                .otherwise(() => undefined)}
-            />
-          }
-        >
-          {renderLabel()}
-        </Button>
-      )}
+      {children ??
+        (iconOnly ? (
+          <Button
+            variant={variant}
+            size={size}
+            aria-label={t('downloadForMobile')}
+            icon={
+              <MobileIcon
+                className={match(variant)
+                  .with(
+                    'outline',
+                    () => 'text-neutral-100 dark:text-neutral-40'
+                  )
+                  .with('grey', () => 'text-neutral-80 dark:text-neutral-50')
+                  .otherwise(() => undefined)}
+              />
+            }
+          />
+        ) : (
+          <Button
+            variant={variant}
+            size={size}
+            iconBefore={
+              <MobileIcon
+                className={match(variant)
+                  .with(
+                    'outline',
+                    () => 'text-neutral-100 dark:text-neutral-40'
+                  )
+                  .with('grey', () => 'text-neutral-80 dark:text-neutral-50')
+                  .otherwise(() => undefined)}
+              />
+            }
+          >
+            {renderLabel()}
+          </Button>
+        ))}
 
       <Dialog.Content className="md:!max-w-[1190px]">
         <div className="absolute right-3 top-3 z-10">

--- a/apps/status.app/src/app/(website)/_components/navigation/floating-desktop.tsx
+++ b/apps/status.app/src/app/(website)/_components/navigation/floating-desktop.tsx
@@ -17,6 +17,31 @@ type Props = {
   visible: boolean
 }
 
+// Download CTAs for the floating (scroll-up) navbar. Mirrors the top navbar:
+// collapse to icon-only below 1320px so the row can't overflow the viewport,
+// full labels return above it.
+const FloatingDownloadCtas = (props: { show?: 'single' | 'all' }) => {
+  const { show } = props
+  return (
+    <>
+      <div className="contents [@media(min-width:1320px)]:hidden">
+        <DownloadDesktopButton
+          size="32"
+          variant="primary"
+          show={show}
+          iconOnly
+        />
+        <DownloadMobileButton size="32" variant="outline" iconOnly />
+      </div>
+      <div className="hidden [@media(min-width:1320px)]:contents">
+        <DownloadDesktopButton size="32" variant="primary" show={show} />
+        <DownloadMobileButton size="32" variant="outline" />
+      </div>
+      <LanguageSelector />
+    </>
+  )
+}
+
 const FloatingDesktop = (props: Props) => {
   const { visible } = props
   const t = useTranslations('nav')
@@ -99,9 +124,7 @@ const FloatingDesktop = (props: Props) => {
             'ios:flex android:flex'
           )}
         >
-          <DownloadDesktopButton size="32" variant="primary" />
-          <DownloadMobileButton size="32" variant="outline" />
-          <LanguageSelector />
+          <FloatingDownloadCtas />
         </div>
         <div
           className={cx(
@@ -109,9 +132,7 @@ const FloatingDesktop = (props: Props) => {
             'macos:flex windows:flex linux:flex unknown:flex'
           )}
         >
-          <DownloadDesktopButton size="32" variant="primary" show="all" />
-          <DownloadMobileButton size="32" variant="outline" />
-          <LanguageSelector />
+          <FloatingDownloadCtas show="all" />
         </div>
       </div>
       <NavigationMenu.Viewport

--- a/apps/status.app/src/app/(website)/_components/navigation/floating-menu.tsx
+++ b/apps/status.app/src/app/(website)/_components/navigation/floating-menu.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react'
 
-import { animated, useScroll } from '@react-spring/web'
 import { cx } from 'class-variance-authority'
 
 import { usePathname } from '~/i18n/navigation'
@@ -31,8 +30,14 @@ const FloatingMenu = () => {
   // Close menu on outside click
   const ref = useOutsideClick(() => setOpen(false))
 
-  useScroll({
-    onChange: ({ value: { scrollY } }) => {
+  // note: a plain window scroll listener rather than `@react-spring/web`'s
+  // `useScroll`. The spring-based hook relies on react-spring's rAF frameloop,
+  // which doesn't fire reliably under Turbopack dev, so the overlay never
+  // appeared locally (it worked in the webpack production build). This reads
+  // `window.scrollY` directly and is build/runtime independent.
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollY = window.scrollY
       const isMenuOpen = openRef.current
       const isScrollingUp = scrollY < scrollYRef.current
       const detectionPoint = scrollY > DETECTION_POINT
@@ -58,11 +63,11 @@ const FloatingMenu = () => {
         }
       }
       scrollYRef.current = scrollY
-    },
-    default: {
-      immediate: true,
-    },
-  })
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
 
   const pathname = usePathname()!
   useEffect(() => {
@@ -79,7 +84,7 @@ const FloatingMenu = () => {
 
   return (
     <>
-      <animated.div
+      <div
         ref={ref}
         style={styles}
         className={cx([
@@ -91,8 +96,8 @@ const FloatingMenu = () => {
         ])}
       >
         <FloatingMobile open={open} setOpen={setOpen} />
-      </animated.div>
-      <animated.div
+      </div>
+      <div
         style={styles}
         className={cx([
           'fixed left-1/2 top-5 z-20 w-max min-w-[746px] -translate-x-1/2 overflow-hidden',
@@ -101,7 +106,7 @@ const FloatingMenu = () => {
         ])}
       >
         <FloatingDesktop visible={visible} />
-      </animated.div>
+      </div>
     </>
   )
 }

--- a/apps/status.app/src/app/(website)/_components/navigation/nav-desktop.tsx
+++ b/apps/status.app/src/app/(website)/_components/navigation/nav-desktop.tsx
@@ -15,6 +15,28 @@ import { DownloadMobileButton } from '../download-mobile-button'
 import { LanguageSelector } from './language-selector'
 import { useDesktopMenu } from './use-desktop-menu'
 
+// Download CTAs for the top navbar.
+const NavDownloadCtas = () => {
+  return (
+    <>
+      <div className="contents [@media(min-width:1320px)]:hidden">
+        <DownloadDesktopButton
+          size="32"
+          variant="darkGrey"
+          show="all"
+          iconOnly
+        />
+        <DownloadMobileButton size="32" variant="outline" iconOnly />
+      </div>
+      <div className="hidden [@media(min-width:1320px)]:contents">
+        <DownloadDesktopButton size="32" variant="darkGrey" show="all" />
+        <DownloadMobileButton size="32" variant="outline" />
+      </div>
+      <LanguageSelector />
+    </>
+  )
+}
+
 const NavDesktop = () => {
   const t = useTranslations('nav')
   const {
@@ -92,9 +114,7 @@ const NavDesktop = () => {
               'macos:flex windows:flex linux:flex unknown:flex'
             )}
           >
-            <DownloadDesktopButton size="32" variant="darkGrey" show="all" />
-            <DownloadMobileButton size="32" variant="outline" />
-            <LanguageSelector />
+            <NavDownloadCtas />
           </div>
 
           <div
@@ -104,9 +124,7 @@ const NavDesktop = () => {
               'ios:flex android:flex'
             )}
           >
-            <DownloadDesktopButton size="32" variant="darkGrey" show="all" />
-            <DownloadMobileButton size="32" variant="outline" />
-            <LanguageSelector />
+            <NavDownloadCtas />
           </div>
         </div>
         <NavigationMenu.Viewport


### PR DESCRIPTION
The desktop top bar renders from 1150px, but its full-text CTAs push the row
past the viewport until ~1315px, causing horizontal page overflow (an empty
strip on the right):

<img width="350" alt="image" src="https://github.com/user-attachments/assets/c745577d-042e-46ae-bef5-f62d0304108b" />
<br/><br/>

Collapse the download CTAs to icon-only below 1320px; full labels return above
it. All nav links, logo, and language selector stay visible at every width.

- Added an `iconOnly` prop to `DownloadDesktopButton` / `DownloadMobileButton`
  (defaults unchanged, so other usages are untouched).
- Nav switches between icon-only and full-label CTAs via `display:contents`
  wrappers, so only one set is ever in the DOM.

---

#### How to test

On [status.app](https://status-website-git-fix-statusappnavbar-overflow-status-im-web.vercel.app/) & [get.status.app](https://status-get-status-app-git-fix-statusappnav-d5d03d-status-im-web.vercel.app/) previews:
- Resize the window between 1150px and 1315px -> CTAs show as icons only; no
  horizontal scroll / empty right strip.
- At >=1320px -> "Download for macOS" / "Download for mobile" labels return.
- Below 1150px -> mobile hamburger nav takes over as before.