### PR TITLE
Improve crawl paths for affected help articles

### DIFF
--- a/apps/status.app/content/help/communities/change-who-can-pin-messages-in-your-community.mdx
+++ b/apps/status.app/content/help/communities/change-who-can-pin-messages-in-your-community.mdx
@@ -5,9 +5,9 @@ language: en
 title: Change who can pin messages in your community
 author: jorge-campo, Fabiomorais87
 roles:
- - Owner
- - TokenMaster
- - Admin
+  - Owners
+  - TokenMasters
+  - Admins
 ---
 
 When you create a Status Community, you can [configure additional settings](./create-a-status-community.mdx#configure-additional-settings) for it, such as who can pin messages in community channels.

--- a/apps/status.app/content/help/communities/index.mdx
+++ b/apps/status.app/content/help/communities/index.mdx
@@ -14,6 +14,7 @@ Create your community, set up token-gated channels or join others' communities a
 - [**Import** a community someone shares with you](./import-a-community-someone-shares-with-you.mdx)
 - [**Invite** people to a Status Community](./invite-people-to-a-status-community.mdx)
 - [About the **different types** of Status Communities](./about-the-different-types-of-status-communities.mdx)
+- [Use a **throwaway profile** in Status Web](./use-a-throwaway-profile-in-status-web.mdx)
 - [About community **request approvals**](./about-community-request-approvals.mdx)
 - [Understand **token requirements** in communities](./understand-token-requirements-in-communities.mdx)
 - [About voting to **change the community visibility**](about-voting-to-change-the-community-visibility.mdx)
@@ -55,6 +56,7 @@ Create your community, set up token-gated channels or join others' communities a
 
 - [**Create** a channel](./create-a-channel.mdx)
 - [**Customize** your channel](./customize-your-channel.mdx)
+- [**Organize channels** using categories](./organize-channels-using-categories.mdx)
 - [Set up your **channel permissions**](./set-up-your-channel-permissions.mdx)
 - [Set up a **token-gated channel**](./set-up-a-token-gated-channel.mdx)
 - [**Change** a token-gated channel to open](./change-a-token-gated-channel-to-open.mdx)
@@ -78,6 +80,7 @@ Create your community, set up token-gated channels or join others' communities a
 
 ## Community permissions
 
+- [About **token-based access** to communities and channels](./token-based-access-to-communities-and-channels.mdx)
 - [Set up your **community permissions**](./set-up-your-community-permissions.mdx)
 - [Set up a **token-gated community**](./set-up-a-token-gated-community.mdx)
 - [**Change** a token-gated community to open](./change-a-token-gated-community-to-open.mdx)


### PR DESCRIPTION
## Problem

The original 116-URL list is no longer available. The current Google Search Console report shows 16 help pages that are discovered but not indexed.

Thirteen already had direct category links. Three Communities articles were only linked from other articles, giving crawlers a less direct path. One affected article also returned a 500 error because its role metadata did not match the renderer's allowed values.

## Fix

- add direct links from the Communities index to the three remaining articles
- normalize the broken article's role metadata so it renders successfully

The 16 URLs in the current report now all have direct category links and render successfully in a production build.

Refs #1264

## How to test

## How to verify in the browser

Preview: https://status-website-git-issue-1264-internal-links-status-im-web.vercel.app

- Open the preview URL, open Chrome DevTools, go to the `Network` tab, tick `Disable cache`, and set the filter to **Doc** so only page documents show up.
- Navigate to `/help/communities/change-who-can-pin-messages-in-your-community`. The top-level document request should return **200**, and the article should render with the "Only relevant to" role tags. On production this same URL returns **500**.
- Navigate to `/help/communities` and use `Cmd+F` (DevTools **Elements** tab, or the page itself) to confirm three new links are present: "Use a **throwaway profile** in Status Web", "**Organize channels** using categories", and "About `token-based access` to communities and channels".
- Click each of the three links from the index page and confirm each document request is **200** in the Network tab. This is the point of the change: crawlers now reach these articles directly from the category index instead of only through other articles.
- Check the `Console` tab on all four pages for React hydration or rendering errors. It should be clean. Note that you may see a `net::ERR_ABORTED` entry for a prefetch request in the Network tab when you navigate away from the index page; that is Next.js cancelling an in-flight prefetch and is unrelated to this change.