### PR TITLE
Collapse additional legacy help redirect chains

### DIFF
--- a/.changeset/quick-plums-smile.md
+++ b/.changeset/quick-plums-smile.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+Send legacy help URLs with renamed slugs directly to their current pages.

--- a/apps/status.app/next.config.mjs
+++ b/apps/status.app/next.config.mjs
@@ -190,6 +190,11 @@ let config = {
         statusCode: 301,
       },
       {
+        source: '/wallet/delete-your-status-wallet-or-wallet-account',
+        destination: '/help/wallet/delete-your-status-wallet-accounts',
+        statusCode: 301,
+      },
+      {
         source: '/wallet/:slug+',
         destination: '/help/wallet/:slug+',
         statusCode: 301,
@@ -215,6 +220,11 @@ let config = {
         statusCode: 301,
       },
       {
+        source: '/keycard/if-you-can-t-unlock-your-keycard',
+        destination: '/help/keycard/if-you-can-t-unblock-your-keycard',
+        statusCode: 301,
+      },
+      {
         source: '/keycard/:slug+',
         destination: '/help/keycard/:slug+',
         statusCode: 301,
@@ -222,6 +232,11 @@ let config = {
       {
         source: '/communities',
         destination: '/help/communities',
+        statusCode: 301,
+      },
+      {
+        source: '/communities/set-up-channel-permissions',
+        destination: '/help/communities/set-up-your-channel-permissions',
         statusCode: 301,
       },
       {

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,11 @@
     },
     "status.app#build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", ".contentlayer/**"],
+      "outputs": [
+        ".next/**",
+        ".contentlayer/**",
+        "public/blog-search-index.json"
+      ],
       "passThroughEnv": [
         "NEXT_PUBLIC_GHOST_API_URL",
         "NEXT_PUBLIC_GHOST_API_KEY",


### PR DESCRIPTION
## Problem

Three legacy help URLs still created two 301 hops because they matched a broad category redirect before a renamed-slug redirect:

`legacy URL → old help URL → current help URL`

## Fix

Added specific rules before the wildcard redirects so these URLs now reach their current help pages in one 301 response.

This covers one wallet URL, one communities URL, and one Keycard URL.

## How to verify

Preview: https://status-website-git-consolidate-redirect-chains-status-im-web.vercel.app

- Open DevTools, go to Network, and turn on Preserve log so the full redirect chain stays visible.
- Load `/wallet/delete-your-status-wallet-or-wallet-account` on production first. You'll see two 301s, hopping through `/help/wallet/delete-your-status-wallet-or-wallet-account` before landing on the real page.
- Load the same path on the preview. Now it's a single 301 straight to `/help/wallet/delete-your-status-wallet-accounts`.
- Do the same for the other 2: `/keycard/if-you-can-t-unlock-your-keycard` and `/communities/set-up-channel-permissions`. Both should be one hop each on the preview.
- Worth a quick sanity check that nothing else broke, since the new rules sit ahead of the wildcards: try any other legacy path like `/wallet/about-bridge-statuses` or `/profile/about-status-display-name`. They should still redirect in one hop as before.
- The old `/help/...` URLs are untouched on purpose, so hitting them directly still redirects to the current pages. Old search results keep working.
