### PR TITLE
Avoid redirect chains for legacy job links

### DIFF
--- a/.changeset/warm-hounds-spark.md
+++ b/.changeset/warm-hounds-spark.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+Avoid redirect chains for legacy Greenhouse job links.

--- a/apps/status.app/next.config.mjs
+++ b/apps/status.app/next.config.mjs
@@ -168,18 +168,6 @@ let config = {
         permanent: false,
       },
       {
-        source: '/jobs',
-        has: [
-          {
-            type: 'query',
-            key: 'gh_jid',
-            value: '(?<paramName>.*)',
-          },
-        ],
-        permanent: false,
-        destination: '/jobs/:paramName',
-      },
-      {
         source: '/feature-upvote',
         destination: 'https://discuss.status.app/c/features/51',
         permanent: false,

--- a/apps/status.app/src/app/(website)/jobs/page.tsx
+++ b/apps/status.app/src/app/(website)/jobs/page.tsx
@@ -2,6 +2,7 @@ import { Button, Tag, Text } from '@status-im/components'
 import { ExternalIcon } from '@status-im/icons/16'
 import { ArrowDownIcon, ArrowRightIcon } from '@status-im/icons/20'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
 import { match } from 'ts-pattern'
 
@@ -12,7 +13,11 @@ import { Image } from '~components/assets'
 import { Body } from '~components/body'
 import { FeatureList } from '~website/_components/feature-list'
 import { ParallaxCircle } from '~website/_components/parallax-circle'
-import { getLogosJobs, getStatusJobs } from '~website/_lib/greenhouse'
+import {
+  getLogosJobs,
+  getStatusJob,
+  getStatusJobs,
+} from '~website/_lib/greenhouse'
 
 import type { ImageId } from '~components/assets'
 import type { FeatureListProps } from '~website/_components/feature-list'
@@ -32,7 +37,26 @@ export async function generateMetadata(): Promise<NextMetadata> {
   })
 }
 
-export default async function JobsPage() {
+type Props = {
+  searchParams: Promise<{
+    gh_jid?: string | string[]
+  }>
+}
+
+export default async function JobsPage({ searchParams }: Props) {
+  const rawJobId = (await searchParams).gh_jid
+  const jobId = Array.isArray(rawJobId) ? rawJobId[0] : rawJobId
+
+  if (jobId) {
+    if (!/^\d+$/.test(jobId)) {
+      redirect('/jobs')
+    }
+
+    const job = await getStatusJob(jobId)
+
+    redirect(job?.content ? `/jobs/${jobId}` : '/jobs')
+  }
+
   const t = await getTranslations('jobs')
 
   const [statusJobs, logosJobs] = await Promise.all([

--- a/apps/status.app/src/app/(website)/jobs/page.tsx
+++ b/apps/status.app/src/app/(website)/jobs/page.tsx
@@ -47,7 +47,7 @@ export default async function JobsPage({ searchParams }: Props) {
   const rawJobId = (await searchParams).gh_jid
   const jobId = Array.isArray(rawJobId) ? rawJobId[0] : rawJobId
 
-  if (jobId) {
+  if (jobId !== undefined) {
     if (!/^\d+$/.test(jobId)) {
       redirect('/jobs')
     }


### PR DESCRIPTION
## Problem

Legacy Greenhouse links use `/jobs?gh_jid=...`. The Next.js redirect preserved the query parameter, and closed jobs then redirected a second time from the job detail page to `/jobs`.

## Fix

Moved `gh_jid` handling to the Jobs page so it can check the current Greenhouse job state:

- open jobs redirect once to `/jobs/:id`
- closed or invalid jobs redirect once to `/jobs`

Related to #1263

## How to verify

Preview: https://status-website-git-direct-job-redirects-status-im-web.vercel.app

- Open DevTools, go to Network, and turn on Preserve log so you can see the whole redirect chain.
- Load `/jobs?gh_jid=7384954` on production first. You'll see two 307s: it goes to `/jobs/7384954?gh_jid=7384954`, then bounces again to `/jobs`.
- Load the same URL on the preview. Now it's one 307 straight to `/jobs`, and the query parameter is gone.
- Try a few bad values too: `/jobs?gh_jid=abc`, `/jobs?gh_jid=1234567`, and `/jobs?gh_jid=`. All of them should land on `/jobs` in a single hop.
- One caveat: the open-job case (`gh_jid` for a live role redirecting to `/jobs/:id`) can't be checked right now because the Status board has no open roles. The ids on the jobs page are Logos roles and link straight out to Greenhouse, so they won't work for this.
