### PR TITLE
feat(status.app): render lists in the mobile and desktop news RSS feeds

### DIFF
--- a/.changeset/loud-pandas-share.md
+++ b/.changeset/loud-pandas-share.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+feat(status.app): render bullet and numbered lists in the news RSS feeds. The mobile feed now uses the same HTML formatting as the desktop feed, line breaks within a paragraph are preserved, and the call-to-action link is extracted structurally so a link inside a list item cannot replace it.

--- a/.changeset/loud-pandas-share.md
+++ b/.changeset/loud-pandas-share.md
@@ -2,4 +2,4 @@
 'status.app': patch
 ---
 
-feat(status.app): render bullet and numbered lists in the news RSS feeds. The mobile feed now uses the same HTML formatting as the desktop feed, line breaks within a paragraph are preserved, and the call-to-action link is extracted structurally so a link inside a list item cannot replace it.
+feat(status.app): render bullet and numbered lists in the news RSS feeds. The desktop feed emits `<ul>`/`<ol>` for its rich text view and the mobile feed emits text bullets, keeping its plain text format. Line breaks within a paragraph are preserved, and the call-to-action link is extracted structurally so a link inside a list item cannot replace it.

--- a/.changeset/olive-badgers-attack.md
+++ b/.changeset/olive-badgers-attack.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): escape the desktop news feed's markup. RSS 2.0 defines `description` as character data, so the markup is no longer served as child elements of it. status-go decodes the element with gofeed before the client sees it, so the markup that arrives is unchanged.

--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -2,4 +2,4 @@
 'status.app': patch
 ---
 
-fix(status.app): escape the values Ghost supplies to the news RSS feeds. Their CDATA wrappers are dropped on parse, so an unescaped `&` in a title was re-served as invalid XML.
+fix(status.app): escape the values Ghost supplies to the news RSS feeds. Their CDATA wrappers are dropped on parse, so an unescaped `&` in a title or in the channel description was re-served as invalid XML. Ghost's HTML entities are resolved to their characters too, since names such as `&nbsp;` are undefined in XML and cost the whole feed rather than one character.

--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): escape the values Ghost supplies to the news RSS feeds. Their CDATA wrappers are dropped on parse, so an unescaped `&` in a title was re-served as invalid XML.

--- a/.changeset/tidy-pumas-repeat.md
+++ b/.changeset/tidy-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): move the news feeds' call-to-action into a `status` namespace. RSS 2.0 rejects an extension element that has none, so `newsLink` and `newsLinkLabel` are now `status:newsLink` and `status:newsLinkLabel`. gofeed reads a namespaced element from `item.Extensions` rather than `item.Custom`, so status-go has to read them from there before this ships.

--- a/apps/status.app/package.json
+++ b/apps/status.app/package.json
@@ -105,6 +105,7 @@
     "drizzle-orm": "^0.31.0",
     "drizzle-zod": "^0.5.1",
     "emoji-datasource-twitter": "^15.1.2",
+    "entities": "^8.0.0",
     "fast-xml-parser": "^5.2.2",
     "github-slugger": "^2.0.0",
     "google-auth-library": "^9.0.0",

--- a/apps/status.app/package.json
+++ b/apps/status.app/package.json
@@ -18,6 +18,7 @@
     "build:content": "contentlayer2 build && :",
     "build:docker": "bash -c 'set -a && . .env.local && set +a && cd ../.. && docker build -f apps/status.app/Dockerfile --secret id=infura_api_key,env=INFURA_API_KEY --secret id=greenhouse_api_key,env=GREENHOUSE_API_KEY --secret id=github_token,env=GITHUB_TOKEN --build-arg NEXT_PUBLIC_GHOST_API_URL=\"$NEXT_PUBLIC_GHOST_API_URL\" --build-arg NEXT_PUBLIC_GHOST_API_KEY=\"$NEXT_PUBLIC_GHOST_API_KEY\" --build-arg NEXT_PUBLIC_INFURA_API_KEY=\"$NEXT_PUBLIC_INFURA_API_KEY\" --build-arg NEXT_PUBLIC_HASURA_API_URL=\"$NEXT_PUBLIC_HASURA_API_URL\" --build-arg GREENHOUSE_STATUS_BOARD_ID=\"$GREENHOUSE_STATUS_BOARD_ID\" --build-arg GREENHOUSE_LOGOS_BOARD_ID=\"$GREENHOUSE_LOGOS_BOARD_ID\" -t status-web/status.app:dev .'",
     "start": "next start",
+    "test": "vitest run",
     "start:standalone": "node .next/standalone/apps/status.app/server.js",
     "start:docker": "bash -c 'set -a && . .env.local && set +a && docker run --rm -p 3001:3001 -e SITE_URL -e NEXT_PUBLIC_GHOST_API_URL -e NEXT_PUBLIC_GHOST_API_KEY -e NEXT_PUBLIC_INFURA_API_KEY -e NEXT_PUBLIC_HASURA_API_URL -e INFURA_API_KEY -e GREENHOUSE_API_KEY -e GREENHOUSE_STATUS_BOARD_ID -e GREENHOUSE_LOGOS_BOARD_ID -e GITHUB_TOKEN -e POSTGRES_URL -e KEYCLOAK_API_URL -e KEYCLOAK_REALM -e KEYCLOAK_ISSUER -e KEYCLOAK_CLIENT_ID -e KEYCLOAK_CLIENT_SECRET -e BAMBOOHR_API_KEY -e UMAMI_WEBSITE_ID -e UMAMI_API_URL status-web/status.app:dev'",
     "preview:docker": "pnpm build:docker && pnpm start:docker",

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -166,13 +166,22 @@ describe('renderFeedContent', () => {
       expect(body).toBe('Use &lt;code&gt; &amp; read the R&amp;D notes')
     })
 
-    it('escapes a bare ampersand without touching existing entities', () => {
+    it('resolves the entities Ghost emits, including ones XML lacks', () => {
       const { body } = renderFeedContent(
-        '<p>Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&A</p>',
+        '<p>Tom &amp; Jerry &#x2019; &#39; &nbsp;&copy; Q&A</p>',
         'html'
       )
 
-      expect(body).toBe('Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&amp;A')
+      expect(body).toBe("Tom &amp; Jerry \u2019 ' \u00A0\u00A9 Q&amp;A")
+    })
+
+    it('leaves a semicolon-less entity name alone', () => {
+      const { body } = renderFeedContent(
+        '<p>https://status.app/x?a=1&copy=1</p>',
+        'html'
+      )
+
+      expect(body).toBe('https://status.app/x?a=1&amp;copy=1')
     })
 
     it('escapes stray angle brackets from unbalanced markup', () => {
@@ -273,7 +282,7 @@ describe('escapeUpstreamValues', () => {
     escapeUpstreamValues(channel, new Set(['description']))
 
     expect(channel.title).toBe('Tom &amp; Jerry')
-    expect(channel.item[0].title).toBe('v2.34.4 &amp; What&#x2019;s Next')
+    expect(channel.item[0].title).toBe('v2.34.4 &amp; What’s Next')
     expect(channel.item[0].description).toBe('<ul><li>Item</li></ul>')
     expect(channel.item[0]['media:content']['@_url']).toBe(
       'https://cdn.test/a.png?w=1&amp;h=2'

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -9,123 +9,143 @@ const BUTTON_CARD =
 
 describe('renderFeedContent', () => {
   it('renders a bullet list the clients can display', () => {
-    const { html } = renderFeedContent(
-      '<p>Fixes:</p><ul><li>High CPU usage</li><li>Endless loading</li></ul>'
+    const { body } = renderFeedContent(
+      '<p>Fixes:</p><ul><li>High CPU usage</li><li>Endless loading</li></ul>',
+      'html'
     )
 
-    expect(html).toBe(
+    expect(body).toBe(
       'Fixes:<ul><li>High CPU usage</li><li>Endless loading</li></ul>'
     )
   })
 
   it('renders numbered lists as an ordered list', () => {
-    const { html } = renderFeedContent('<ol><li>First</li><li>Second</li></ol>')
+    const { body } = renderFeedContent(
+      '<ol><li>First</li><li>Second</li></ol>',
+      'html'
+    )
 
-    expect(html).toBe('<ol><li>First</li><li>Second</li></ol>')
+    expect(body).toBe('<ol><li>First</li><li>Second</li></ol>')
   })
 
   it('nests sublists inside their parent item', () => {
-    const { html } = renderFeedContent(
-      '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>'
+    const { body } = renderFeedContent(
+      '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>',
+      'html'
     )
 
-    expect(html).toBe(
+    expect(body).toBe(
       '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>'
     )
   })
 
   it('separates paragraphs with a blank line but not lists', () => {
-    const { html } = renderFeedContent(
-      '<p>One</p><ul><li>Item</li></ul><p>Two</p><p>Three</p>'
+    const { body } = renderFeedContent(
+      '<p>One</p><ul><li>Item</li></ul><p>Two</p><p>Three</p>',
+      'html'
     )
 
-    expect(html).toBe('One<ul><li>Item</li></ul>Two<br /><br />Three')
+    expect(body).toBe('One<ul><li>Item</li></ul>Two<br /><br />Three')
   })
 
   it('keeps a line break inside a paragraph as a single break', () => {
-    const { html } = renderFeedContent('<p>1 Install<br>2 Follow the guide</p>')
+    const { body } = renderFeedContent(
+      '<p>1 Install<br>2 Follow the guide</p>',
+      'html'
+    )
 
-    expect(html).toBe('1 Install<br />2 Follow the guide')
+    expect(body).toBe('1 Install<br />2 Follow the guide')
   })
 
   it('drops empty list items', () => {
-    const { html } = renderFeedContent(
-      '<ul><li>Kept</li><li></li><li> </li></ul>'
+    const { body } = renderFeedContent(
+      '<ul><li>Kept</li><li></li><li> </li></ul>',
+      'html'
     )
 
-    expect(html).toBe('<ul><li>Kept</li></ul>')
+    expect(body).toBe('<ul><li>Kept</li></ul>')
   })
 
   it('drops images, captions markup and script content', () => {
-    const { html } = renderFeedContent(
-      '<img src="hero.png" alt="Hero"><script>alert("x")</script><p>Body</p>'
+    const { body } = renderFeedContent(
+      '<img src="hero.png" alt="Hero"><script>alert("x")</script><p>Body</p>',
+      'html'
     )
 
-    expect(html).toBe('Body')
+    expect(body).toBe('Body')
   })
 
   it('collapses whitespace introduced by the source markup', () => {
-    const { html } = renderFeedContent(
-      '<p>\n  Spread   over\n  lines\n</p>\n<p>Next</p>'
+    const { body } = renderFeedContent(
+      '<p>\n  Spread   over\n  lines\n</p>\n<p>Next</p>',
+      'html'
     )
 
-    expect(html).toBe('Spread over lines<br /><br />Next')
+    expect(body).toBe('Spread over lines<br /><br />Next')
   })
 
   describe('call to action', () => {
     it('extracts a Ghost button card and keeps its label out of the body', () => {
-      const { html, link } = renderFeedContent(`<p>Body</p>${BUTTON_CARD}`)
+      const { body, link } = renderFeedContent(
+        `<p>Body</p>${BUTTON_CARD}`,
+        'html'
+      )
 
       expect(link).toEqual({
         href: 'https://status.app/',
         label: 'Update your Status',
       })
-      expect(html).toBe('Body')
+      expect(body).toBe('Body')
     })
 
     it('falls back to a plain trailing link', () => {
-      const { html, link } = renderFeedContent(
-        '<p>Body</p><p><a href="https://status.app/blog/x">Read more</a></p>'
+      const { body, link } = renderFeedContent(
+        '<p>Body</p><p><a href="https://status.app/blog/x">Read more</a></p>',
+        'html'
       )
 
       expect(link).toEqual({
         href: 'https://status.app/blog/x',
         label: 'Read more',
       })
-      expect(html).toBe('Body')
+      expect(body).toBe('Body')
     })
 
     it('never lets a link inside a list become the call to action', () => {
-      const { html, link } = renderFeedContent(
+      const { body, link } = renderFeedContent(
         '<ul><li>Fixed <a href="https://github.com/status-im/status-go/issues/1">issue 1</a></li></ul>' +
-          BUTTON_CARD
+          BUTTON_CARD,
+        'html'
       )
 
       expect(link?.href).toBe('https://status.app/')
-      expect(html).toBe('<ul><li>Fixed issue 1</li></ul>')
+      expect(body).toBe('<ul><li>Fixed issue 1</li></ul>')
     })
 
     it('leaves list links in the body when there is no other link', () => {
-      const { html, link } = renderFeedContent(
-        '<p>Body</p><ul><li>See <a href="https://status.app/x">the notes</a></li></ul>'
+      const { body, link } = renderFeedContent(
+        '<p>Body</p><ul><li>See <a href="https://status.app/x">the notes</a></li></ul>',
+        'html'
       )
 
       expect(link).toBeNull()
-      expect(html).toBe('Body<ul><li>See the notes</li></ul>')
+      expect(body).toBe('Body<ul><li>See the notes</li></ul>')
     })
 
     it('keeps surrounding text when the call to action is inline', () => {
-      const { html, link } = renderFeedContent(
-        '<p>Check <a href="https://status.app/x">the notes</a> for details</p>'
+      const { body, link } = renderFeedContent(
+        '<p>Check <a href="https://status.app/x">the notes</a> for details</p>',
+        'html'
       )
 
       expect(link?.label).toBe('the notes')
-      expect(html).toBe('Check for details')
+      expect(body).toBe('Check for details')
     })
 
     it('prefers the button card over an earlier plain link', () => {
       const { link } = renderFeedContent(
-        '<p><a href="https://status.app/first">First</a></p>' + BUTTON_CARD
+        '<p><a href="https://status.app/first">First</a></p>' + BUTTON_CARD,
+        'html'
       )
 
       expect(link?.href).toBe('https://status.app/')
@@ -134,29 +154,101 @@ describe('renderFeedContent', () => {
 
   describe('escaping', () => {
     it('escapes characters that would break the feed', () => {
-      const { html } = renderFeedContent(
-        '<p>Use &lt;code&gt; &amp; read the R&amp;D notes</p>'
+      const { body } = renderFeedContent(
+        '<p>Use &lt;code&gt; &amp; read the R&amp;D notes</p>',
+        'html'
       )
 
-      expect(html).toBe('Use &lt;code&gt; &amp; read the R&amp;D notes')
+      expect(body).toBe('Use &lt;code&gt; &amp; read the R&amp;D notes')
     })
 
     it('escapes a bare ampersand without touching existing entities', () => {
-      const { html } = renderFeedContent(
-        '<p>Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&A</p>'
+      const { body } = renderFeedContent(
+        '<p>Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&A</p>',
+        'html'
       )
 
-      expect(html).toBe('Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&amp;A')
+      expect(body).toBe('Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&amp;A')
     })
 
     it('escapes stray angle brackets from unbalanced markup', () => {
-      const { html } = renderFeedContent('<p>5 > 3 and 2 < 4</p>')
+      const { body } = renderFeedContent('<p>5 > 3 and 2 < 4</p>', 'html')
 
-      expect(html).toBe('5 &gt; 3 and 2 &lt; 4')
+      expect(body).toBe('5 &gt; 3 and 2 &lt; 4')
     })
 
     it('returns empty content for empty input', () => {
-      expect(renderFeedContent('')).toEqual({ html: '', link: null })
+      expect(renderFeedContent('', 'html')).toEqual({ body: '', link: null })
+    })
+  })
+
+  describe("the mobile client's plain text format", () => {
+    it('renders lists as text bullets, never as markup', () => {
+      const { body } = renderFeedContent(
+        '<p>Fixes:</p><ul><li>High CPU usage</li><li>Endless loading</li></ul>',
+        'text'
+      )
+
+      expect(body).toBe('Fixes:\n\n• High CPU usage\n• Endless loading')
+      expect(body).not.toContain('<')
+    })
+
+    it('numbers ordered lists', () => {
+      const { body } = renderFeedContent(
+        '<ol><li>Install</li><li>Follow the guide</li></ol>',
+        'text'
+      )
+
+      expect(body).toBe('1. Install\n2. Follow the guide')
+    })
+
+    it('hangs nested items under their parent', () => {
+      const { body } = renderFeedContent(
+        '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>',
+        'text'
+      )
+
+      expect(body).toBe('• Wallet\n  • Swap\n  • Send\n• Chat')
+    })
+
+    it('numbers from one after empty items are dropped', () => {
+      const { body } = renderFeedContent(
+        '<ol><li></li><li>First</li><li>Second</li></ol>',
+        'text'
+      )
+
+      expect(body).toBe('1. First\n2. Second')
+    })
+
+    it('keeps paragraphs separated by a blank line', () => {
+      const { body } = renderFeedContent('<p>One</p><p>Two</p>', 'text')
+
+      expect(body).toBe('One\n\nTwo')
+    })
+
+    it('renders a line break inside a paragraph as a newline', () => {
+      const { body } = renderFeedContent(
+        '<p>1 Install<br>2 Follow the guide</p>',
+        'text'
+      )
+
+      expect(body).toBe('1 Install\n2 Follow the guide')
+    })
+
+    it('still escapes characters that would break the feed', () => {
+      const { body } = renderFeedContent('<p>Tom &amp; Jerry, Q&A</p>', 'text')
+
+      expect(body).toBe('Tom &amp; Jerry, Q&amp;A')
+    })
+
+    it('extracts the call to action the same way', () => {
+      const { body, link } = renderFeedContent(
+        `<p>Body</p>${BUTTON_CARD}`,
+        'text'
+      )
+
+      expect(link?.href).toBe('https://status.app/')
+      expect(body).toBe('Body')
     })
   })
 })

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { escapeUpstreamValues, renderFeedContent } from './feed-content'
+import {
+  escapeUpstreamChannel,
+  escapeUpstreamValues,
+  renderFeedContent,
+} from './feed-content'
 
 const BUTTON_CARD =
   '<div class="kg-card kg-button-card kg-align-center">' +
@@ -288,5 +292,19 @@ describe('escapeUpstreamValues', () => {
     expect(channel['media:content']['@_url']).toBe(
       'https://cdn.test/a&quot;.png'
     )
+  })
+})
+
+describe('escapeUpstreamChannel', () => {
+  it('escapes the channel description that items are skipped for', () => {
+    const channel = {
+      description: 'Research & Development',
+      item: [{ description: '<ul><li>Item</li></ul>' }],
+    }
+
+    escapeUpstreamChannel(channel, new Set(['description']))
+
+    expect(channel.description).toBe('Research &amp; Development')
+    expect(channel.item[0].description).toBe('<ul><li>Item</li></ul>')
   })
 })

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderFeedContent } from './feed-content'
+import { escapeUpstreamValues, renderFeedContent } from './feed-content'
 
 const BUTTON_CARD =
   '<div class="kg-card kg-button-card kg-align-center">' +
@@ -158,5 +158,43 @@ describe('renderFeedContent', () => {
     it('returns empty content for empty input', () => {
       expect(renderFeedContent('')).toEqual({ html: '', link: null })
     })
+  })
+})
+
+describe('escapeUpstreamValues', () => {
+  it('escapes Ghost values but leaves generated fields untouched', () => {
+    const channel = {
+      title: 'Tom & Jerry',
+      item: [
+        {
+          title: 'v2.34.4 & What&#x2019;s Next',
+          description: '<ul><li>Item</li></ul>',
+          'media:content': { '@_url': 'https://cdn.test/a.png?w=1&h=2' },
+        },
+      ],
+    }
+
+    escapeUpstreamValues(channel, new Set(['description']))
+
+    expect(channel.title).toBe('Tom &amp; Jerry')
+    expect(channel.item[0].title).toBe('v2.34.4 &amp; What&#x2019;s Next')
+    expect(channel.item[0].description).toBe('<ul><li>Item</li></ul>')
+    expect(channel.item[0]['media:content']['@_url']).toBe(
+      'https://cdn.test/a.png?w=1&amp;h=2'
+    )
+  })
+
+  it('escapes quotes in attribute values only', () => {
+    const channel = {
+      title: 'The "best" release',
+      'media:content': { '@_url': 'https://cdn.test/a".png' },
+    }
+
+    escapeUpstreamValues(channel, new Set())
+
+    expect(channel.title).toBe('The "best" release')
+    expect(channel['media:content']['@_url']).toBe(
+      'https://cdn.test/a&quot;.png'
+    )
   })
 })

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderFeedContent } from './feed-content'
+
+const BUTTON_CARD =
+  '<div class="kg-card kg-button-card kg-align-center">' +
+  '<a href="https://status.app/" class="kg-btn kg-btn-accent">Update your Status</a>' +
+  '</div>'
+
+describe('renderFeedContent', () => {
+  it('renders a bullet list the clients can display', () => {
+    const { html } = renderFeedContent(
+      '<p>Fixes:</p><ul><li>High CPU usage</li><li>Endless loading</li></ul>'
+    )
+
+    expect(html).toBe(
+      'Fixes:<ul><li>High CPU usage</li><li>Endless loading</li></ul>'
+    )
+  })
+
+  it('renders numbered lists as an ordered list', () => {
+    const { html } = renderFeedContent('<ol><li>First</li><li>Second</li></ol>')
+
+    expect(html).toBe('<ol><li>First</li><li>Second</li></ol>')
+  })
+
+  it('nests sublists inside their parent item', () => {
+    const { html } = renderFeedContent(
+      '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>'
+    )
+
+    expect(html).toBe(
+      '<ul><li>Wallet<ul><li>Swap</li><li>Send</li></ul></li><li>Chat</li></ul>'
+    )
+  })
+
+  it('separates paragraphs with a blank line but not lists', () => {
+    const { html } = renderFeedContent(
+      '<p>One</p><ul><li>Item</li></ul><p>Two</p><p>Three</p>'
+    )
+
+    expect(html).toBe('One<ul><li>Item</li></ul>Two<br /><br />Three')
+  })
+
+  it('keeps a line break inside a paragraph as a single break', () => {
+    const { html } = renderFeedContent('<p>1 Install<br>2 Follow the guide</p>')
+
+    expect(html).toBe('1 Install<br />2 Follow the guide')
+  })
+
+  it('drops empty list items', () => {
+    const { html } = renderFeedContent(
+      '<ul><li>Kept</li><li></li><li> </li></ul>'
+    )
+
+    expect(html).toBe('<ul><li>Kept</li></ul>')
+  })
+
+  it('drops images, captions markup and script content', () => {
+    const { html } = renderFeedContent(
+      '<img src="hero.png" alt="Hero"><script>alert("x")</script><p>Body</p>'
+    )
+
+    expect(html).toBe('Body')
+  })
+
+  it('collapses whitespace introduced by the source markup', () => {
+    const { html } = renderFeedContent(
+      '<p>\n  Spread   over\n  lines\n</p>\n<p>Next</p>'
+    )
+
+    expect(html).toBe('Spread over lines<br /><br />Next')
+  })
+
+  describe('call to action', () => {
+    it('extracts a Ghost button card and keeps its label out of the body', () => {
+      const { html, link } = renderFeedContent(`<p>Body</p>${BUTTON_CARD}`)
+
+      expect(link).toEqual({
+        href: 'https://status.app/',
+        label: 'Update your Status',
+      })
+      expect(html).toBe('Body')
+    })
+
+    it('falls back to a plain trailing link', () => {
+      const { html, link } = renderFeedContent(
+        '<p>Body</p><p><a href="https://status.app/blog/x">Read more</a></p>'
+      )
+
+      expect(link).toEqual({
+        href: 'https://status.app/blog/x',
+        label: 'Read more',
+      })
+      expect(html).toBe('Body')
+    })
+
+    it('never lets a link inside a list become the call to action', () => {
+      const { html, link } = renderFeedContent(
+        '<ul><li>Fixed <a href="https://github.com/status-im/status-go/issues/1">issue 1</a></li></ul>' +
+          BUTTON_CARD
+      )
+
+      expect(link?.href).toBe('https://status.app/')
+      expect(html).toBe('<ul><li>Fixed issue 1</li></ul>')
+    })
+
+    it('leaves list links in the body when there is no other link', () => {
+      const { html, link } = renderFeedContent(
+        '<p>Body</p><ul><li>See <a href="https://status.app/x">the notes</a></li></ul>'
+      )
+
+      expect(link).toBeNull()
+      expect(html).toBe('Body<ul><li>See the notes</li></ul>')
+    })
+
+    it('keeps surrounding text when the call to action is inline', () => {
+      const { html, link } = renderFeedContent(
+        '<p>Check <a href="https://status.app/x">the notes</a> for details</p>'
+      )
+
+      expect(link?.label).toBe('the notes')
+      expect(html).toBe('Check for details')
+    })
+
+    it('prefers the button card over an earlier plain link', () => {
+      const { link } = renderFeedContent(
+        '<p><a href="https://status.app/first">First</a></p>' + BUTTON_CARD
+      )
+
+      expect(link?.href).toBe('https://status.app/')
+    })
+  })
+
+  describe('escaping', () => {
+    it('escapes characters that would break the feed', () => {
+      const { html } = renderFeedContent(
+        '<p>Use &lt;code&gt; &amp; read the R&amp;D notes</p>'
+      )
+
+      expect(html).toBe('Use &lt;code&gt; &amp; read the R&amp;D notes')
+    })
+
+    it('escapes a bare ampersand without touching existing entities', () => {
+      const { html } = renderFeedContent(
+        '<p>Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&A</p>'
+      )
+
+      expect(html).toBe('Tom &amp; Jerry &#x2019; &#39; &nbsp; Q&amp;A')
+    })
+
+    it('escapes stray angle brackets from unbalanced markup', () => {
+      const { html } = renderFeedContent('<p>5 > 3 and 2 < 4</p>')
+
+      expect(html).toBe('5 &gt; 3 and 2 &lt; 4')
+    })
+
+    it('returns empty content for empty input', () => {
+      expect(renderFeedContent('')).toEqual({ html: '', link: null })
+    })
+  })
+})

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -2,12 +2,11 @@
  * Converts Ghost post HTML into the small HTML subset the Status desktop and
  * mobile clients render for news notifications.
  *
- * status-go parses `<description>` with gofeed, which decodes the element via
- * `xml:",innerxml"` and hands the raw markup to the client, so anything emitted
- * here has to stay well-formed XML. That is guaranteed by construction: text
- * nodes are escaped and the only tags in the output are the ones this module
- * writes itself. A parsing mistake can misplace text but cannot produce a feed
- * that fails to parse, which would take news down for every installed client.
+ * status-go parses `<description>` with gofeed and hands the decoded element to
+ * the client, so the markup this module writes is what the client renders. It
+ * stays well-formed by construction: text nodes are escaped and the only tags
+ * in the output are the ones written here. A parsing mistake can misplace text
+ * but cannot leave a tag unbalanced in front of the client's renderer.
  */
 
 import { decodeHTMLStrict } from 'entities'
@@ -359,11 +358,26 @@ const FORBIDDEN_XML_CHARS =
  * into `©=1`.
  */
 export function escapeFeedText(text: string): string {
-  return decodeHTMLStrict(text)
-    .replace(FORBIDDEN_XML_CHARS, '')
+  return escapeXml(decodeHTMLStrict(text).replace(FORBIDDEN_XML_CHARS, ''))
+}
+
+/** Escapes without decoding, so it can be applied on top of `escapeFeedText`. */
+function escapeXml(text: string): string {
+  return text
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
+}
+
+/**
+ * RSS 2.0 defines `description` as character data, so the desktop feed's markup
+ * is escaped on its way into the XML tree rather than served as child elements.
+ * status-go decodes the element with gofeed before handing it to the client,
+ * which therefore receives the same markup as it did before. The mobile feed
+ * carries no markup and is already character data.
+ */
+export function serializeFeedBody(body: string, format: FeedFormat): string {
+  return format === 'html' ? escapeXml(body) : body
 }
 
 function renderBlocks(blocks: Block[], format: FeedFormat): string {

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -11,6 +11,7 @@
  */
 
 const PARAGRAPH_BREAK = '<br /><br />'
+const PLAIN_PARAGRAPH_BREAK = '\n\n'
 
 const VOID_TAGS = new Set([
   'area',
@@ -92,9 +93,16 @@ type Block =
   | { type: 'text'; text: string }
   | { type: 'list'; ordered: boolean; items: Block[][] }
 
+/**
+ * `html` targets the desktop client's rich text view; `text` targets the mobile
+ * client, which renders the description as plain text and would show markup
+ * literally.
+ */
+export type FeedFormat = 'html' | 'text'
+
 export type FeedLink = { href: string; label: string }
 
-export type FeedContent = { html: string; link: FeedLink | null }
+export type FeedContent = { body: string; link: FeedLink | null }
 
 function tokenize(html: string): Token[] {
   const tokens: Token[] = []
@@ -348,13 +356,24 @@ export function escapeFeedText(text: string): string {
     .replace(/>/g, '&gt;')
 }
 
-function renderBlocks(blocks: Block[]): string {
+function renderBlocks(blocks: Block[], format: FeedFormat): string {
+  if (format === 'text') {
+    return blocks
+      .map(block =>
+        block.type === 'list'
+          ? renderList(block, format)
+          : escapeFeedText(block.text)
+      )
+      .filter(Boolean)
+      .join(PLAIN_PARAGRAPH_BREAK)
+  }
+
   let html = ''
 
   blocks.forEach((block, index) => {
     const rendered =
       block.type === 'list'
-        ? renderList(block)
+        ? renderList(block, format)
         : escapeFeedText(block.text).replaceAll('\n', '<br />')
 
     if (!rendered) {
@@ -375,9 +394,33 @@ function renderBlocks(blocks: Block[]): string {
   return html
 }
 
-function renderList(block: Extract<Block, { type: 'list' }>): string {
+function renderList(
+  block: Extract<Block, { type: 'list' }>,
+  format: FeedFormat
+): string {
+  if (format === 'text') {
+    return block.items
+      .map(item =>
+        item
+          .map(child =>
+            child.type === 'list'
+              ? renderList(child, format)
+              : escapeFeedText(child.text)
+          )
+          .filter(Boolean)
+          .join('\n')
+      )
+      .filter(Boolean)
+      .map((item, index) => {
+        const marker = block.ordered ? `${index + 1}. ` : '• '
+        // Continuation lines and nested items hang under the marker.
+        return marker + item.replaceAll('\n', '\n  ')
+      })
+      .join('\n')
+  }
+
   const items = block.items
-    .map(item => renderBlocks(item))
+    .map(item => renderBlocks(item, format))
     .filter(Boolean)
     .map(item => `<li>${item}</li>`)
     .join('')
@@ -428,9 +471,12 @@ export function escapeUpstreamValues(
   return value
 }
 
-export function renderFeedContent(html: string): FeedContent {
+export function renderFeedContent(
+  html: string,
+  format: FeedFormat
+): FeedContent {
   if (!html) {
-    return { html: '', link: null }
+    return { body: '', link: null }
   }
 
   const tokens = tokenize(html)
@@ -444,7 +490,7 @@ export function renderFeedContent(html: string): FeedContent {
   )
 
   return {
-    html: renderBlocks(blocks),
+    body: renderBlocks(blocks, format),
     link: link ? { href: link.href, label: link.label } : null,
   }
 }

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -458,18 +458,48 @@ export function escapeUpstreamValues(
         continue
       }
 
-      const escaped = escapeUpstreamValues(child, skipKeys)
-
-      // Attribute values are re-serialised inside double quotes.
-      ;(value as Record<string, unknown>)[key] =
-        key.startsWith('@_') && typeof escaped === 'string'
-          ? escaped.replaceAll('"', '&quot;')
-          : escaped
+      escapeChild(value as Record<string, unknown>, key, child, skipKeys)
     }
   }
 
   return value
 }
+
+function escapeChild(
+  container: Record<string, unknown>,
+  key: string,
+  child: unknown,
+  skipKeys: ReadonlySet<string>
+): void {
+  const escaped = escapeUpstreamValues(child, skipKeys)
+
+  // Attribute values are re-serialised inside double quotes.
+  container[key] =
+    key.startsWith('@_') && typeof escaped === 'string'
+      ? escaped.replaceAll('"', '&quot;')
+      : escaped
+}
+
+/**
+ * Applies the generated fields only inside `<item>`. `description` names both
+ * an item and a channel element, so skipping it channel-wide would re-serve
+ * Ghost's publication description with its `&` unescaped.
+ */
+export function escapeUpstreamChannel(
+  channel: Record<string, unknown>,
+  generatedItemFields: ReadonlySet<string>
+): void {
+  for (const [key, child] of Object.entries(channel)) {
+    escapeChild(
+      channel,
+      key,
+      child,
+      key === 'item' ? generatedItemFields : NO_SKIPPED_KEYS
+    )
+  }
+}
+
+const NO_SKIPPED_KEYS: ReadonlySet<string> = new Set()
 
 export function renderFeedContent(
   html: string,

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -10,6 +10,8 @@
  * that fails to parse, which would take news down for every installed client.
  */
 
+import { decodeHTMLStrict } from 'entities'
+
 const PARAGRAPH_BREAK = '<br /><br />'
 const PLAIN_PARAGRAPH_BREAK = '\n\n'
 
@@ -343,17 +345,25 @@ function parseList(
 const LI_STOP_OPEN: ReadonlySet<string> = new Set(['li'])
 const LI_STOP_CLOSE: ReadonlySet<string> = new Set(['li', 'ol', 'ul'])
 
+/** XML 1.0 forbids these outright, including as numeric references. */
+const FORBIDDEN_XML_CHARS =
+  /[^\t\n\r\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu
+
 /**
- * Escapes text for embedding in XML while leaving existing HTML entities
- * intact. Ghost emits entities such as `&quot;` and `&#x2019;`, and gofeed
- * decodes them once on the client, so re-escaping the ampersand would surface
- * the entity literally in the notification.
+ * Resolves Ghost's HTML entities to their characters and escapes the result for
+ * XML. Passing the entities through would emit names such as `&nbsp;` that XML
+ * leaves undefined, which costs the whole feed rather than one character.
+ *
+ * Decoding is strict so that a trailing semicolon is required: the legacy HTML
+ * rules resolve `&copy` on its own, turning the `&copy=1` of a query string
+ * into `©=1`.
  */
 export function escapeFeedText(text: string): string {
-  return text
-    .replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return decodeHTMLStrict(text)
+    .replace(FORBIDDEN_XML_CHARS, '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
 }
 
 function renderBlocks(blocks: Block[], format: FeedFormat): string {

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -1,0 +1,413 @@
+/**
+ * Converts Ghost post HTML into the small HTML subset the Status desktop and
+ * mobile clients render for news notifications.
+ *
+ * status-go parses `<description>` with gofeed, which decodes the element via
+ * `xml:",innerxml"` and hands the raw markup to the client, so anything emitted
+ * here has to stay well-formed XML. That is guaranteed by construction: text
+ * nodes are escaped and the only tags in the output are the ones this module
+ * writes itself. A parsing mistake can misplace text but cannot produce a feed
+ * that fails to parse, which would take news down for every installed client.
+ */
+
+const PARAGRAPH_BREAK = '<br /><br />'
+
+const VOID_TAGS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+
+const BLOCK_TAGS = new Set([
+  'address',
+  'article',
+  'aside',
+  'blockquote',
+  'dd',
+  'details',
+  'div',
+  'dl',
+  'dt',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hgroup',
+  'hr',
+  'main',
+  'nav',
+  'p',
+  'pre',
+  'section',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'tr',
+])
+
+// Elements whose text content never belongs in a notification.
+const SKIPPED_TAGS = new Set([
+  'iframe',
+  'noscript',
+  'script',
+  'style',
+  'svg',
+  'template',
+])
+
+const LIST_TAGS = new Set(['ol', 'ul'])
+
+/** Attribute values may contain `>`, so quoted runs are matched before it. */
+const TAG_PATTERN =
+  /<!--[\s\S]*?-->|<\/\s*([a-zA-Z][\w:-]*)\s*>|<\s*([a-zA-Z][\w:-]*)((?:"[^"]*"|'[^']*'|[^"'>])*)>/g
+
+type Token =
+  | { kind: 'text'; value: string }
+  | { kind: 'open'; name: string; attributes: string }
+  | { kind: 'close'; name: string }
+
+type Block =
+  | { type: 'text'; text: string }
+  | { type: 'list'; ordered: boolean; items: Block[][] }
+
+export type FeedLink = { href: string; label: string }
+
+export type FeedContent = { html: string; link: FeedLink | null }
+
+function tokenize(html: string): Token[] {
+  const tokens: Token[] = []
+  let cursor = 0
+
+  for (const match of html.matchAll(TAG_PATTERN)) {
+    const index = match.index ?? 0
+
+    if (index > cursor) {
+      tokens.push({ kind: 'text', value: html.slice(cursor, index) })
+    }
+    cursor = index + match[0].length
+
+    const [, closeName, openName, attributes = ''] = match
+
+    if (closeName) {
+      tokens.push({ kind: 'close', name: closeName.toLowerCase() })
+      continue
+    }
+
+    if (openName) {
+      const name = openName.toLowerCase()
+      tokens.push({ kind: 'open', name, attributes })
+
+      if (VOID_TAGS.has(name) || attributes.trimEnd().endsWith('/')) {
+        tokens.push({ kind: 'close', name })
+      }
+    }
+  }
+
+  if (cursor < html.length) {
+    tokens.push({ kind: 'text', value: html.slice(cursor) })
+  }
+
+  return tokens
+}
+
+function getAttribute(attributes: string, name: string): string {
+  const match = attributes.match(
+    new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i')
+  )
+
+  return match?.[2] ?? match?.[3] ?? ''
+}
+
+/** Collects the text of an element, starting just after its opening tag. */
+function readElementText(tokens: Token[], start: number, name: string): string {
+  let depth = 1
+  let text = ''
+
+  for (let index = start; index < tokens.length; index++) {
+    const token = tokens[index]
+
+    if (token.kind === 'text') {
+      text += token.value
+    } else if (token.name === name) {
+      depth += token.kind === 'open' ? 1 : -1
+      if (depth === 0) break
+    }
+  }
+
+  return collapseWhitespace(text)
+}
+
+/**
+ * Picks the anchor that becomes the notification's call-to-action. Ghost button
+ * cards win; otherwise the first anchor outside a list does, so that a link
+ * inside a bullet cannot hijack the CTA.
+ */
+function findLinkToken(
+  tokens: Token[]
+): (FeedLink & { tokenIndex: number }) | null {
+  let listDepth = 0
+  let fallback: (FeedLink & { tokenIndex: number }) | null = null
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]
+
+    if (token.kind === 'open' && LIST_TAGS.has(token.name)) {
+      listDepth++
+    } else if (token.kind === 'close' && LIST_TAGS.has(token.name)) {
+      listDepth = Math.max(0, listDepth - 1)
+    } else if (token.kind === 'open' && token.name === 'a') {
+      const href = getAttribute(token.attributes, 'href')
+      if (!href) continue
+
+      const label = readElementText(tokens, index + 1, 'a')
+      const isButton = /(^|\s)kg-btn(\s|$)/.test(
+        getAttribute(token.attributes, 'class')
+      )
+
+      if (isButton) {
+        return { href, label: label.trim(), tokenIndex: index }
+      }
+      if (listDepth === 0 && !fallback) {
+        fallback = { href, label: label.trim(), tokenIndex: index }
+      }
+    }
+  }
+
+  return fallback
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ')
+}
+
+type Cursor = { index: number }
+
+function skipElement(tokens: Token[], cursor: Cursor, name: string): void {
+  let depth = 1
+
+  while (cursor.index < tokens.length && depth > 0) {
+    const token = tokens[cursor.index++]
+
+    if (token.kind !== 'text' && token.name === name) {
+      depth += token.kind === 'open' ? 1 : -1
+    }
+  }
+}
+
+function parseBlocks(
+  tokens: Token[],
+  cursor: Cursor,
+  linkTokenIndex: number,
+  stopOnOpen: ReadonlySet<string>,
+  stopOnClose: ReadonlySet<string>
+): Block[] {
+  const blocks: Block[] = []
+  let buffer = ''
+
+  const flush = () => {
+    // Removing a suppressed anchor can leave the spaces that surrounded it
+    // doubled up; `\n` marks a break and has to survive.
+    const text = buffer.replace(/[^\S\n]+/g, ' ').trim()
+    buffer = ''
+    if (text) {
+      blocks.push({ type: 'text', text })
+    }
+  }
+
+  while (cursor.index < tokens.length) {
+    const token = tokens[cursor.index]
+
+    if (token.kind === 'text') {
+      cursor.index++
+      buffer += collapseWhitespace(token.value)
+      continue
+    }
+
+    if (token.kind === 'close') {
+      if (stopOnClose.has(token.name)) break
+
+      cursor.index++
+      if (BLOCK_TAGS.has(token.name)) {
+        flush()
+      }
+      continue
+    }
+
+    if (stopOnOpen.has(token.name)) break
+
+    const tokenIndex = cursor.index
+    cursor.index++
+
+    if (SKIPPED_TAGS.has(token.name)) {
+      skipElement(tokens, cursor, token.name)
+      continue
+    }
+
+    if (token.name === 'br') {
+      // Rendered as a single break; a blank line only ever comes from a real
+      // block boundary.
+      buffer += '\n'
+      continue
+    }
+
+    if (LIST_TAGS.has(token.name)) {
+      flush()
+      blocks.push(
+        parseList(tokens, cursor, linkTokenIndex, token.name === 'ol')
+      )
+      continue
+    }
+
+    if (token.name === 'a') {
+      const label = readElementText(tokens, cursor.index, 'a')
+      skipElement(tokens, cursor, 'a')
+      // The CTA is surfaced as its own feed element, so its label must not be
+      // repeated in the body.
+      if (tokenIndex !== linkTokenIndex) {
+        buffer += label
+      }
+      continue
+    }
+
+    if (BLOCK_TAGS.has(token.name)) {
+      flush()
+    }
+  }
+
+  flush()
+
+  return blocks
+}
+
+function parseList(
+  tokens: Token[],
+  cursor: Cursor,
+  linkTokenIndex: number,
+  ordered: boolean
+): Block {
+  const items: Block[][] = []
+
+  while (cursor.index < tokens.length) {
+    const token = tokens[cursor.index]
+
+    if (token.kind === 'close' && LIST_TAGS.has(token.name)) {
+      cursor.index++
+      break
+    }
+
+    if (token.kind === 'open' && token.name === 'li') {
+      cursor.index++
+      items.push(
+        parseBlocks(tokens, cursor, linkTokenIndex, LI_STOP_OPEN, LI_STOP_CLOSE)
+      )
+      continue
+    }
+
+    // Whitespace and stray markup between items carries no content.
+    cursor.index++
+  }
+
+  return { type: 'list', ordered, items }
+}
+
+const LI_STOP_OPEN: ReadonlySet<string> = new Set(['li'])
+const LI_STOP_CLOSE: ReadonlySet<string> = new Set(['li', 'ol', 'ul'])
+
+/**
+ * Escapes text for embedding in XML while leaving existing HTML entities
+ * intact. Ghost emits entities such as `&quot;` and `&#x2019;`, and gofeed
+ * decodes them once on the client, so re-escaping the ampersand would surface
+ * the entity literally in the notification.
+ */
+export function escapeFeedText(text: string): string {
+  return text
+    .replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function renderBlocks(blocks: Block[]): string {
+  let html = ''
+
+  blocks.forEach((block, index) => {
+    const rendered =
+      block.type === 'list'
+        ? renderList(block)
+        : escapeFeedText(block.text).replaceAll('\n', '<br />')
+
+    if (!rendered) {
+      return
+    }
+
+    if (html) {
+      // Lists are block elements in the clients' rich text renderer and bring
+      // their own spacing, so an explicit break next to one adds a blank line.
+      const adjacentToList =
+        block.type === 'list' || blocks[index - 1]?.type === 'list'
+      html += adjacentToList ? '' : PARAGRAPH_BREAK
+    }
+
+    html += rendered
+  })
+
+  return html
+}
+
+function renderList(block: Extract<Block, { type: 'list' }>): string {
+  const items = block.items
+    .map(item => renderBlocks(item))
+    .filter(Boolean)
+    .map(item => `<li>${item}</li>`)
+    .join('')
+
+  if (!items) {
+    return ''
+  }
+
+  const tag = block.ordered ? 'ol' : 'ul'
+
+  return `<${tag}>${items}</${tag}>`
+}
+
+export function renderFeedContent(html: string): FeedContent {
+  if (!html) {
+    return { html: '', link: null }
+  }
+
+  const tokens = tokenize(html)
+  const link = findLinkToken(tokens)
+  const blocks = parseBlocks(
+    tokens,
+    { index: 0 },
+    link?.tokenIndex ?? -1,
+    new Set(),
+    new Set()
+  )
+
+  return {
+    html: renderBlocks(blocks),
+    link: link ? { href: link.href, label: link.label } : null,
+  }
+}

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -391,6 +391,43 @@ function renderList(block: Extract<Block, { type: 'list' }>): string {
   return `<${tag}>${items}</${tag}>`
 }
 
+/**
+ * Escapes every string Ghost supplies, in place, skipping the keys whose values
+ * are generated here. The news feeds lose Ghost's CDATA wrappers on parse and
+ * are rebuilt with entity processing off, so an unescaped `&` in a title would
+ * otherwise be re-served as invalid XML.
+ */
+export function escapeUpstreamValues(
+  value: unknown,
+  skipKeys: ReadonlySet<string>
+): unknown {
+  if (typeof value === 'string') {
+    return escapeFeedText(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(entry => escapeUpstreamValues(entry, skipKeys))
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      if (skipKeys.has(key)) {
+        continue
+      }
+
+      const escaped = escapeUpstreamValues(child, skipKeys)
+
+      // Attribute values are re-serialised inside double quotes.
+      ;(value as Record<string, unknown>)[key] =
+        key.startsWith('@_') && typeof escaped === 'string'
+          ? escaped.replaceAll('"', '&quot;')
+          : escaped
+    }
+  }
+
+  return value
+}
+
 export function renderFeedContent(html: string): FeedContent {
   if (!html) {
     return { html: '', link: null }

--- a/apps/status.app/src/app/_utils/news-feed.test.ts
+++ b/apps/status.app/src/app/_utils/news-feed.test.ts
@@ -77,9 +77,13 @@ describe('buildNewsFeed', () => {
   it('emits the desktop feed as markup and the mobile feed as text', () => {
     const desktop = buildNewsFeed(LIST_FEED, 'html')
 
-    // The markup is the description's content, so it is read as a string here.
+    // RSS 2.0 defines `description` as character data, so the markup is escaped
+    // on the wire and the client decodes it back.
     expect(desktop).toContain(
-      '<description>Fixes:<ul><li>High CPU usage</li></ul></description>'
+      '<description>Fixes:&lt;ul&gt;&lt;li&gt;High CPU usage&lt;/li&gt;&lt;/ul&gt;</description>'
+    )
+    expect(parseItem(desktop).description).toBe(
+      'Fixes:<ul><li>High CPU usage</li></ul>'
     )
     expect(XMLValidator.validate(desktop)).toBe(true)
     expect(parseItem(buildNewsFeed(LIST_FEED, 'text')).description).toBe(

--- a/apps/status.app/src/app/_utils/news-feed.test.ts
+++ b/apps/status.app/src/app/_utils/news-feed.test.ts
@@ -70,8 +70,14 @@ describe('buildNewsFeed', () => {
   it('keeps a semicolon-less entity name out of the link target', () => {
     const item = parseItem(buildNewsFeed(GHOST_FEED, 'text'))
 
-    expect(item.newsLink).toBe('https://status.app/x?a=1&copy=1')
-    expect(item.newsLinkLabel).toBe('Read more')
+    expect(item['status:newsLink']).toBe('https://status.app/x?a=1&copy=1')
+    expect(item['status:newsLinkLabel']).toBe('Read more')
+  })
+
+  it('declares the namespace the call-to-action elements live in', () => {
+    const feed = buildNewsFeed(GHOST_FEED, 'text')
+
+    expect(feed).toContain('xmlns:status="https://status.app/ns/rss/1.0"')
   })
 
   it('emits the desktop feed as markup and the mobile feed as text', () => {

--- a/apps/status.app/src/app/_utils/news-feed.test.ts
+++ b/apps/status.app/src/app/_utils/news-feed.test.ts
@@ -1,0 +1,106 @@
+import { XMLParser, XMLValidator } from 'fast-xml-parser'
+import { describe, expect, it } from 'vitest'
+
+import { buildNewsFeed } from './news-feed'
+
+/**
+ * A Ghost feed carrying every construct that has broken the output: an
+ * ampersand in the channel description, entity names XML does not define, a
+ * semicolon-less `&copy` in a query string and an ampersand in an attribute.
+ */
+const GHOST_FEED =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">' +
+  '<channel>' +
+  '<title><![CDATA[Mobile news]]></title>' +
+  '<description><![CDATA[Research & Development at Status]]></description>' +
+  '<link>https://our.status.im/</link>' +
+  '<item>' +
+  '<title><![CDATA[v2.36 &amp; what&#x2019;s next]]></title>' +
+  '<description><![CDATA[<p>Ada &amp; Co&nbsp;&copy; 2026</p>' +
+  '<p><a href="https://status.app/x?a=1&copy=1">Read more</a></p>]]></description>' +
+  '<media:content url="https://cdn.test/a.png?w=1&amp;h=2"/>' +
+  '</item>' +
+  '</channel>' +
+  '</rss>'
+
+const LIST_FEED =
+  '<rss version="2.0"><channel>' +
+  '<item>' +
+  '<title><![CDATA[One &amp; only]]></title>' +
+  '<description><![CDATA[<p>Fixes:</p><ul><li>High CPU usage</li></ul>]]></description>' +
+  '</item>' +
+  '</channel></rss>'
+
+/** The entities XML defines; Go's parser rejects every other name. */
+const UNDEFINED_ENTITY =
+  /&(?!(?:amp|lt|gt|quot|apos|#\d+|#[xX][0-9a-fA-F]+);)\S*/
+
+/** Reads the output back the way a client does, entities and all. */
+function parseItem(feed: string) {
+  return new XMLParser({ ignoreAttributes: false }).parse(feed).rss.channel.item
+}
+
+describe('buildNewsFeed', () => {
+  it('produces a feed that parses as XML', () => {
+    const feed = buildNewsFeed(GHOST_FEED, 'text')
+
+    expect(XMLValidator.validate(feed)).toBe(true)
+    expect(feed.match(UNDEFINED_ENTITY)).toBeNull()
+  })
+
+  it('escapes the ampersand in the channel description', () => {
+    const feed = buildNewsFeed(GHOST_FEED, 'text')
+
+    expect(feed).toContain(
+      '<description>Research &amp; Development at Status</description>'
+    )
+  })
+
+  it('escapes every ampersand exactly once', () => {
+    const item = parseItem(buildNewsFeed(GHOST_FEED, 'text'))
+
+    expect(item.title).toBe('v2.36 & what\u2019s next')
+    expect(item.description).toBe('Ada & Co\u00A0\u00A9 2026')
+    expect(item['media:content']['@_url']).toBe(
+      'https://cdn.test/a.png?w=1&h=2'
+    )
+  })
+
+  it('keeps a semicolon-less entity name out of the link target', () => {
+    const item = parseItem(buildNewsFeed(GHOST_FEED, 'text'))
+
+    expect(item.newsLink).toBe('https://status.app/x?a=1&copy=1')
+    expect(item.newsLinkLabel).toBe('Read more')
+  })
+
+  it('emits the desktop feed as markup and the mobile feed as text', () => {
+    const desktop = buildNewsFeed(LIST_FEED, 'html')
+
+    // The markup is the description's content, so it is read as a string here.
+    expect(desktop).toContain(
+      '<description>Fixes:<ul><li>High CPU usage</li></ul></description>'
+    )
+    expect(XMLValidator.validate(desktop)).toBe(true)
+    expect(parseItem(buildNewsFeed(LIST_FEED, 'text')).description).toBe(
+      'Fixes:\n\n• High CPU usage'
+    )
+  })
+
+  it('handles a channel holding a single item', () => {
+    const feed = buildNewsFeed(LIST_FEED, 'text')
+
+    expect(XMLValidator.validate(feed)).toBe(true)
+    expect(parseItem(feed).title).toBe('One & only')
+  })
+
+  it('escapes a channel that has no items', () => {
+    const feed = buildNewsFeed(
+      '<rss version="2.0"><channel><description><![CDATA[R & D]]></description></channel></rss>',
+      'text'
+    )
+
+    expect(XMLValidator.validate(feed)).toBe(true)
+    expect(feed).toContain('<description>R &amp; D</description>')
+  })
+})

--- a/apps/status.app/src/app/_utils/news-feed.ts
+++ b/apps/status.app/src/app/_utils/news-feed.ts
@@ -1,6 +1,6 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 
-import { escapeUpstreamValues } from './feed-content'
+import { escapeUpstreamChannel } from './feed-content'
 import { GENERATED_ITEM_FIELDS, processItem } from './process-item'
 
 import type { FeedFormat } from './feed-content'
@@ -29,7 +29,7 @@ export function buildNewsFeed(body: string, format: FeedFormat): string {
       processItem(channel.item, format)
     }
 
-    escapeUpstreamValues(channel, GENERATED_ITEM_FIELDS)
+    escapeUpstreamChannel(channel, GENERATED_ITEM_FIELDS)
   }
 
   const builder = new XMLBuilder({

--- a/apps/status.app/src/app/_utils/news-feed.ts
+++ b/apps/status.app/src/app/_utils/news-feed.ts
@@ -1,7 +1,12 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 
 import { escapeUpstreamChannel } from './feed-content'
-import { GENERATED_ITEM_FIELDS, processItem } from './process-item'
+import {
+  GENERATED_ITEM_FIELDS,
+  NEWS_NAMESPACE_PREFIX,
+  NEWS_NAMESPACE_URI,
+  processItem,
+} from './process-item'
 
 import type { FeedFormat } from './feed-content'
 import type { X2jOptions } from 'fast-xml-parser'
@@ -21,6 +26,10 @@ export function buildNewsFeed(body: string, format: FeedFormat): string {
 
   const xml = parser.parse(body)
   const channel = xml.rss?.channel
+
+  if (xml.rss) {
+    xml.rss[`@_xmlns:${NEWS_NAMESPACE_PREFIX}`] = NEWS_NAMESPACE_URI
+  }
 
   if (channel) {
     if (Array.isArray(channel.item)) {

--- a/apps/status.app/src/app/_utils/news-feed.ts
+++ b/apps/status.app/src/app/_utils/news-feed.ts
@@ -1,0 +1,41 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+
+import { escapeUpstreamValues } from './feed-content'
+import { GENERATED_ITEM_FIELDS, processItem } from './process-item'
+
+import type { FeedFormat } from './feed-content'
+import type { X2jOptions } from 'fast-xml-parser'
+
+/**
+ * Rewrites a Ghost feed into the news feed the desktop and mobile clients
+ * consume. Ghost's CDATA wrappers are dropped on parse and entity processing is
+ * off in both directions, so nothing here can rely on the upstream escaping:
+ * every value the feed carries has to be escaped before it is rebuilt.
+ */
+export function buildNewsFeed(body: string, format: FeedFormat): string {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    processEntities: false,
+    htmlEntities: true,
+  } as X2jOptions)
+
+  const xml = parser.parse(body)
+  const channel = xml.rss?.channel
+
+  if (channel) {
+    if (Array.isArray(channel.item)) {
+      channel.item.forEach((item: any) => processItem(item, format))
+    } else if (channel.item) {
+      processItem(channel.item, format)
+    }
+
+    escapeUpstreamValues(channel, GENERATED_ITEM_FIELDS)
+  }
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    processEntities: false,
+  })
+
+  return builder.build(xml)
+}

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -1,3 +1,4 @@
+import { decodeXML } from 'entities'
 import { describe, expect, it } from 'vitest'
 
 import { processItem } from './process-item'
@@ -56,8 +57,8 @@ describe('processItem', () => {
     const item = process(GHOST.manuallyNumbered)
 
     expect(item.description).toBe(
-      "If you're migrating using a local backup:<br /><br />" +
-        '1\uFE0F Install v2.36.2<br />2\uFE0F Follow the official migration guide'
+      "If you're migrating using a local backup:&lt;br /&gt;&lt;br /&gt;" +
+        '1\uFE0F Install v2.36.2&lt;br /&gt;2\uFE0F Follow the official migration guide'
     )
     // The label is padded upstream; it must still be stripped from the body.
     expect(item.newsLinkLabel).toBe('Migrate your Status')
@@ -99,9 +100,22 @@ describe('processItem', () => {
 
     expect(item.description).toBe(
       'This release fixes:' +
-        '<ul><li>High CPU usage on Linux</li><li>Endless message loading</li></ul>'
+        '&lt;ul&gt;&lt;li&gt;High CPU usage on Linux&lt;/li&gt;' +
+        '&lt;li&gt;Endless message loading&lt;/li&gt;&lt;/ul&gt;'
     )
     expect(item.newsLink).toBe('https://status.app/')
+  })
+
+  it('hands the desktop client back its markup once decoded', () => {
+    const item = process(
+      '<p>Ada &amp; Co released:</p><ul><li>High CPU usage</li></ul>'
+    )
+
+    // status-go decodes the element with gofeed before the client sees it, so
+    // what arrives is the markup, with the body text still escaped for HTML.
+    expect(decodeXML(item.description ?? '')).toBe(
+      'Ada &amp; Co released:<ul><li>High CPU usage</li></ul>'
+    )
   })
 
   it('renders the mobile feed as plain text', () => {

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -32,8 +32,8 @@ const GHOST = {
 type FeedItem = {
   'content:encoded'?: string
   description?: string
-  newsLink?: string
-  newsLinkLabel?: string
+  'status:newsLink'?: string
+  'status:newsLinkLabel'?: string
 }
 
 function process(html: string, format: FeedFormat = 'html'): FeedItem {
@@ -46,8 +46,8 @@ describe('processItem', () => {
   it('lifts a Ghost button card into the feed link elements', () => {
     const item = process(GHOST.buttonCard)
 
-    expect(item.newsLink).toBe('https://status.app/')
-    expect(item.newsLinkLabel).toBe('Update your Status')
+    expect(item['status:newsLink']).toBe('https://status.app/')
+    expect(item['status:newsLinkLabel']).toBe('Update your Status')
     expect(item.description).toBe(
       'Fixes for high CPU and data usage overheating mobile devices.'
     )
@@ -61,16 +61,16 @@ describe('processItem', () => {
         '1\uFE0F Install v2.36.2&lt;br /&gt;2\uFE0F Follow the official migration guide'
     )
     // The label is padded upstream; it must still be stripped from the body.
-    expect(item.newsLinkLabel).toBe('Migrate your Status')
+    expect(item['status:newsLinkLabel']).toBe('Migrate your Status')
   })
 
   it('uses a trailing "Read more" link when there is no button card', () => {
     const item = process(GHOST.trailingReadMore)
 
-    expect(item.newsLink).toBe(
+    expect(item['status:newsLink']).toBe(
       'https://github.com/status-im/status-app/releases/tag/2.36.1'
     )
-    expect(item.newsLinkLabel).toBe('Read more')
+    expect(item['status:newsLinkLabel']).toBe('Read more')
     expect(item.description).toBe('Fixed a crash on the Home page.')
   })
 
@@ -78,8 +78,8 @@ describe('processItem', () => {
     const item = process(GHOST.leadingImage)
 
     expect(item['content:encoded']).toBe('Also moved to a new GIF provider.')
-    expect(item.newsLink).toBeUndefined()
-    expect(item.newsLinkLabel).toBeUndefined()
+    expect(item['status:newsLink']).toBeUndefined()
+    expect(item['status:newsLinkLabel']).toBeUndefined()
   })
 
   it('escapes an ampersand in the link target', () => {
@@ -87,8 +87,8 @@ describe('processItem', () => {
       '<p>Body</p><p><a href="https://status.app/x?a=1&amp;b=2">Read &amp; more</a></p>'
     )
 
-    expect(item.newsLink).toBe('https://status.app/x?a=1&amp;b=2')
-    expect(item.newsLinkLabel).toBe('Read &amp; more')
+    expect(item['status:newsLink']).toBe('https://status.app/x?a=1&amp;b=2')
+    expect(item['status:newsLinkLabel']).toBe('Read &amp; more')
   })
 
   it('renders a bullet list end to end', () => {
@@ -103,7 +103,7 @@ describe('processItem', () => {
         '&lt;ul&gt;&lt;li&gt;High CPU usage on Linux&lt;/li&gt;' +
         '&lt;li&gt;Endless message loading&lt;/li&gt;&lt;/ul&gt;'
     )
-    expect(item.newsLink).toBe('https://status.app/')
+    expect(item['status:newsLink']).toBe('https://status.app/')
   })
 
   it('hands the desktop client back its markup once decoded', () => {

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -56,8 +56,8 @@ describe('processItem', () => {
     const item = process(GHOST.manuallyNumbered)
 
     expect(item.description).toBe(
-      'If you&apos;re migrating using a local backup:<br /><br />' +
-        '1&#xFE0F; Install v2.36.2<br />2&#xFE0F; Follow the official migration guide'
+      "If you're migrating using a local backup:<br /><br />" +
+        '1\uFE0F Install v2.36.2<br />2\uFE0F Follow the official migration guide'
     )
     // The label is padded upstream; it must still be stripped from the body.
     expect(item.newsLinkLabel).toBe('Migrate your Status')
@@ -120,8 +120,8 @@ describe('processItem', () => {
     const item = process(GHOST.manuallyNumbered, 'text')
 
     expect(item.description).toBe(
-      'If you&apos;re migrating using a local backup:\n\n' +
-        '1&#xFE0F; Install v2.36.2\n2&#xFE0F; Follow the official migration guide'
+      "If you're migrating using a local backup:\n\n" +
+        '1\uFE0F Install v2.36.2\n2\uFE0F Follow the official migration guide'
     )
   })
 

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import { processItem } from './process-item'
 
+import type { FeedFormat } from './feed-content'
+
 /**
  * Markup taken verbatim from https://our.status.im/tag/desktop-news/rss/ so the
  * shapes Ghost actually produces stay covered.
@@ -33,9 +35,9 @@ type FeedItem = {
   newsLinkLabel?: string
 }
 
-function process(html: string): FeedItem {
+function process(html: string, format: FeedFormat = 'html'): FeedItem {
   const item: FeedItem = { 'content:encoded': html, description: html }
-  processItem(item)
+  processItem(item, format)
   return item
 }
 
@@ -102,9 +104,30 @@ describe('processItem', () => {
     expect(item.newsLink).toBe('https://status.app/')
   })
 
+  it('renders the mobile feed as plain text', () => {
+    const item = process(
+      '<p>This release fixes:</p>' +
+        '<ul><li>High CPU usage on Linux</li><li>Endless message loading</li></ul>',
+      'text'
+    )
+
+    expect(item.description).toBe(
+      'This release fixes:\n\n• High CPU usage on Linux\n• Endless message loading'
+    )
+  })
+
+  it('keeps the mobile feed free of markup for the manually numbered post', () => {
+    const item = process(GHOST.manuallyNumbered, 'text')
+
+    expect(item.description).toBe(
+      'If you&apos;re migrating using a local backup:\n\n' +
+        '1&#xFE0F; Install v2.36.2\n2&#xFE0F; Follow the official migration guide'
+    )
+  })
+
   it('tolerates items without content', () => {
     const item: FeedItem = {}
-    processItem(item)
+    processItem(item, 'html')
 
     expect(item.description).toBe('')
     expect(item['content:encoded']).toBe('')

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { processItem } from './process-item'
+
+/**
+ * Markup taken verbatim from https://our.status.im/tag/desktop-news/rss/ so the
+ * shapes Ghost actually produces stay covered.
+ */
+const GHOST = {
+  buttonCard:
+    '<p>Fixes for high CPU and data usage overheating mobile devices. </p>' +
+    '<div class="kg-card kg-button-card kg-align-center">' +
+    '<a href="https://status.app/" class="kg-btn kg-btn-accent">Update your Status</a>' +
+    '</div>',
+  manuallyNumbered:
+    '<p>If you&apos;re migrating using a local backup:</p>' +
+    '<p>1&#xFE0F; Install v2.36.2<br>2&#xFE0F; Follow the official migration guide</p>' +
+    '<div class="kg-card kg-button-card kg-align-center">' +
+    '<a href="https://status.app/blog/migrate" class="kg-btn kg-btn-accent"> Migrate your Status</a>' +
+    '</div>',
+  trailingReadMore:
+    '<p>Fixed a crash on the Home page.</p>' +
+    '<p><a href="https://github.com/status-im/status-app/releases/tag/2.36.1" rel="noreferrer">Read more</a></p>',
+  leadingImage:
+    '<img src="https://our.status.im/content/images/hero.png" alt="Status v2.38.2 is Here!">' +
+    '<p>Also moved to a new GIF provider.</p>',
+}
+
+type FeedItem = {
+  'content:encoded'?: string
+  description?: string
+  newsLink?: string
+  newsLinkLabel?: string
+}
+
+function process(html: string): FeedItem {
+  const item: FeedItem = { 'content:encoded': html, description: html }
+  processItem(item)
+  return item
+}
+
+describe('processItem', () => {
+  it('lifts a Ghost button card into the feed link elements', () => {
+    const item = process(GHOST.buttonCard)
+
+    expect(item.newsLink).toBe('https://status.app/')
+    expect(item.newsLinkLabel).toBe('Update your Status')
+    expect(item.description).toBe(
+      'Fixes for high CPU and data usage overheating mobile devices.'
+    )
+  })
+
+  it('keeps manually numbered lines on separate lines', () => {
+    const item = process(GHOST.manuallyNumbered)
+
+    expect(item.description).toBe(
+      'If you&apos;re migrating using a local backup:<br /><br />' +
+        '1&#xFE0F; Install v2.36.2<br />2&#xFE0F; Follow the official migration guide'
+    )
+    // The label is padded upstream; it must still be stripped from the body.
+    expect(item.newsLinkLabel).toBe('Migrate your Status')
+  })
+
+  it('uses a trailing "Read more" link when there is no button card', () => {
+    const item = process(GHOST.trailingReadMore)
+
+    expect(item.newsLink).toBe(
+      'https://github.com/status-im/status-app/releases/tag/2.36.1'
+    )
+    expect(item.newsLinkLabel).toBe('Read more')
+    expect(item.description).toBe('Fixed a crash on the Home page.')
+  })
+
+  it('drops the lead image Ghost puts in content:encoded', () => {
+    const item = process(GHOST.leadingImage)
+
+    expect(item['content:encoded']).toBe('Also moved to a new GIF provider.')
+    expect(item.newsLink).toBeUndefined()
+    expect(item.newsLinkLabel).toBeUndefined()
+  })
+
+  it('escapes an ampersand in the link target', () => {
+    const item = process(
+      '<p>Body</p><p><a href="https://status.app/x?a=1&amp;b=2">Read &amp; more</a></p>'
+    )
+
+    expect(item.newsLink).toBe('https://status.app/x?a=1&amp;b=2')
+    expect(item.newsLinkLabel).toBe('Read &amp; more')
+  })
+
+  it('renders a bullet list end to end', () => {
+    const item = process(
+      '<p>This release fixes:</p>' +
+        '<ul><li>High CPU usage on Linux</li><li>Endless message loading</li></ul>' +
+        '<div class="kg-card kg-button-card"><a href="https://status.app/" class="kg-btn">Update</a></div>'
+    )
+
+    expect(item.description).toBe(
+      'This release fixes:' +
+        '<ul><li>High CPU usage on Linux</li><li>Endless message loading</li></ul>'
+    )
+    expect(item.newsLink).toBe('https://status.app/')
+  })
+
+  it('tolerates items without content', () => {
+    const item: FeedItem = {}
+    processItem(item)
+
+    expect(item.description).toBe('')
+    expect(item['content:encoded']).toBe('')
+  })
+})

--- a/apps/status.app/src/app/_utils/process-item.ts
+++ b/apps/status.app/src/app/_utils/process-item.ts
@@ -1,4 +1,8 @@
-import { escapeFeedText, renderFeedContent } from './feed-content'
+import {
+  escapeFeedText,
+  renderFeedContent,
+  serializeFeedBody,
+} from './feed-content'
 
 import type { FeedFormat } from './feed-content'
 
@@ -17,6 +21,6 @@ export function processItem(item: any, format: FeedFormat) {
 
   item.newsLink = link ? escapeFeedText(link.href) : undefined
   item.newsLinkLabel = link ? escapeFeedText(link.label) : undefined
-  item['content:encoded'] = content.body
-  item.description = description.body
+  item['content:encoded'] = serializeFeedBody(content.body, format)
+  item.description = serializeFeedBody(description.body, format)
 }

--- a/apps/status.app/src/app/_utils/process-item.ts
+++ b/apps/status.app/src/app/_utils/process-item.ts
@@ -1,5 +1,13 @@
 import { escapeFeedText, renderFeedContent } from './feed-content'
 
+/** Fields this module rewrites; their markup must not be escaped again. */
+export const GENERATED_ITEM_FIELDS: ReadonlySet<string> = new Set([
+  'content:encoded',
+  'description',
+  'newsLink',
+  'newsLinkLabel',
+])
+
 export function processItem(item: any) {
   const content = renderFeedContent(item['content:encoded'] ?? '')
   const description = renderFeedContent(item.description ?? '')

--- a/apps/status.app/src/app/_utils/process-item.ts
+++ b/apps/status.app/src/app/_utils/process-item.ts
@@ -1,33 +1,12 @@
-function stripHtml(content: string, lineBreak: string) {
-  return content
-    .split(/<\/p>/i)
-    .map((part: string) => part.replace(/<[^>]+>/g, '').trim())
-    .filter(
-      (part: string, index: number, arr: string[]) =>
-        part || index < arr.length - 1
-    )
-    .join(lineBreak)
-}
+import { escapeFeedText, renderFeedContent } from './feed-content'
 
-function processField(item: any, field: string, lineBreak: string) {
-  let content = stripHtml(item[field], lineBreak)
-  if (item.newsLinkLabel) {
-    content = content.replace(item.newsLinkLabel, '')
-  }
-  if (content.endsWith(lineBreak)) {
-    content = content.slice(0, -lineBreak.length)
-  }
+export function processItem(item: any) {
+  const content = renderFeedContent(item['content:encoded'] ?? '')
+  const description = renderFeedContent(item.description ?? '')
+  const link = content.link ?? description.link
 
-  return content
-}
-
-export function processItem(item: any, lineBreak: string) {
-  const newsLink = item['content:encoded'].match(
-    /<a[^>]*href="([^"]+)"[^>]*>([^<]*)<\/a>/
-  )
-  item.newsLink = newsLink?.[1]
-  item.newsLinkLabel = newsLink?.[2]
-
-  item['content:encoded'] = processField(item, 'content:encoded', lineBreak)
-  item.description = processField(item, 'description', lineBreak)
+  item.newsLink = link ? escapeFeedText(link.href) : undefined
+  item.newsLinkLabel = link ? escapeFeedText(link.label) : undefined
+  item['content:encoded'] = content.html
+  item.description = description.html
 }

--- a/apps/status.app/src/app/_utils/process-item.ts
+++ b/apps/status.app/src/app/_utils/process-item.ts
@@ -1,5 +1,7 @@
 import { escapeFeedText, renderFeedContent } from './feed-content'
 
+import type { FeedFormat } from './feed-content'
+
 /** Fields this module rewrites; their markup must not be escaped again. */
 export const GENERATED_ITEM_FIELDS: ReadonlySet<string> = new Set([
   'content:encoded',
@@ -8,13 +10,13 @@ export const GENERATED_ITEM_FIELDS: ReadonlySet<string> = new Set([
   'newsLinkLabel',
 ])
 
-export function processItem(item: any) {
-  const content = renderFeedContent(item['content:encoded'] ?? '')
-  const description = renderFeedContent(item.description ?? '')
+export function processItem(item: any, format: FeedFormat) {
+  const content = renderFeedContent(item['content:encoded'] ?? '', format)
+  const description = renderFeedContent(item.description ?? '', format)
   const link = content.link ?? description.link
 
   item.newsLink = link ? escapeFeedText(link.href) : undefined
   item.newsLinkLabel = link ? escapeFeedText(link.label) : undefined
-  item['content:encoded'] = content.html
-  item.description = description.html
+  item['content:encoded'] = content.body
+  item.description = description.body
 }

--- a/apps/status.app/src/app/_utils/process-item.ts
+++ b/apps/status.app/src/app/_utils/process-item.ts
@@ -6,12 +6,24 @@ import {
 
 import type { FeedFormat } from './feed-content'
 
+/**
+ * The call-to-action has no RSS 2.0 equivalent, so it is carried in a namespace
+ * of ours. RSS 2.0 rejects an extension element that has no namespace, and
+ * gofeed reads a namespaced one from `item.Extensions` rather than
+ * `item.Custom`, so status-go has to be updated in step with this prefix.
+ */
+export const NEWS_NAMESPACE_PREFIX = 'status'
+export const NEWS_NAMESPACE_URI = 'https://status.app/ns/rss/1.0'
+
+const LINK_FIELD = `${NEWS_NAMESPACE_PREFIX}:newsLink`
+const LINK_LABEL_FIELD = `${NEWS_NAMESPACE_PREFIX}:newsLinkLabel`
+
 /** Fields this module rewrites; their markup must not be escaped again. */
 export const GENERATED_ITEM_FIELDS: ReadonlySet<string> = new Set([
   'content:encoded',
   'description',
-  'newsLink',
-  'newsLinkLabel',
+  LINK_FIELD,
+  LINK_LABEL_FIELD,
 ])
 
 export function processItem(item: any, format: FeedFormat) {
@@ -19,8 +31,8 @@ export function processItem(item: any, format: FeedFormat) {
   const description = renderFeedContent(item.description ?? '', format)
   const link = content.link ?? description.link
 
-  item.newsLink = link ? escapeFeedText(link.href) : undefined
-  item.newsLinkLabel = link ? escapeFeedText(link.label) : undefined
+  item[LINK_FIELD] = link ? escapeFeedText(link.href) : undefined
+  item[LINK_LABEL_FIELD] = link ? escapeFeedText(link.label) : undefined
   item['content:encoded'] = serializeFeedBody(content.body, format)
   item.description = serializeFeedBody(description.body, format)
 }

--- a/apps/status.app/src/app/_utils/rss-handler.ts
+++ b/apps/status.app/src/app/_utils/rss-handler.ts
@@ -1,7 +1,8 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 
 import { clientEnv } from '~/config/env.client.mjs'
-import { processItem } from '~app/_utils/process-item'
+import { escapeUpstreamValues } from '~app/_utils/feed-content'
+import { GENERATED_ITEM_FIELDS, processItem } from '~app/_utils/process-item'
 import { baseUrl } from '~website/_lib/base-url'
 
 import type { X2jOptions } from 'fast-xml-parser'
@@ -64,6 +65,10 @@ export async function handleRssFeed(type: FeedType) {
         xml.rss.channel.item.forEach((item: any) => processItem(item))
       } else {
         processItem(xml.rss.channel.item)
+      }
+
+      if (type !== 'main') {
+        escapeUpstreamValues(xml.rss.channel, GENERATED_ITEM_FIELDS)
       }
     }
 

--- a/apps/status.app/src/app/_utils/rss-handler.ts
+++ b/apps/status.app/src/app/_utils/rss-handler.ts
@@ -5,24 +5,28 @@ import { escapeUpstreamValues } from '~app/_utils/feed-content'
 import { GENERATED_ITEM_FIELDS, processItem } from '~app/_utils/process-item'
 import { baseUrl } from '~website/_lib/base-url'
 
+import type { FeedFormat } from '~app/_utils/feed-content'
 import type { X2jOptions } from 'fast-xml-parser'
 
 const FEED = {
   'desktop-news': {
+    format: 'html',
     path: '/tag/desktop-news/rss/',
   },
   'mobile-news': {
+    format: 'text',
     path: '/tag/mobile-news/rss/',
   },
   main: {
+    format: 'html',
     path: '/rss/',
   },
-} as const
+} as const satisfies Record<string, { format: FeedFormat; path: string }>
 
 type FeedType = keyof typeof FEED
 
 export async function handleRssFeed(type: FeedType) {
-  const { path } = FEED[type]
+  const { format, path } = FEED[type]
 
   try {
     const response = await fetch(
@@ -62,9 +66,9 @@ export async function handleRssFeed(type: FeedType) {
           )
         })
       } else if (Array.isArray(xml.rss.channel.item)) {
-        xml.rss.channel.item.forEach((item: any) => processItem(item))
+        xml.rss.channel.item.forEach((item: any) => processItem(item, format))
       } else {
-        processItem(xml.rss.channel.item)
+        processItem(xml.rss.channel.item, format)
       }
 
       if (type !== 'main') {

--- a/apps/status.app/src/app/_utils/rss-handler.ts
+++ b/apps/status.app/src/app/_utils/rss-handler.ts
@@ -1,8 +1,7 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 
 import { clientEnv } from '~/config/env.client.mjs'
-import { escapeUpstreamValues } from '~app/_utils/feed-content'
-import { GENERATED_ITEM_FIELDS, processItem } from '~app/_utils/process-item'
+import { buildNewsFeed } from '~app/_utils/news-feed'
 import { baseUrl } from '~website/_lib/base-url'
 
 import type { FeedFormat } from '~app/_utils/feed-content'
@@ -43,46 +42,8 @@ export async function handleRssFeed(type: FeedType) {
     }
 
     const body = await response.text()
-    const parser = new XMLParser({
-      ignoreAttributes: false,
-      processEntities: false,
-      htmlEntities: true,
-      cdataPropName: type === 'main' ? '__cdata' : undefined,
-    } as X2jOptions)
-
-    const xml = parser.parse(body)
-
-    if (xml.rss?.channel?.item) {
-      if (type === 'main') {
-        xml.rss.channel.item = xml.rss.channel.item.filter(
-          (item: any) =>
-            !item.category?.__cdata?.includes('Desktop news') &&
-            !item.category?.__cdata?.includes('Mobile news')
-        )
-        xml.rss.channel.item.forEach((item: any) => {
-          item.link = item.link.replace(
-            `${clientEnv.NEXT_PUBLIC_GHOST_API_URL}`,
-            `${baseUrl()}/blog`
-          )
-        })
-      } else if (Array.isArray(xml.rss.channel.item)) {
-        xml.rss.channel.item.forEach((item: any) => processItem(item, format))
-      } else {
-        processItem(xml.rss.channel.item, format)
-      }
-
-      if (type !== 'main') {
-        escapeUpstreamValues(xml.rss.channel, GENERATED_ITEM_FIELDS)
-      }
-    }
-
-    const builder = new XMLBuilder({
-      ignoreAttributes: false,
-      processEntities: false,
-      cdataPropName: type === 'main' ? '__cdata' : undefined,
-    })
-
-    const newXml = builder.build(xml)
+    const newXml =
+      type === 'main' ? buildBlogFeed(body) : buildNewsFeed(body, format)
 
     return new Response(newXml, {
       headers: {
@@ -99,4 +60,42 @@ export async function handleRssFeed(type: FeedType) {
       },
     })
   }
+}
+
+/**
+ * Drops the posts the clients receive through the news feeds and points the
+ * remaining ones at the blog. Ghost's CDATA wrappers are kept, so its markup
+ * and escaping are served back untouched.
+ */
+function buildBlogFeed(body: string): string {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    processEntities: false,
+    htmlEntities: true,
+    cdataPropName: '__cdata',
+  } as X2jOptions)
+
+  const xml = parser.parse(body)
+
+  if (xml.rss?.channel?.item) {
+    xml.rss.channel.item = xml.rss.channel.item.filter(
+      (item: any) =>
+        !item.category?.__cdata?.includes('Desktop news') &&
+        !item.category?.__cdata?.includes('Mobile news')
+    )
+    xml.rss.channel.item.forEach((item: any) => {
+      item.link = item.link.replace(
+        `${clientEnv.NEXT_PUBLIC_GHOST_API_URL}`,
+        `${baseUrl()}/blog`
+      )
+    })
+  }
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    processEntities: false,
+    cdataPropName: '__cdata',
+  })
+
+  return builder.build(xml)
 }

--- a/apps/status.app/src/app/_utils/rss-handler.ts
+++ b/apps/status.app/src/app/_utils/rss-handler.ts
@@ -8,15 +8,12 @@ import type { X2jOptions } from 'fast-xml-parser'
 
 const FEED = {
   'desktop-news': {
-    lineBreak: '<br /><br />',
     path: '/tag/desktop-news/rss/',
   },
   'mobile-news': {
-    lineBreak: '\n\n',
     path: '/tag/mobile-news/rss/',
   },
   main: {
-    lineBreak: '',
     path: '/rss/',
   },
 } as const
@@ -24,7 +21,7 @@ const FEED = {
 type FeedType = keyof typeof FEED
 
 export async function handleRssFeed(type: FeedType) {
-  const { path, lineBreak } = FEED[type]
+  const { path } = FEED[type]
 
   try {
     const response = await fetch(
@@ -64,11 +61,9 @@ export async function handleRssFeed(type: FeedType) {
           )
         })
       } else if (Array.isArray(xml.rss.channel.item)) {
-        xml.rss.channel.item.forEach((item: any) =>
-          processItem(item, lineBreak)
-        )
+        xml.rss.channel.item.forEach((item: any) => processItem(item))
       } else {
-        processItem(xml.rss.channel.item, lineBreak)
+        processItem(xml.rss.channel.item)
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1645,6 +1645,9 @@ importers:
       emoji-datasource-twitter:
         specifier: ^15.1.2
         version: 15.1.2
+      entities:
+        specifier: ^8.0.0
+        version: 8.0.0
       fast-xml-parser:
         specifier: ^5.2.2
         version: 5.3.1
@@ -14430,6 +14433,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -42604,6 +42611,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 


### PR DESCRIPTION
Ghost HTML was split on `</p>` and stripped of every other tag, so `<li>` text was concatenated into one run:

```
<ul><li>High CPU usage</li><li>Endless loading</li></ul> -> High CPU usageEndless loading
```

The feed now parses the markup into blocks and emits `<ul>`/`<ol>`/`<li>` with nesting.

Also in scope:
- `<br>` inside a paragraph is preserved instead of dropped.
- The CTA link is extracted structurally: a link inside a bullet can no longer replace it, and its label no longer leaks into the body (the old `content.replace(label, '')` failed whenever Ghost padded the label).
- Ghost-supplied values are escaped. Their CDATA wrappers are dropped on parse, so a bare `&` in a title was re-served as invalid XML -- `/mobile-news/rss` is currently malformed on production.
- `apps/status.app` had test files but no `test` script, so `turbo run test` skipped them. Now wired up: 39 tests.

#### How to test

The live Ghost feed contains no list markup right now, so the lists cannot be exercised against real data. The check below stands up a fake Ghost that serves one item with a nested list, a `<br>`, a CTA button, and a bare `&`/`<beta>` in the title -- all CDATA-wrapped the way Ghost really does it. Anything that is not a tag RSS path is proxied to `demo.ghost.io`, so `predev:next`'s blog-search generator still gets real Content API JSON and `pnpm dev` starts normally.

1. Save this as `fake-ghost.py` outside the repo and run it (`python3 "fake-ghost.py"`):

```python
"""Serves a Ghost-shaped RSS feed containing bullet lists, a nested list,
a <br>, and XML-hostile characters in the title. Point
NEXT_PUBLIC_GHOST_API_URL at this server to exercise /desktop-news/rss
and /mobile-news/rss without touching our.status.im."""

import urllib.error
import urllib.request
from http.server import BaseHTTPRequestHandler, HTTPServer

# Everything that isn't a tag RSS path is proxied here, so predev:next's
# blog-search generator still gets real Content API JSON.
UPSTREAM = "https://demo.ghost.io"

BODY = """<?xml version="1.0" encoding="UTF-8"?>
<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
<channel>
<title><![CDATA[Desktop news - Our Status]]></title>
<description><![CDATA[Research &amp; Development at Status]]></description>
<link>https://our.status.im/</link>
<atom:link href="http://127.0.0.1:8099/tag/desktop-news/rss/" rel="self" type="application/rss+xml"/>
<item>
<title><![CDATA[Status v2.38.2: fixes & tweaks <beta>]]></title>
<description><![CDATA[<p>Fixes &amp; improvements:<br>shipped today.</p><ul><li>High CPU usage</li><li>Endless loading, see the <a href="https://wikipedia.org/">test link</a> for details<ol><li>in communities</li><li>on iOS</li></ol></li><li><a href="https://wikipedia.org/wiki/RSS">RSS on Wikipedia</a></li></ul><p>Thanks for testing.</p><div class="kg-card kg-button-card"><a href="https://status.app/" class="kg-btn kg-btn-accent">Update your Status</a></div>]]></description>
<link>https://our.status.im/status-v2-38-2-is-here/</link>
<guid isPermaLink="false">6a5f5210834292000196a904</guid>
<category><![CDATA[Desktop news]]></category>
<dc:creator><![CDATA[Bobby Zalke]]></dc:creator>
<pubDate>Tue, 21 Jul 2026 11:19:19 GMT</pubDate>
<content:encoded><![CDATA[<p>Fixes &amp; improvements:<br>shipped today.</p><ul><li>High CPU usage</li><li>Endless loading, see the <a href="https://wikipedia.org/">test link</a> for details<ol><li>in communities</li><li>on iOS</li></ol></li><li><a href="https://wikipedia.org/wiki/RSS">RSS on Wikipedia</a></li></ul><p>Thanks for testing.</p><div class="kg-card kg-button-card"><a href="https://status.app/" class="kg-btn kg-btn-accent">Update your Status</a></div>]]></content:encoded>
</item>
</channel>
</rss>
""".encode("utf-8")


class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        if self.path.startswith("/tag/") and "/rss" in self.path:
            self.send_response(200)
            self.send_header("content-type", "application/rss+xml; charset=utf-8")
            self.send_header("content-length", str(len(BODY)))
            self.end_headers()
            self.wfile.write(BODY)
            return

        try:
            with urllib.request.urlopen(UPSTREAM + self.path, timeout=30) as up:
                payload, status = up.read(), up.status
                ctype = up.headers.get("content-type", "application/json")
        except urllib.error.HTTPError as err:
            payload, status = err.read(), err.code
            ctype = err.headers.get("content-type", "application/json")

        self.send_response(status)
        self.send_header("content-type", ctype)
        self.send_header("content-length", str(len(payload)))
        self.end_headers()
        self.wfile.write(payload)

    def log_message(self, *args):
        pass


print("fake Ghost on http://127.0.0.1:8099")
HTTPServer(("127.0.0.1", 8099), Handler).serve_forever()
```

2. Start dev pointed at it:

```bash
NEXT_PUBLIC_GHOST_API_URL=http://127.0.0.1:8099 pnpm dev
```

3. Fetch the feed and validate it:

```bash
curl -s http://localhost:3001/desktop-news/rss | python3 -c "import sys,xml.dom.minidom as m; s=sys.stdin.read(); m.parseString(s); print('XML: VALID'); i=s.index('<item>'); print(s[i:s.index('</item>')+7])"
```

Expected on this branch -- valid XML, nested lists, escaped title, CTA lifted into `newsLink`:

```
XML: VALID
<item><title>Status v2.38.2: fixes &amp; tweaks &lt;beta&gt;</title><description>Fixes &amp;amp; improvements:&lt;br /&gt;shipped today.&lt;ul&gt;&lt;li&gt;High CPU usage&lt;/li&gt;&lt;li&gt;Endless loading, see the test link for details&lt;ol&gt;&lt;li&gt;in communities&lt;/li&gt;&lt;li&gt;on iOS&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;li&gt;RSS on Wikipedia&lt;/li&gt;&lt;/ul&gt;Thanks for testing.</description><link>https://our.status.im/status-v2-38-2-is-here/</link><guid isPermaLink="false">6a5f5210834292000196a904</guid><category>Desktop news</category><dc:creator>Bobby Zalke</dc:creator><pubDate>Tue, 21 Jul 2026 11:19:19 GMT</pubDate><content:encoded>Fixes &amp;amp; improvements:&lt;br /&gt;shipped today.&lt;ul&gt;&lt;li&gt;High CPU usage&lt;/li&gt;&lt;li&gt;Endless loading, see the test link for details&lt;ol&gt;&lt;li&gt;in communities&lt;/li&gt;&lt;li&gt;on iOS&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;li&gt;RSS on Wikipedia&lt;/li&gt;&lt;/ul&gt;Thanks for testing.</content:encoded><status:newsLink>https://status.app/</status:newsLink><status:newsLinkLabel>Update your Status</status:newsLinkLabel></item>
```
