### PR TITLE
fix(status.app): improve mobile core web vitals

### DIFF
--- a/.changeset/mobile-core-web-vitals.md
+++ b/.changeset/mobile-core-web-vitals.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+fix(status.app): restore static rendering and defer the help search index

--- a/apps/status.app/src/app/(website)/(content)/_components/fullscreen-search-dialog.tsx
+++ b/apps/status.app/src/app/(website)/(content)/_components/fullscreen-search-dialog.tsx
@@ -37,7 +37,7 @@ export const FullscreenSearchDialog = (props: Props) => {
 
   const tc = useTranslations('common')
   const t = useTranslations('help')
-  const { query, results } = useSearchEngine(type)
+  const { query, results } = useSearchEngine(type, { enabled: open })
   const [value, setValue] = useState('')
 
   useEffect(() => {

--- a/apps/status.app/src/app/(website)/(content)/_hooks/use-search-engine.ts
+++ b/apps/status.app/src/app/(website)/(content)/_hooks/use-search-engine.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import MiniSearch from 'minisearch'
 
@@ -49,58 +49,108 @@ type SearchDoc = {
 
 const SEARCH_RESULTS_LIMIT = 50
 
-export const useSearchEngine = (
-  type: SearchType,
-  limit = SEARCH_RESULTS_LIMIT
-) => {
-  const [engine] = useState<Promise<MiniSearch<SearchDoc>>>(async () => {
-    const miniSearch = new MiniSearch<SearchDoc>({
-      fields: ['title', 'heading', 'text'], // fields to index for full-text search
-      storeFields: ['title', 'heading', 'text', 'path'], // fields to return with search results
-      searchOptions: {
-        boost: { title: 2 },
-        fuzzy: 0.2,
-        prefix: true,
-      },
-    })
+/**
+ * Deadline for the idle callback that warms the index, so the build still
+ * happens promptly on browsers that stay busy after the dialog opens.
+ */
+const ENGINE_WARMUP_TIMEOUT_MS = 500
 
-    if (typeof window === 'undefined') {
-      return miniSearch
-    }
+const loadDocIndex = async (type: SearchType): Promise<DocIndex[]> => {
+  switch (type) {
+    case 'help':
+      return (await import('../../../../../.contentlayer/en.json'))
+        .default as unknown as DocIndex[]
+    case 'specs':
+      return (await import('../../../../../.contentlayer/specs.en.json'))
+        .default as unknown as DocIndex[]
+  }
+}
 
-    let docIndex: DocIndex[]
-    switch (type) {
-      case 'help':
-        docIndex = (await import('../../../../../.contentlayer/en.json'))
-          .default as unknown as DocIndex[]
-        break
-      case 'specs':
-        docIndex = (await import('../../../../../.contentlayer/specs.en.json'))
-          .default as unknown as DocIndex[]
-        break
-    }
+const createSearchEngine = async (
+  type: SearchType
+): Promise<MiniSearch<SearchDoc>> => {
+  const miniSearch = new MiniSearch<SearchDoc>({
+    fields: ['title', 'heading', 'text'], // fields to index for full-text search
+    storeFields: ['title', 'heading', 'text', 'path'], // fields to return with search results
+    searchOptions: {
+      boost: { title: 2 },
+      fuzzy: 0.2,
+      prefix: true,
+    },
+  })
 
-    const docs: SearchDoc[] = []
-    let id = 0
+  if (typeof window === 'undefined') {
+    return miniSearch
+  }
 
-    for (const item of docIndex!) {
-      for (const [heading, texts] of Object.entries(item.content)) {
-        for (const text of texts) {
-          docs.push({
-            id: id++,
-            title: item.title,
-            path: item.path,
-            heading,
-            text,
-          })
-        }
+  const docIndex = await loadDocIndex(type)
+
+  const docs: SearchDoc[] = []
+  let id = 0
+
+  for (const item of docIndex) {
+    for (const [heading, texts] of Object.entries(item.content)) {
+      for (const text of texts) {
+        docs.push({
+          id: id++,
+          title: item.title,
+          path: item.path,
+          heading,
+          text,
+        })
       }
     }
+  }
 
-    miniSearch.addAll(docs)
+  miniSearch.addAll(docs)
 
-    return miniSearch
+  return miniSearch
+}
+
+const whenIdle = (callback: () => void): (() => void) => {
+  if (typeof window.requestIdleCallback !== 'function') {
+    const timeoutId = window.setTimeout(callback, 0)
+    return () => window.clearTimeout(timeoutId)
+  }
+
+  const handle = window.requestIdleCallback(callback, {
+    timeout: ENGINE_WARMUP_TIMEOUT_MS,
   })
+  return () => window.cancelIdleCallback(handle)
+}
+
+type Options = {
+  /**
+   * Whether the index may be built. The doc index is ~540KB and indexing it
+   * blocks the main thread for hundreds of milliseconds on mobile, so callers
+   * enable it only once the user reaches for search — never on page load.
+   */
+  enabled?: boolean
+  limit?: number
+}
+
+export const useSearchEngine = (type: SearchType, options: Options = {}) => {
+  const { enabled = true, limit = SEARCH_RESULTS_LIMIT } = options
+
+  const engineRef = useRef<Promise<MiniSearch<SearchDoc>> | null>(null)
+
+  const loadEngine = useCallback((): Promise<MiniSearch<SearchDoc>> => {
+    engineRef.current ??= createSearchEngine(type)
+
+    return engineRef.current
+  }, [type])
+
+  // Warm the index once search is reachable, but off the interaction that
+  // opened it, so building it never delays the dialog's first paint.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    return whenIdle(() => {
+      void loadEngine()
+    })
+  }, [enabled, loadEngine])
 
   const [results, setResults] = useState<Result[]>([])
 
@@ -113,7 +163,7 @@ export const useSearchEngine = (
         return
       }
 
-      const searchResults = (await engine)
+      const searchResults = (await loadEngine())
         .search(normalizedTerm)
         .slice(0, limit) as SearchResult[]
 
@@ -220,7 +270,7 @@ export const useSearchEngine = (
 
       setResults(results)
     },
-    [engine, limit]
+    [loadEngine, limit]
   )
 
   return { results, query } as const

--- a/apps/status.app/src/app/(website)/(content)/help/(sidebar)/[...slug]/page.tsx
+++ b/apps/status.app/src/app/(website)/(content)/help/(sidebar)/[...slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/utils/structured-data'
 import { Metadata } from '~app/_metadata'
 import { formatDate } from '~app/_utils/format-time'
+import { getGithubAvatarUrl } from '~app/_utils/github-avatar'
 import { isHelpDocWorkInProgress } from '~app/_utils/help-doc'
 import { Icon } from '~components/assets'
 import { Breadcrumbs } from '~components/breadcrumbs'
@@ -83,6 +84,8 @@ type Props = {
 }
 
 const MAX_VISIBLE_AUTHORS = 4
+/** Matches the `size="20"` token the author avatars render at. */
+const AVATAR_SIZE = 20
 
 export default async function HelpDetailPage(props: Props) {
   const { params } = props
@@ -162,7 +165,7 @@ export default async function HelpDetailPage(props: Props) {
                     type="user"
                     size="20"
                     name={mainAuthor || ''}
-                    src={`https://github.com/${mainAuthor}.png`}
+                    src={getGithubAvatarUrl(mainAuthor, AVATAR_SIZE)}
                   />
                   <Text size={15} weight="semibold">
                     {mainAuthor}
@@ -193,7 +196,7 @@ export default async function HelpDetailPage(props: Props) {
                               type="user"
                               size="20"
                               name={author}
-                              src={`https://github.com/${author}.png`}
+                              src={getGithubAvatarUrl(author, AVATAR_SIZE)}
                             />
                           </div>
                         </Link>
@@ -299,7 +302,10 @@ export default async function HelpDetailPage(props: Props) {
                           type="user"
                           size="20"
                           name={doc.lastEditedAuthor.githubUsername}
-                          src={`https://github.com/${doc.lastEditedAuthor.githubUsername}.png`}
+                          src={getGithubAvatarUrl(
+                            doc.lastEditedAuthor.githubUsername,
+                            AVATAR_SIZE
+                          )}
                         />
                         <Text size={15} weight="semibold">
                           {doc.lastEditedAuthor.githubUsername}

--- a/apps/status.app/src/app/[locale]/layout.tsx
+++ b/apps/status.app/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import { hasLocale } from 'next-intl'
+import { setRequestLocale } from 'next-intl/server'
 
 import { routing } from '~/i18n/routing'
 
@@ -20,6 +21,10 @@ export default async function LocaleLayout({ children, params }: Props) {
   if (!hasLocale(routing.locales, locale)) {
     notFound()
   }
+
+  // Keeps next-intl on the route param instead of `headers()` so this subtree
+  // can be prerendered. why: https://next-intl.dev/docs/getting-started/app-router
+  setRequestLocale(locale)
 
   return children
 }

--- a/apps/status.app/src/app/_utils/github-avatar.ts
+++ b/apps/status.app/src/app/_utils/github-avatar.ts
@@ -1,0 +1,16 @@
+/**
+ * GitHub serves `https://github.com/<user>.png` at full resolution — around
+ * 45KB per avatar — no matter how small it is rendered. Asking for an explicit
+ * size brings that down to a couple of KB, which matters on article pages where
+ * several author avatars load eagerly and compete with the largest paint.
+ */
+export const getGithubAvatarUrl = (
+  username: string,
+  renderedSize: number
+): string => {
+  const url = new URL(`https://github.com/${username}.png`)
+  // Request 2x so the avatar stays sharp on high-density screens.
+  url.searchParams.set('size', String(renderedSize * 2))
+
+  return url.toString()
+}

--- a/apps/status.app/src/app/layout.tsx
+++ b/apps/status.app/src/app/layout.tsx
@@ -5,7 +5,9 @@ import { Analytics } from '@vercel/analytics/next'
 import { Inter } from 'next/font/google'
 import Script from 'next/script'
 import { NextIntlClientProvider } from 'next-intl'
-import { getLocale, getMessages } from 'next-intl/server'
+import { getLocale, getMessages, setRequestLocale } from 'next-intl/server'
+
+import { routing } from '~/i18n/routing'
 
 import { PlatformDetector } from './_components/platform-detector'
 import { Metadata } from './_metadata'
@@ -56,6 +58,13 @@ type Props = {
 }
 
 export default async function RootLayout({ children }: Props) {
+  // This layout sits above the `[locale]` segment, so it has no locale param to
+  // hand next-intl. Without a pinned locale next-intl falls back to `headers()`,
+  // which opts every route out of static rendering: nothing is prerendered and
+  // each response is served `no-store`, so the CDN can't cache any HTML.
+  // Safe while `en` is the only locale and detection is off, see `~/i18n/routing`.
+  setRequestLocale(routing.defaultLocale)
+
   const [locale, messages] = await Promise.all([getLocale(), getMessages()])
 
   return (
@@ -72,6 +81,9 @@ export default async function RootLayout({ children }: Props) {
     >
       <head>
         <link rel="preconnect" href="https://res.cloudinary.com" />
+        {/* The analytics script is already preloaded by `next/script`, but the
+            connection to its origin is only opened once the preload resolves. */}
+        <link rel="preconnect" href="https://umami.bi.status.im" />
         <link
           rel="alternate"
           type="application/atom+xml"

--- a/apps/status.app/src/i18n/routing.ts
+++ b/apps/status.app/src/i18n/routing.ts
@@ -9,6 +9,11 @@ export const routing = defineRouting({
   // NEXT_LOCALE cookie) that contributes to cloaking false-positives and aligns
   // with get.status.app. why: https://github.com/status-im/status-web/issues/1236
   localeDetection: false,
+  // The cookie can't influence anything while `en` is the only locale and
+  // detection is off, and a `Set-Cookie` on an HTML response makes CDNs treat
+  // it as per-user and skip the cache — which would waste the prerendering the
+  // `setRequestLocale` calls buy us.
+  localeCookie: false,
 })
 
 /**


### PR DESCRIPTION
## Summary

Search Console flags 2 mobile Core Web Vitals issues on status.app: INP over 200ms on 143 URLs, and LCP over 2.5s on 131 URLs. Desktop is green. Almost all of it is `/help/*`.

2 things:

1. Nothing was actually being prerendered. `next build` printed "685/685 static pages" but wrote zero HTML files. `setRequestLocale` was never called, so next-intl reached for `headers()` and Next.js threw every prerender away. Each request came back `Cache-Control: private, no-cache, no-store` and re-rendered React on the origin. Measured TTFB was 0.9s to 1.15s.

2. Every help page also built a search index it usually never needed. `useSearchEngine` created the MiniSearch index inside a `useState` initializer, so it ran on mount whether or not anyone opened search. That pulled a 544KB doc index and cost one 316ms long task on mobile.

## Changes

- `app/layout.tsx`, `app/[locale]/layout.tsx`: call `setRequestLocale` so next-intl uses the route param instead of `headers()`. This is what restores prerendering.
- `i18n/routing.ts`: `localeCookie: false`. A `Set-Cookie` on an HTML response makes CDNs treat it as per-user and skip the cache, and with `en` as the only locale the cookie wasn't doing anything anyway.
- `use-search-engine.ts`: build the index when the search dialog opens, on `requestIdleCallback` so it doesn't block the dialog's first paint.
- `github-avatar.ts`: ask GitHub for `?size=40` author avatars. They render at 20px but were downloading the full 37KB original, and an article carries one to four of them.
- `app/layout.tsx`: preconnect to the analytics origin.

## Result

Prerendered pages went from 0 to 657, and the preview serves help articles with `x-vercel-cache: PRERENDER` and no `Set-Cookie`.

On the deployed preview the 316ms long task is gone, the 130KB search chunk no longer loads until you open search, and each avatar dropped from 37KB to 1.4KB.

One caveat on LCP: Cloudflare in front of status.app caches by file extension, so it will still pass HTML through to the origin even with cacheable headers coming back. `/rss` sends `s-maxage=60` today and Cloudflare answers `cf-cache-status: DYNAMIC`. What this PR removes is the per-request React render. Turning the remaining round trip into an edge hit needs a Cache Rule on the zone, which is outside this repo.

The homepage INP group (12 of the 143 URLs) isn't covered here. It has no search index, and what's left there is React hydration and the shared vendor chunk.

## How to test

Production is the before, the preview is the after:

- https://status.app/help/getting-started/what-is-status
- https://status-website-git-mobile-core-web-vitals-status-im-web.vercel.app/help/getting-started/what-is-status

1. Caching. In DevTools, Network tab, reload and click the first request (the document). Production says `cache-control: private, no-cache, no-store` and drops a `NEXT_LOCALE` cookie. The preview has neither and shows `x-vercel-cache: PRERENDER`, so the page came off disk instead of being rendered for that request.

2. Search index. Still in Network, filter to JS and sort by size. Production pulls a ~130KB chunk on load, the preview doesn't. Click Search in the header and it shows up only then. Type "keycard" and check the results still look right.

3. Avatars. Filter to Img and find the two github.com author avatars above the title. About 37KB each on production, 1.4KB on the preview, and they should look identical at 20px.

4. Long task. In the Performance tab, set CPU to 4x slowdown and record a reload. Production has a ~300ms long task from the search chunk. The preview doesn't.

`setRequestLocale` touches every route, so click through a few help articles, the sidebar and the table of contents to make sure nothing lost its text.