### PR TITLE
feat(status.app): keep body links in the desktop news feed

### DIFF
--- a/.changeset/great-jars-smile.md
+++ b/.changeset/great-jars-smile.md
@@ -1,0 +1,5 @@
+---
+'status.app': patch
+---
+
+feat(status.app): keep body links in the desktop news feed. An anchor in a paragraph or a list item is emitted as `<a href>` instead of being flattened to its label, with the href escaped. The mobile feed keeps the label alone, since plain text cannot carry a link, and the call-to-action is still lifted out of the body.

--- a/apps/status.app/src/app/_utils/feed-content.test.ts
+++ b/apps/status.app/src/app/_utils/feed-content.test.ts
@@ -123,7 +123,10 @@ describe('renderFeedContent', () => {
       )
 
       expect(link?.href).toBe('https://status.app/')
-      expect(body).toBe('<ul><li>Fixed issue 1</li></ul>')
+      expect(body).toBe(
+        '<ul><li>Fixed <a href="https://github.com/status-im/status-go/issues/1">' +
+          'issue 1</a></li></ul>'
+      )
     })
 
     it('leaves list links in the body when there is no other link', () => {
@@ -133,7 +136,9 @@ describe('renderFeedContent', () => {
       )
 
       expect(link).toBeNull()
-      expect(body).toBe('Body<ul><li>See the notes</li></ul>')
+      expect(body).toBe(
+        'Body<ul><li>See <a href="https://status.app/x">the notes</a></li></ul>'
+      )
     })
 
     it('keeps surrounding text when the call to action is inline', () => {
@@ -153,6 +158,63 @@ describe('renderFeedContent', () => {
       )
 
       expect(link?.href).toBe('https://status.app/')
+    })
+  })
+
+  describe('body links', () => {
+    it('keeps an anchor that sits inside a sentence', () => {
+      const { body } = renderFeedContent(
+        '<p>See the <a href="https://wikipedia.org/">test link</a> for details</p>' +
+          BUTTON_CARD,
+        'html'
+      )
+
+      expect(body).toBe(
+        'See the <a href="https://wikipedia.org/">test link</a> for details'
+      )
+    })
+
+    it('keeps an anchor that is a whole list item', () => {
+      const { body } = renderFeedContent(
+        '<ul><li><a href="https://wikipedia.org/wiki/RSS">RSS on Wikipedia</a></li></ul>' +
+          BUTTON_CARD,
+        'html'
+      )
+
+      expect(body).toBe(
+        '<ul><li><a href="https://wikipedia.org/wiki/RSS">RSS on Wikipedia</a></li></ul>'
+      )
+    })
+
+    it('escapes the href, quotes included', () => {
+      const { body } = renderFeedContent(
+        '<p>Go <a href=\'https://status.app/?a=1&amp;b="2"\'>there</a> now</p>' +
+          BUTTON_CARD,
+        'html'
+      )
+
+      expect(body).toBe(
+        'Go <a href="https://status.app/?a=1&amp;b=&quot;2&quot;">there</a> now'
+      )
+    })
+
+    it('drops the anchor of a link that carries no target', () => {
+      const { body } = renderFeedContent(
+        '<p>An <a name="anchor">anchor</a> only</p>' + BUTTON_CARD,
+        'html'
+      )
+
+      expect(body).toBe('An anchor only')
+    })
+
+    it('keeps only the label for the mobile client', () => {
+      const { body } = renderFeedContent(
+        '<p>See the <a href="https://wikipedia.org/">test link</a> for details</p>' +
+          BUTTON_CARD,
+        'text'
+      )
+
+      expect(body).toBe('See the test link for details')
     })
   })
 

--- a/apps/status.app/src/app/_utils/feed-content.ts
+++ b/apps/status.app/src/app/_utils/feed-content.ts
@@ -90,8 +90,12 @@ type Token =
   | { kind: 'open'; name: string; attributes: string }
   | { kind: 'close'; name: string }
 
+type Inline =
+  | { kind: 'text'; value: string }
+  | { kind: 'link'; href: string; label: string }
+
 type Block =
-  | { type: 'text'; text: string }
+  | { type: 'text'; inlines: Inline[] }
   | { type: 'list'; ordered: boolean; items: Block[][] }
 
 /**
@@ -233,15 +237,22 @@ function parseBlocks(
   stopOnClose: ReadonlySet<string>
 ): Block[] {
   const blocks: Block[] = []
-  let buffer = ''
+  let buffer: Inline[] = []
+
+  const pushText = (value: string) => {
+    const last = buffer.at(-1)
+    if (last?.kind === 'text') {
+      last.value += value
+    } else {
+      buffer.push({ kind: 'text', value })
+    }
+  }
 
   const flush = () => {
-    // Removing a suppressed anchor can leave the spaces that surrounded it
-    // doubled up; `\n` marks a break and has to survive.
-    const text = buffer.replace(/[^\S\n]+/g, ' ').trim()
-    buffer = ''
-    if (text) {
-      blocks.push({ type: 'text', text })
+    const inlines = normalizeInlines(buffer)
+    buffer = []
+    if (inlines.length) {
+      blocks.push({ type: 'text', inlines })
     }
   }
 
@@ -250,7 +261,7 @@ function parseBlocks(
 
     if (token.kind === 'text') {
       cursor.index++
-      buffer += collapseWhitespace(token.value)
+      pushText(collapseWhitespace(token.value))
       continue
     }
 
@@ -277,7 +288,7 @@ function parseBlocks(
     if (token.name === 'br') {
       // Rendered as a single break; a blank line only ever comes from a real
       // block boundary.
-      buffer += '\n'
+      pushText('\n')
       continue
     }
 
@@ -291,11 +302,17 @@ function parseBlocks(
 
     if (token.name === 'a') {
       const label = readElementText(tokens, cursor.index, 'a')
+      const href = getAttribute(token.attributes, 'href')
       skipElement(tokens, cursor, 'a')
       // The CTA is surfaced as its own feed element, so its label must not be
       // repeated in the body.
-      if (tokenIndex !== linkTokenIndex) {
-        buffer += label
+      if (tokenIndex === linkTokenIndex) {
+        continue
+      }
+      if (href) {
+        buffer.push({ kind: 'link', href, label })
+      } else {
+        pushText(label)
       }
       continue
     }
@@ -341,6 +358,33 @@ function parseList(
   return { type: 'list', ordered, items }
 }
 
+/**
+ * Collapses the runs of spaces a suppressed anchor or a block boundary leaves
+ * behind and trims the block's edges. `\n` marks a `<br>` and has to survive.
+ */
+function normalizeInlines(inlines: Inline[]): Inline[] {
+  const collapsed = inlines
+    .map(inline =>
+      inline.kind === 'text'
+        ? { ...inline, value: inline.value.replace(/[^\S\n]+/g, ' ') }
+        : inline
+    )
+    .filter(inline => inline.kind !== 'text' || inline.value !== '')
+
+  const first = collapsed.at(0)
+  if (first?.kind === 'text') {
+    first.value = first.value.replace(/^\s+/, '')
+  }
+  const last = collapsed.at(-1)
+  if (last?.kind === 'text') {
+    last.value = last.value.replace(/\s+$/, '')
+  }
+
+  return collapsed.filter(
+    inline => inline.kind !== 'text' || inline.value !== ''
+  )
+}
+
 const LI_STOP_OPEN: ReadonlySet<string> = new Set(['li'])
 const LI_STOP_CLOSE: ReadonlySet<string> = new Set(['li', 'ol', 'ul'])
 
@@ -359,6 +403,11 @@ const FORBIDDEN_XML_CHARS =
  */
 export function escapeFeedText(text: string): string {
   return escapeXml(decodeHTMLStrict(text).replace(FORBIDDEN_XML_CHARS, ''))
+}
+
+/** The body's anchors quote their `href`, so it may not carry a bare `"`. */
+function escapeFeedAttribute(value: string): string {
+  return escapeFeedText(value).replaceAll('"', '&quot;')
 }
 
 /** Escapes without decoding, so it can be applied on top of `escapeFeedText`. */
@@ -380,13 +429,33 @@ export function serializeFeedBody(body: string, format: FeedFormat): string {
   return format === 'html' ? escapeXml(body) : body
 }
 
+/**
+ * The mobile client cannot follow a link in plain text, so an anchor keeps only
+ * its label there. The desktop client is given the anchor itself.
+ */
+function renderInlines(inlines: Inline[], format: FeedFormat): string {
+  return inlines
+    .map(inline => {
+      if (inline.kind === 'link') {
+        const label = escapeFeedText(inline.label)
+        return format === 'text'
+          ? label
+          : `<a href="${escapeFeedAttribute(inline.href)}">${label}</a>`
+      }
+
+      const text = escapeFeedText(inline.value)
+      return format === 'text' ? text : text.replaceAll('\n', '<br />')
+    })
+    .join('')
+}
+
 function renderBlocks(blocks: Block[], format: FeedFormat): string {
   if (format === 'text') {
     return blocks
       .map(block =>
         block.type === 'list'
           ? renderList(block, format)
-          : escapeFeedText(block.text)
+          : renderInlines(block.inlines, format)
       )
       .filter(Boolean)
       .join(PLAIN_PARAGRAPH_BREAK)
@@ -398,7 +467,7 @@ function renderBlocks(blocks: Block[], format: FeedFormat): string {
     const rendered =
       block.type === 'list'
         ? renderList(block, format)
-        : escapeFeedText(block.text).replaceAll('\n', '<br />')
+        : renderInlines(block.inlines, format)
 
     if (!rendered) {
       return
@@ -429,7 +498,7 @@ function renderList(
           .map(child =>
             child.type === 'list'
               ? renderList(child, format)
-              : escapeFeedText(child.text)
+              : renderInlines(child.inlines, format)
           )
           .filter(Boolean)
           .join('\n')

--- a/apps/status.app/src/app/_utils/process-item.test.ts
+++ b/apps/status.app/src/app/_utils/process-item.test.ts
@@ -118,6 +118,20 @@ describe('processItem', () => {
     )
   })
 
+  it('escapes a body link on the wire and decodes it back', () => {
+    const item = process(
+      '<p>See the <a href="https://wikipedia.org/?a=1&amp;b=2">test link</a></p>' +
+        '<div class="kg-card kg-button-card"><a href="https://status.app/" class="kg-btn">Update</a></div>'
+    )
+
+    expect(item.description).toBe(
+      'See the &lt;a href="https://wikipedia.org/?a=1&amp;amp;b=2"&gt;test link&lt;/a&gt;'
+    )
+    expect(decodeXML(item.description ?? '')).toBe(
+      'See the <a href="https://wikipedia.org/?a=1&amp;b=2">test link</a>'
+    )
+  })
+
   it('renders the mobile feed as plain text', () => {
     const item = process(
       '<p>This release fixes:</p>' +


### PR DESCRIPTION
Based on #1293.

Anchors in the body were flattened to their label, so `<a href="https://wikipedia.org/">test link</a>` reached the client as `test link` and the target was lost.

The parser now carries anchors as inline nodes, so a link in a paragraph or a list item reaches the desktop client as `<a href>`, with the href escaped (quotes included). Anchors without an `href` still flatten to their label.

Unchanged:
- The mobile feed keeps the label alone -- plain text cannot carry a link.
- The call-to-action is still lifted out of the body into `status:newsLink`, and a link inside a bullet still cannot become it.
- Validity. The whole body is escaped on its way into `description`, so the anchor is `&lt;a href="..."&gt;` on the wire, never an element.

---

#### How to test

Use the same script as #1293:

```bash
python3 "fake-ghost.py"
NEXT_PUBLIC_GHOST_API_URL=http://127.0.0.1:8099 pnpm dev
```

Desktop -- anchors survive with their targets (e.g. `href="https://wikipedia.org/wiki/RSS`):
```bash
curl -s http://localhost:3001/desktop-news/rss | python3 -c "import sys,xml.dom.minidom as m; s=sys.stdin.read(); m.parseString(s); print('XML: VALID'); i=s.index('<item>'); print(s[i:s.index('</item>')+7])"
```

```xml
XML: VALID
<item><title>Status v2.38.2: fixes &amp; tweaks &lt;beta&gt;</title><description>Fixes &amp;amp; improvements:&lt;br /&gt;shipped today.&lt;ul&gt;&lt;li&gt;High CPU usage&lt;/li&gt;&lt;li&gt;Endless loading, see the &lt;a href="https://wikipedia.org/"&gt;test link&lt;/a&gt; for details&lt;ol&gt;&lt;li&gt;in communities&lt;/li&gt;&lt;li&gt;on iOS&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;li&gt;&lt;a href="https://wikipedia.org/wiki/RSS"&gt;RSS on Wikipedia&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;Thanks for testing.</description><link>https://our.status.im/status-v2-38-2-is-here/</link><guid isPermaLink="false">6a5f5210834292000196a904</guid><category>Desktop news</category><dc:creator>Bobby Zalke</dc:creator><pubDate>Tue, 21 Jul 2026 11:19:19 GMT</pubDate><content:encoded>Fixes &amp;amp; improvements:&lt;br /&gt;shipped today.&lt;ul&gt;&lt;li&gt;High CPU usage&lt;/li&gt;&lt;li&gt;Endless loading, see the &lt;a href="https://wikipedia.org/"&gt;test link&lt;/a&gt; for details&lt;ol&gt;&lt;li&gt;in communities&lt;/li&gt;&lt;li&gt;on iOS&lt;/li&gt;&lt;/ol&gt;&lt;/li&gt;&lt;li&gt;&lt;a href="https://wikipedia.org/wiki/RSS"&gt;RSS on Wikipedia&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;Thanks for testing.</content:encoded><status:newsLink>https://status.app/</status:newsLink><status:newsLinkLabel>Update your Status</status:newsLinkLabel></item>
```

Mobile -- labels only:
```bash
curl -s http://localhost:3001/mobile-news/rss | python3 -c "import sys,xml.dom.minidom as m; s=sys.stdin.read(); m.parseString(s); print('XML: VALID'); i=s.index('<item>'); print(s[i:s.index('</item>')+7])"
```

```xml
XML: VALID
<item><title>Status v2.38.2: fixes &amp; tweaks &lt;beta&gt;</title><description>Fixes &amp; improvements:
shipped today.

• High CPU usage
• Endless loading, see the test link for details
  1. in communities
  2. on iOS
• RSS on Wikipedia

Thanks for testing.</description><link>https://our.status.im/status-v2-38-2-is-here/</link><guid isPermaLink="false">6a5f5210834292000196a904</guid><category>Desktop news</category><dc:creator>Bobby Zalke</dc:creator><pubDate>Tue, 21 Jul 2026 11:19:19 GMT</pubDate><content:encoded>Fixes &amp; improvements:
shipped today.

• High CPU usage
• Endless loading, see the test link for details
  1. in communities
  2. on iOS
• RSS on Wikipedia

Thanks for testing.</content:encoded><status:newsLink>https://status.app/</status:newsLink><status:newsLinkLabel>Update your Status</status:newsLinkLabel></item>
```