### PR TITLE
fix(wallet): persist dApp connections per account

### DIFF
--- a/.changeset/slimy-houses-rhyme.md
+++ b/.changeset/slimy-houses-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@status-im/ethereum-provider': patch
+---
+
+fix(wallet): persist dApp connections per account

--- a/apps/wallet/src/components/connected-dapps/index.tsx
+++ b/apps/wallet/src/components/connected-dapps/index.tsx
@@ -1,64 +1,148 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
-import { DropdownMenu } from '@status-im/components'
+import { Button, DropdownMenu } from '@status-im/components'
+import {
+  BrowserIcon,
+  ConnectIcon,
+  ConnectionIcon,
+  DisconnectIcon,
+} from '@status-im/icons/20'
+import { shortenAddress } from '@status-im/wallet/components'
 
+import {
+  ETH_ACCOUNTS_CAPABILITY,
+  isSameAddress,
+  readStore,
+  watchPermissions,
+} from '../../data/dapp-permissions'
+import { connectAccountToDapp, disconnectDapp } from '../../lib/dapp-events'
+import { useWallet } from '../../providers/wallet-context'
+
+type ConnectedDApp = {
+  origin: string
+  /** The account this dApp currently sees, which outlives a wallet switch. */
+  connectedAddress: string | null
+  /** Whether the account selected in the wallet is connected here at all. */
+  hasCurrentAccount: boolean
+}
+
+/**
+ * dApp connection management, in its own menu beside the wallet selector.
+ *
+ * Switching to an account a dApp was never connected to deliberately leaves
+ * that dApp on the account it was connected with, so this is where the user
+ * connects the new one.
+ *
+ * Renders nothing until at least one dApp is connected -- there is nothing to
+ * manage before that, and an always-present button would open an empty menu.
+ */
 const ConnectedDApps = () => {
-  const [origins, setOrigins] = useState<string[]>([])
-  const [isOpen, setIsOpen] = useState(false)
+  const { currentAccount } = useWallet()
+  const address = currentAccount?.address
+
+  const [dapps, setDapps] = useState<ConnectedDApp[]>([])
+
+  const load = useCallback(async () => {
+    const store = await readStore()
+
+    setDapps(
+      Object.entries(store.origins)
+        .filter(([, record]) =>
+          record.permissions.some(
+            permission =>
+              permission.parentCapability === ETH_ACCOUNTS_CAPABILITY,
+          ),
+        )
+        .map(([origin, record]) => ({
+          origin,
+          connectedAddress: record.selectedAddress,
+          hasCurrentAccount: record.accounts.some(account =>
+            isSameAddress(account, address ?? null),
+          ),
+        })),
+    )
+  }, [address])
 
   useEffect(() => {
-    const load = () => {
-      chrome.storage.session
-        .get('connectedOrigins')
-        .then(result => {
-          setOrigins(result.connectedOrigins || [])
-        })
-        .catch(() => {})
-    }
+    void load()
+    return watchPermissions(() => void load())
+  }, [load])
 
-    load()
+  // No approval popup: choosing this in the wallet is the consent the popup
+  // would have collected.
+  const connect = useCallback(
+    async (origin: string) => {
+      if (!address) return
+      await connectAccountToDapp(origin, address)
+      await load()
+    },
+    [address, load],
+  )
 
-    const listener = (
-      changes: Record<string, chrome.storage.StorageChange>,
-      area: string,
-    ) => {
-      if (area === 'session' && changes.connectedOrigins) {
-        setOrigins(changes.connectedOrigins.newValue || [])
-      }
-    }
+  const disconnect = useCallback(
+    async (origin: string) => {
+      await disconnectDapp(origin)
+      await load()
+    },
+    [load],
+  )
 
-    chrome.storage.onChanged.addListener(listener)
-    return () => chrome.storage.onChanged.removeListener(listener)
-  }, [])
-
-  if (origins.length === 0) {
+  if (dapps.length === 0) {
     return null
   }
 
   return (
-    <DropdownMenu.Root onOpenChange={setIsOpen} open={isOpen}>
-      <button className="flex cursor-pointer items-center gap-1.5 rounded-10 border border-neutral-70 px-2 py-[5px] hover:border-neutral-60">
-        <span className="size-2 rounded-full bg-success-50" />
-        <span className="text-13 font-500 text-white-100">
-          {origins.length} {origins.length === 1 ? 'dApp' : 'dApps'}
-        </span>
-      </button>
+    <DropdownMenu.Root modal={false}>
+      <Button
+        size="24"
+        variant="outline"
+        icon={<ConnectionIcon />}
+        aria-label={`Manage dApp connections (${dapps.length} connected)`}
+      />
 
-      <DropdownMenu.Content
-        collisionPadding={12}
-        sideOffset={24}
-        className="w-[256px]"
-      >
-        {origins.map(origin => (
-          <DropdownMenu.Item
-            key={origin}
-            label={formatOrigin(origin)}
-            onSelect={() => {
-              window.open(origin, '_blank')
-            }}
-          />
+      <DropdownMenu.Content className="w-[280px]">
+        <DropdownMenu.Label>Connected dApps</DropdownMenu.Label>
+        {dapps.map(dapp => (
+          <DropdownMenu.Sub key={dapp.origin}>
+            <DropdownMenu.SubTrigger
+              icon={<BrowserIcon />}
+              label={formatOrigin(dapp.origin)}
+            />
+            <DropdownMenu.SubContent className="w-[260px]">
+              {dapp.connectedAddress && (
+                <DropdownMenu.Label>
+                  Using {shortenAddress(dapp.connectedAddress)}
+                </DropdownMenu.Label>
+              )}
+              {address && !dapp.hasCurrentAccount && (
+                <DropdownMenu.Item
+                  icon={<ConnectIcon />}
+                  label={`Connect ${shortenAddress(address)}`}
+                  onSelect={() => {
+                    void connect(dapp.origin)
+                  }}
+                />
+              )}
+              <DropdownMenu.Item
+                label="Open site"
+                external
+                onSelect={() => {
+                  window.open(dapp.origin, '_blank')
+                }}
+              />
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item
+                icon={<DisconnectIcon />}
+                label="Disconnect"
+                danger
+                onSelect={() => {
+                  void disconnect(dapp.origin)
+                }}
+              />
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
         ))}
       </DropdownMenu.Content>
     </DropdownMenu.Root>

--- a/apps/wallet/src/components/wallet-selector.tsx
+++ b/apps/wallet/src/components/wallet-selector.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from '@tanstack/react-router'
 
 import { useWallet } from '@/providers/wallet-context'
 
+import { ConnectedDApps } from './connected-dapps'
 import { WatchOnlyTag } from './watch-only-tag'
 
 type Props = {
@@ -74,75 +75,79 @@ export function WalletSelector(props: Props) {
         </div>
       </div>
 
-      <DropdownMenu.Root modal={false}>
-        <Button
-          size="24"
-          variant="outline"
-          icon={<ChevronDownIcon />}
-          aria-label="Open wallet menu"
-        />
+      <div className="inline-flex items-center gap-1.5">
+        <DropdownMenu.Root modal={false}>
+          <Button
+            size="24"
+            variant="outline"
+            icon={<ChevronDownIcon />}
+            aria-label="Open wallet menu"
+          />
 
-        <DropdownMenu.Content className="w-[320px]">
-          <DropdownMenu.Label>Wallets</DropdownMenu.Label>
-          {wallets.map(wallet => (
+          <DropdownMenu.Content className="w-[320px]">
+            <DropdownMenu.Label>Wallets</DropdownMenu.Label>
+            {wallets.map(wallet => (
+              <DropdownMenu.Item
+                key={wallet.id}
+                icon={<WalletIcon />}
+                label={wallet.name}
+                selected={wallet.id === currentWallet.id}
+                onClick={() => setCurrentWallet(wallet.id)}
+              />
+            ))}
+
+            {selectableAccounts.length > 0 && (
+              <>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Label>Accounts</DropdownMenu.Label>
+                {selectableAccounts.map(account => (
+                  <DropdownMenu.Item
+                    key={account.address}
+                    icon={<WalletIcon />}
+                    label={shortenAddress(account.address)}
+                    selected={account.address === currentAccount?.address}
+                    onClick={() => setCurrentAccount(account.address)}
+                  />
+                ))}
+                {currentWallet.type === 'mnemonic' && (
+                  <DropdownMenu.Item
+                    icon={<AddIcon />}
+                    label="Create account"
+                    onClick={() => {
+                      navigate({ to: '/wallet-flow/add-account' })
+                    }}
+                  />
+                )}
+              </>
+            )}
+
+            <DropdownMenu.Separator />
             <DropdownMenu.Item
-              key={wallet.id}
-              icon={<WalletIcon />}
-              label={wallet.name}
-              selected={wallet.id === currentWallet.id}
-              onClick={() => setCurrentWallet(wallet.id)}
+              icon={<AddIcon />}
+              label="Create wallet"
+              onClick={() => {
+                navigate({ to: '/wallet-flow/new' })
+              }}
             />
-          ))}
+            <DropdownMenu.Item
+              icon={<ImportIcon />}
+              label="Import wallet"
+              onClick={() => {
+                navigate({ to: '/wallet-flow/import' })
+              }}
+            />
+            <DropdownMenu.Item
+              icon={<KeycardIcon />}
+              label="Connect hardware wallet"
+              onClick={() => {
+                navigate({ to: '/wallet-flow/import-hardware' })
+              }}
+            />
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
 
-          {selectableAccounts.length > 0 && (
-            <>
-              <DropdownMenu.Separator />
-              <DropdownMenu.Label>Accounts</DropdownMenu.Label>
-              {selectableAccounts.map(account => (
-                <DropdownMenu.Item
-                  key={account.address}
-                  icon={<WalletIcon />}
-                  label={shortenAddress(account.address)}
-                  selected={account.address === currentAccount?.address}
-                  onClick={() => setCurrentAccount(account.address)}
-                />
-              ))}
-              {currentWallet.type === 'mnemonic' && (
-                <DropdownMenu.Item
-                  icon={<AddIcon />}
-                  label="Create account"
-                  onClick={() => {
-                    navigate({ to: '/wallet-flow/add-account' })
-                  }}
-                />
-              )}
-            </>
-          )}
-
-          <DropdownMenu.Separator />
-          <DropdownMenu.Item
-            icon={<AddIcon />}
-            label="Create wallet"
-            onClick={() => {
-              navigate({ to: '/wallet-flow/new' })
-            }}
-          />
-          <DropdownMenu.Item
-            icon={<ImportIcon />}
-            label="Import wallet"
-            onClick={() => {
-              navigate({ to: '/wallet-flow/import' })
-            }}
-          />
-          <DropdownMenu.Item
-            icon={<KeycardIcon />}
-            label="Connect hardware wallet"
-            onClick={() => {
-              navigate({ to: '/wallet-flow/import-hardware' })
-            }}
-          />
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+        <ConnectedDApps />
+      </div>
     </div>
   )
 }

--- a/apps/wallet/src/data/approval.test.ts
+++ b/apps/wallet/src/data/approval.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import {
+  APPROVAL_TIMEOUT_MS,
+  clearPendingApproval,
+  getPendingApproval,
+  type PendingApproval,
+  setPendingApproval,
+} from './approval'
+
+const approval = (createdAt: number): PendingApproval => ({
+  id: 'approval-1',
+  createdAt,
+  type: 'eth_requestAccounts',
+  origin: 'https://app.velora.xyz',
+  title: 'Velora',
+  favicon: 'https://app.velora.xyz/favicon.ico',
+  address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  accountName: 'Wallet 1',
+  chainId: '0x1',
+})
+
+beforeEach(() => {
+  const session = new Map<string, unknown>()
+  vi.stubGlobal('chrome', {
+    storage: {
+      session: {
+        get: async (key: string) =>
+          session.has(key) ? { [key]: session.get(key) } : {},
+        set: async (items: Record<string, unknown>) => {
+          for (const [k, v] of Object.entries(items)) session.set(k, v)
+        },
+        remove: async (key: string) => {
+          session.delete(key)
+        },
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('a fresh pending approval is returned', async () => {
+  await setPendingApproval(approval(Date.now()))
+
+  expect(await getPendingApproval()).not.toBeNull()
+})
+
+// Regression: MV3 can terminate the worker while the approval popup is open,
+// so the handler that would clear this never runs. The leftover record then
+// rejected every later connection attempt with -32002 until the browser was
+// restarted, which reads as "the dApp keeps asking and never connects".
+test('a pending approval older than the timeout is discarded', async () => {
+  await setPendingApproval(approval(Date.now() - APPROVAL_TIMEOUT_MS - 1))
+
+  expect(await getPendingApproval()).toBeNull()
+  // and is cleared, so it cannot block again
+  expect(await chrome.storage.session.get('pendingApproval')).toEqual({})
+})
+
+test('a record predating the createdAt field is treated as stale', async () => {
+  const legacy: Record<string, unknown> = { ...approval(Date.now()) }
+  delete legacy.createdAt
+  await chrome.storage.session.set({ pendingApproval: legacy })
+
+  expect(await getPendingApproval()).toBeNull()
+})
+
+test('clearing removes the record', async () => {
+  await setPendingApproval(approval(Date.now()))
+  await clearPendingApproval()
+
+  expect(await getPendingApproval()).toBeNull()
+})

--- a/apps/wallet/src/data/approval.ts
+++ b/apps/wallet/src/data/approval.ts
@@ -1,4 +1,7 @@
-export type PendingApproval =
+/** How long a pending approval stays valid. Mirrored in `rpc-handler.ts`. */
+export const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000
+
+export type PendingApproval = { createdAt: number } & (
   | {
       id: string
       type: 'eth_requestAccounts'
@@ -20,6 +23,7 @@ export type PendingApproval =
       chainId: string
       message: string
     }
+)
 
 export type ApprovalResult = {
   id: string
@@ -34,7 +38,19 @@ export async function setPendingApproval(
 
 export async function getPendingApproval(): Promise<PendingApproval | null> {
   const result = await chrome.storage.session.get('pendingApproval')
-  return (result.pendingApproval as PendingApproval) || null
+  const pending = (result.pendingApproval as PendingApproval) || null
+  if (!pending) return null
+
+  // MV3 can terminate the worker while the popup is open, killing the handler
+  // that would have cleared this. Without an age check the leftover record
+  // rejects every later connection attempt with -32002 until the browser
+  // restarts.
+  if (Date.now() - (pending.createdAt ?? 0) > APPROVAL_TIMEOUT_MS) {
+    await clearPendingApproval()
+    return null
+  }
+
+  return pending
 }
 
 export async function clearPendingApproval(): Promise<void> {
@@ -43,6 +59,11 @@ export async function clearPendingApproval(): Promise<void> {
 
 export async function setApprovalResult(result: ApprovalResult): Promise<void> {
   await chrome.storage.session.set({ approvalResult: result })
+}
+
+export async function getApprovalResult(): Promise<ApprovalResult | null> {
+  const result = await chrome.storage.session.get('approvalResult')
+  return (result.approvalResult as ApprovalResult) || null
 }
 
 export async function clearApprovalResult(): Promise<void> {

--- a/apps/wallet/src/data/dapp-permissions.test.ts
+++ b/apps/wallet/src/data/dapp-permissions.test.ts
@@ -1,0 +1,327 @@
+import { storage } from '@wxt-dev/storage'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import {
+  adoptSelectedAddress,
+  connectAccount,
+  DAPP_PERMISSIONS_KEY,
+  ETH_ACCOUNTS_CAPABILITY,
+  getChainIdForOrigin,
+  getConnectedAccounts,
+  getPermissions,
+  getPermittedOrigins,
+  getSelectedAddress,
+  grantPermission,
+  isAccountConnected,
+  isOriginPermitted,
+  normalizeOrigin,
+  type PermissionStore,
+  readStore,
+  revokeOrigin,
+  selectAccountForOrigin,
+  setChainIdForOrigin,
+  watchPermissions,
+} from './dapp-permissions'
+
+const ORIGIN = 'https://app.uniswap.org'
+const OTHER_ORIGIN = 'https://app.aave.com'
+const ACCOUNT_A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const ACCOUNT_B = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+beforeEach(async () => {
+  await storage.clear('local')
+  await storage.clear('session')
+})
+
+afterEach(async () => {
+  await storage.clear('local')
+  await storage.clear('session')
+})
+
+describe('grants', () => {
+  test('an origin is not permitted until eth_accounts is granted', async () => {
+    expect(await isOriginPermitted(ORIGIN)).toBe(false)
+    expect(await getPermissions(ORIGIN)).toEqual([])
+
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+    expect(await getPermissions(ORIGIN)).toEqual([
+      { parentCapability: ETH_ACCOUNTS_CAPABILITY, caveats: [] },
+    ])
+  })
+
+  test('a non-eth_accounts capability alone does not connect an origin', async () => {
+    await grantPermission(ORIGIN, 'endowment:permitted-chains')
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(false)
+    expect(await getPermittedOrigins()).toEqual([])
+  })
+
+  test('re-granting a capability replaces it rather than duplicating', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY, [
+      { type: 'restrictReturnedAccounts', value: ['0x1'] },
+    ])
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY, [])
+
+    expect(await getPermissions(ORIGIN)).toEqual([
+      { parentCapability: ETH_ACCOUNTS_CAPABILITY, caveats: [] },
+    ])
+  })
+
+  test('revoking removes the origin entirely', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await revokeOrigin(ORIGIN)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(false)
+    expect((await readStore()).origins).toEqual({})
+  })
+
+  test('revoking an unknown origin is a no-op', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await revokeOrigin(OTHER_ORIGIN)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+  })
+
+  test('concurrent grants for different origins do not clobber each other', async () => {
+    await Promise.all([
+      grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY),
+      grantPermission(OTHER_ORIGIN, ETH_ACCOUNTS_CAPABILITY),
+    ])
+
+    expect(await getPermittedOrigins()).toEqual(
+      expect.arrayContaining([ORIGIN, OTHER_ORIGIN]),
+    )
+  })
+})
+
+describe('per-account connections', () => {
+  test('connecting records the account and points the origin at it', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A])
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+    expect(await isAccountConnected(ORIGIN, ACCOUNT_B)).toBe(false)
+  })
+
+  test('connecting a second account keeps the first', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(ORIGIN, ACCOUNT_B)
+
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A, ACCOUNT_B])
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_B)
+  })
+
+  test('reconnecting the same account does not duplicate it', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(ORIGIN, ACCOUNT_A.toLowerCase())
+
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A])
+  })
+
+  test('accounts are tracked per origin', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(OTHER_ORIGIN, ACCOUNT_B)
+
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+    expect(await getSelectedAddress(OTHER_ORIGIN)).toBe(ACCOUNT_B)
+  })
+})
+
+describe('switching the account an origin sees', () => {
+  test('an origin cannot be switched to an unconnected account', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    expect(await selectAccountForOrigin(ORIGIN, ACCOUNT_B)).toBe(false)
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+  })
+
+  test('switching to a previously connected account is allowed', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(ORIGIN, ACCOUNT_B)
+
+    expect(await selectAccountForOrigin(ORIGIN, ACCOUNT_A)).toBe(true)
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+  })
+
+  test('selecting the account already shown reports no change', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    expect(await selectAccountForOrigin(ORIGIN, ACCOUNT_A.toLowerCase())).toBe(
+      false,
+    )
+  })
+
+  test('an unknown origin is never given an account', async () => {
+    expect(await selectAccountForOrigin(OTHER_ORIGIN, ACCOUNT_A)).toBe(false)
+    expect(await getSelectedAddress(OTHER_ORIGIN)).toBeNull()
+  })
+})
+
+describe('adopting records written before per-account tracking', () => {
+  test('an accountless record pins to the account it was showing', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await adoptSelectedAddress(ORIGIN, ACCOUNT_A)).toBe(ACCOUNT_A)
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A])
+  })
+
+  test('adoption cannot move an origin that already has an account', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    expect(await adoptSelectedAddress(ORIGIN, ACCOUNT_B)).toBe(ACCOUNT_A)
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A])
+  })
+
+  test('adoption does not create a record for an unknown origin', async () => {
+    await adoptSelectedAddress(OTHER_ORIGIN, ACCOUNT_A)
+
+    expect(await isOriginPermitted(OTHER_ORIGIN)).toBe(false)
+  })
+
+  // Regression: the approval popup persisted the grant with `grantPermission`,
+  // leaving no account on the record. Adoption would then pin the dApp to
+  // whichever account the wallet had selected, which need not be the approved
+  // one -- exactly the drift per-account tracking exists to prevent.
+  test('a grant carrying no account is adoptable by any account', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await adoptSelectedAddress(ORIGIN, ACCOUNT_B)).toBe(ACCOUNT_B)
+
+    // Whereas connecting records the account up front and pins it.
+    await revokeOrigin(OTHER_ORIGIN)
+    await connectAccount(OTHER_ORIGIN, ACCOUNT_A)
+    expect(await adoptSelectedAddress(OTHER_ORIGIN, ACCOUNT_B)).toBe(ACCOUNT_A)
+  })
+})
+
+describe('origin normalization', () => {
+  test('trailing slashes and case do not create a second key', async () => {
+    expect(normalizeOrigin('https://App.Uniswap.org/')).toBe(ORIGIN)
+
+    await grantPermission('https://App.Uniswap.org/', ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+    expect(Object.keys((await readStore()).origins)).toEqual([ORIGIN])
+  })
+})
+
+describe('per-origin chain', () => {
+  test('defaults to mainnet and is stored per origin', async () => {
+    expect(await getChainIdForOrigin(ORIGIN)).toBe('0x1')
+
+    await setChainIdForOrigin(ORIGIN, '0x6300b5ea')
+
+    expect(await getChainIdForOrigin(ORIGIN)).toBe('0x6300b5ea')
+    expect(await getChainIdForOrigin(OTHER_ORIGIN)).toBe('0x1')
+  })
+
+  test('switching chains preserves an existing grant', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await setChainIdForOrigin(ORIGIN, '0x6300b5ea')
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+  })
+})
+
+describe('a grant is dropped only by an explicit request', () => {
+  // Regression: the store used to record the granting account and revoke
+  // everything when it changed. wallet-context resolves `currentWallet` to
+  // `wallets[0]` until the persisted selection hydrates, so every extension
+  // page load briefly reported the wrong account and wiped all connections.
+  test('the store holds no account identity to invalidate against', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await readStore()).toEqual({
+      version: 2,
+      origins: {
+        [ORIGIN]: {
+          permissions: [
+            { parentCapability: ETH_ACCOUNTS_CAPABILITY, caveats: [] },
+          ],
+          accounts: [],
+          selectedAddress: null,
+          chainId: '0x1',
+          grantedAt: expect.any(Number),
+        },
+      },
+    })
+  })
+
+  test('unrelated writes never drop an existing grant', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    await setChainIdForOrigin(ORIGIN, '0x6300b5ea')
+    await grantPermission(OTHER_ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await setChainIdForOrigin(OTHER_ORIGIN, '0x1')
+    await revokeOrigin(OTHER_ORIGIN)
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+    expect(await getChainIdForOrigin(ORIGIN)).toBe('0x6300b5ea')
+  })
+
+  test('reads are pure -- repeated reads cannot revoke', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    for (let i = 0; i < 5; i++) {
+      await readStore()
+      await isOriginPermitted(ORIGIN)
+      await getPermittedOrigins()
+      await getChainIdForOrigin(ORIGIN)
+    }
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+  })
+})
+
+describe('watchPermissions', () => {
+  // The connected-dApps header has no other refresh mechanism.
+  test('fires on grant and on revoke', async () => {
+    const seen: string[][] = []
+    const unwatch = watchPermissions(store => {
+      seen.push(Object.keys(store.origins))
+    })
+
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await revokeOrigin(ORIGIN)
+    unwatch()
+    await grantPermission(OTHER_ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(seen).toEqual([[ORIGIN], []])
+  })
+})
+
+describe('legacy migration', () => {
+  test('adopts session connectedOrigins as eth_accounts grants', async () => {
+    await storage.setItem('session:connectedOrigins', [ORIGIN, OTHER_ORIGIN])
+    await storage.setItem('session:originChainIds', { [ORIGIN]: '0x6300b5ea' })
+
+    expect(await isOriginPermitted(ORIGIN)).toBe(true)
+    expect(await isOriginPermitted(OTHER_ORIGIN)).toBe(true)
+    expect(await getChainIdForOrigin(ORIGIN)).toBe('0x6300b5ea')
+    expect(await getChainIdForOrigin(OTHER_ORIGIN)).toBe('0x1')
+  })
+
+  test('removes the legacy keys and does not run twice', async () => {
+    await storage.setItem('session:connectedOrigins', [ORIGIN])
+    await readStore()
+
+    expect(await storage.getItem('session:connectedOrigins')).toBeNull()
+    expect(await storage.getItem('session:originChainIds')).toBeNull()
+
+    // A later revoke must not be undone by a second migration pass.
+    await revokeOrigin(ORIGIN)
+    expect(await isOriginPermitted(ORIGIN)).toBe(false)
+  })
+
+  test('with no legacy data it reads empty without writing', async () => {
+    expect(await readStore()).toEqual({ version: 2, origins: {} })
+    // A fresh install must not write on read, or watchPermissions fires
+    // spuriously before anything is connected.
+    expect(
+      await storage.getItem<PermissionStore>(DAPP_PERMISSIONS_KEY),
+    ).toBeNull()
+  })
+})

--- a/apps/wallet/src/data/dapp-permissions.ts
+++ b/apps/wallet/src/data/dapp-permissions.ts
@@ -1,0 +1,440 @@
+import { storage } from '@wxt-dev/storage'
+
+/**
+ * dApp connection permissions, modelled on EIP-2255 and on status-go's
+ * `services/connector/database` so the wallet, desktop and mobile agree on what
+ * a granted permission looks like.
+ *
+ * Stored in `local`: a connection is revoked only by an explicit request --
+ * `wallet_revokePermissions` or the Disconnect action. Nothing else drops it,
+ * not a page reload, a browser restart, locking, or switching accounts.
+ */
+
+export const DAPP_PERMISSIONS_KEY = 'local:dapp:permissions' as const
+
+/** Capability granted by `eth_requestAccounts`; presence of it means "connected". */
+export const ETH_ACCOUNTS_CAPABILITY = 'eth_accounts'
+
+export const DEFAULT_CHAIN_ID = '0x1'
+
+export type Caveat = {
+  type: string
+  value: unknown
+}
+
+export type Permission = {
+  parentCapability: string
+  caveats: Caveat[]
+}
+
+export type OriginRecord = {
+  permissions: Permission[]
+  /**
+   * Every account the user has explicitly connected to this origin. Source of
+   * truth for `eth_accounts`' `restrictReturnedAccounts` caveat, which is
+   * derived from it rather than stored alongside it.
+   */
+  accounts: string[]
+  /**
+   * The single account this origin currently sees. Null until adopted, which
+   * only happens for records predating per-account tracking.
+   */
+  selectedAddress: string | null
+  chainId: string
+  grantedAt: number
+}
+
+export type PermissionStore = {
+  version: typeof STORE_VERSION
+  origins: Record<string, OriginRecord>
+}
+
+const STORE_VERSION = 2
+
+const EMPTY_STORE: PermissionStore = {
+  version: STORE_VERSION,
+  origins: {},
+}
+
+// Legacy session keys, superseded by DAPP_PERMISSIONS_KEY. Read once for
+// migration, then removed.
+const LEGACY_ORIGINS_KEY = 'session:connectedOrigins' as const
+const LEGACY_CHAIN_IDS_KEY = 'session:originChainIds' as const
+
+/**
+ * Mirrors status-go's `persistence.NormalizeURL`: strip a trailing slash and
+ * lowercase, so an origin can never be keyed two ways.
+ */
+export function normalizeOrigin(origin: string): string {
+  return origin.trim().replace(/\/+$/, '').toLowerCase()
+}
+
+/** Addresses are stored as given (checksummed) but always compared folded. */
+export function isSameAddress(a: string | null, b: string | null): boolean {
+  if (!a || !b) return false
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * Fills in fields added after a record was written, in memory only -- a read
+ * must never write, or a fresh install fires `watchPermissions` before
+ * anything is connected. The upgraded shape persists on the next real write.
+ */
+function normalizeRecord(record: Partial<OriginRecord>): OriginRecord {
+  return {
+    permissions: record.permissions ?? [],
+    accounts: record.accounts ?? [],
+    selectedAddress: record.selectedAddress ?? null,
+    chainId: record.chainId ?? DEFAULT_CHAIN_ID,
+    grantedAt: record.grantedAt ?? Date.now(),
+  }
+}
+
+// Serializes read-modify-write cycles so concurrent grants/revocations for
+// different origins can't clobber each other. Per-context only -- the page and
+// the service worker hold separate chains, so a simultaneous write from both
+// can still race. chrome.storage offers no transaction to close that, and in
+// practice the two never mutate permissions at the same moment.
+let writeChain: Promise<unknown> = Promise.resolve()
+
+function withStore<T>(
+  mutate: (store: PermissionStore) => { store: PermissionStore; result: T },
+): Promise<T> {
+  const next = writeChain.then(async () => {
+    const current = await readStore()
+    const { store, result } = mutate(current)
+    // Mutations that decline to change anything hand back the same object.
+    // Writing it anyway would fire `watchPermissions` on every refused switch.
+    if (store !== current) {
+      await storage.setItem(DAPP_PERMISSIONS_KEY, store)
+    }
+    return result
+  })
+  // Keep the chain alive even if this link rejects.
+  writeChain = next.catch(() => {})
+  return next
+}
+
+/**
+ * Adopts the pre-`local` session keys. Returns null -- and deliberately writes
+ * nothing -- when there is nothing to migrate, so a fresh install neither
+ * touches storage nor fires `watchPermissions` on the first read.
+ */
+async function migrateLegacyKeys(): Promise<PermissionStore | null> {
+  const [origins, chainIds] = await Promise.all([
+    storage.getItem<string[]>(LEGACY_ORIGINS_KEY),
+    storage.getItem<Record<string, string>>(LEGACY_CHAIN_IDS_KEY),
+  ])
+
+  if (!origins?.length) {
+    return null
+  }
+
+  const grantedAt = Date.now()
+  const store: PermissionStore = {
+    version: STORE_VERSION,
+    origins: Object.fromEntries(
+      origins.map(origin => [
+        normalizeOrigin(origin),
+        // The legacy keys carried no account identity, so these records adopt
+        // the active account on first use -- see `adoptSelectedAddress`.
+        normalizeRecord({
+          permissions: [
+            { parentCapability: ETH_ACCOUNTS_CAPABILITY, caveats: [] },
+          ],
+          chainId: chainIds?.[origin] ?? DEFAULT_CHAIN_ID,
+          grantedAt,
+        }),
+      ]),
+    ),
+  }
+
+  await storage.setItem(DAPP_PERMISSIONS_KEY, store)
+  await storage.removeItems([LEGACY_ORIGINS_KEY, LEGACY_CHAIN_IDS_KEY])
+  return store
+}
+
+export async function readStore(): Promise<PermissionStore> {
+  const stored = await storage.getItem<PermissionStore>(DAPP_PERMISSIONS_KEY)
+  if (!stored) {
+    return (await migrateLegacyKeys()) ?? EMPTY_STORE
+  }
+
+  return {
+    version: STORE_VERSION,
+    origins: Object.fromEntries(
+      Object.entries(stored.origins ?? {}).map(([origin, record]) => [
+        origin,
+        normalizeRecord(record),
+      ]),
+    ),
+  }
+}
+
+/**
+ * Diagnostics for dApp connection loss. Enable from the service-worker
+ * console with `chrome.storage.local.set({ 'dapp:debug': true })`.
+ */
+async function debugEnabled(): Promise<boolean> {
+  return (await storage.getItem<boolean>('local:dapp:debug')) === true
+}
+
+export async function debugLog(event: string, detail: unknown): Promise<void> {
+  if (!(await debugEnabled())) return
+  const store = await readStore()
+
+  console.log(
+    `[status:dapp] ${event}`,
+    detail,
+    'stored origins:',
+    Object.keys(store.origins),
+  )
+}
+
+export async function getOriginRecord(
+  origin: string,
+): Promise<OriginRecord | null> {
+  const store = await readStore()
+  return store.origins[normalizeOrigin(origin)] ?? null
+}
+
+/** An origin is connected once it holds the `eth_accounts` capability. */
+export async function isOriginPermitted(origin: string): Promise<boolean> {
+  const record = await getOriginRecord(origin)
+  return (
+    record?.permissions.some(
+      permission => permission.parentCapability === ETH_ACCOUNTS_CAPABILITY,
+    ) ?? false
+  )
+}
+
+export async function getPermissions(origin: string): Promise<Permission[]> {
+  const record = await getOriginRecord(origin)
+  return record?.permissions ?? []
+}
+
+export async function getPermittedOrigins(): Promise<string[]> {
+  const store = await readStore()
+  return Object.entries(store.origins)
+    .filter(([, record]) =>
+      record.permissions.some(
+        permission => permission.parentCapability === ETH_ACCOUNTS_CAPABILITY,
+      ),
+    )
+    .map(([origin]) => origin)
+}
+
+/**
+ * Grants `parentCapability` to `origin`, replacing any existing grant of the
+ * same capability. Creates the origin record if this is the first grant.
+ *
+ * Not the way to connect an account -- the record it creates has no account, so
+ * `eth_accounts` would fall back to adopting whichever one the wallet has
+ * selected. Anything granting `eth_accounts` must call `connectAccount`.
+ */
+export function grantPermission(
+  origin: string,
+  parentCapability: string,
+  caveats: Caveat[] = [],
+): Promise<Permission> {
+  const key = normalizeOrigin(origin)
+  const permission: Permission = { parentCapability, caveats }
+
+  return withStore(store => {
+    const existing = normalizeRecord(store.origins[key] ?? {})
+    const permissions = [
+      ...existing.permissions.filter(
+        p => p.parentCapability !== parentCapability,
+      ),
+      permission,
+    ]
+
+    return {
+      store: {
+        ...store,
+        origins: { ...store.origins, [key]: { ...existing, permissions } },
+      },
+      result: permission,
+    }
+  })
+}
+
+/**
+ * Connects `address` to `origin` and makes it the account the origin sees.
+ *
+ * The only way an account joins an origin's list, so a dApp can never be
+ * handed an account the user did not deliberately connect to it. Called both
+ * from the `eth_requestAccounts` approval and from the wallet's own Connect
+ * action -- in the latter the click *is* the consent, so no popup is shown.
+ */
+export function connectAccount(origin: string, address: string): Promise<void> {
+  const key = normalizeOrigin(origin)
+
+  return withStore(store => {
+    const existing = normalizeRecord(store.origins[key] ?? {})
+    const accounts = existing.accounts.some(a => isSameAddress(a, address))
+      ? existing.accounts
+      : [...existing.accounts, address]
+    const permissions = [
+      ...existing.permissions.filter(
+        p => p.parentCapability !== ETH_ACCOUNTS_CAPABILITY,
+      ),
+      { parentCapability: ETH_ACCOUNTS_CAPABILITY, caveats: [] },
+    ]
+
+    return {
+      store: {
+        ...store,
+        origins: {
+          ...store.origins,
+          [key]: {
+            ...existing,
+            accounts,
+            permissions,
+            selectedAddress: address,
+          },
+        },
+      },
+      result: undefined,
+    }
+  })
+}
+
+export async function getConnectedAccounts(origin: string): Promise<string[]> {
+  return (await getOriginRecord(origin))?.accounts ?? []
+}
+
+export async function isAccountConnected(
+  origin: string,
+  address: string,
+): Promise<boolean> {
+  const accounts = await getConnectedAccounts(origin)
+  return accounts.some(a => isSameAddress(a, address))
+}
+
+export async function getSelectedAddress(
+  origin: string,
+): Promise<string | null> {
+  return (await getOriginRecord(origin))?.selectedAddress ?? null
+}
+
+/**
+ * Points `origin` at an account it is already connected to. Refuses otherwise:
+ * switching accounts in the wallet must not silently expose a new account to a
+ * dApp the user never connected it to.
+ *
+ * Returns whether the origin's account actually changed, so the caller only
+ * emits `accountsChanged` when there is something to report.
+ */
+export function selectAccountForOrigin(
+  origin: string,
+  address: string,
+): Promise<boolean> {
+  const key = normalizeOrigin(origin)
+
+  return withStore(store => {
+    const existing = store.origins[key]
+    if (
+      !existing ||
+      !existing.accounts.some(a => isSameAddress(a, address)) ||
+      isSameAddress(existing.selectedAddress, address)
+    ) {
+      return { store, result: false }
+    }
+
+    return {
+      store: {
+        ...store,
+        origins: {
+          ...store.origins,
+          [key]: { ...existing, selectedAddress: address },
+        },
+      },
+      result: true,
+    }
+  })
+}
+
+/**
+ * Pins a record that predates per-account tracking to `address`, which is the
+ * account it has been showing all along. Idempotent and one-way: once a record
+ * has a selected address nothing here can move it, so the fallback can never
+ * become a path for drifting a dApp onto the wallet's current selection.
+ */
+export function adoptSelectedAddress(
+  origin: string,
+  address: string,
+): Promise<string> {
+  const key = normalizeOrigin(origin)
+
+  return withStore(store => {
+    const existing = store.origins[key]
+    if (!existing) {
+      return { store, result: address }
+    }
+    if (existing.selectedAddress) {
+      return { store, result: existing.selectedAddress }
+    }
+
+    return {
+      store: {
+        ...store,
+        origins: {
+          ...store.origins,
+          [key]: {
+            ...existing,
+            accounts: existing.accounts.length ? existing.accounts : [address],
+            selectedAddress: address,
+          },
+        },
+      },
+      result: address,
+    }
+  })
+}
+
+export function revokeOrigin(origin: string): Promise<void> {
+  const key = normalizeOrigin(origin)
+  void debugLog('revoke', { origin, stack: new Error('revoke').stack })
+
+  return withStore(store => {
+    if (!(key in store.origins)) {
+      return { store, result: undefined }
+    }
+
+    const origins = { ...store.origins }
+    delete origins[key]
+    return { store: { ...store, origins }, result: undefined }
+  })
+}
+
+export async function getChainIdForOrigin(origin: string): Promise<string> {
+  const record = await getOriginRecord(origin)
+  return record?.chainId ?? DEFAULT_CHAIN_ID
+}
+
+export function setChainIdForOrigin(
+  origin: string,
+  chainId: string,
+): Promise<void> {
+  const key = normalizeOrigin(origin)
+
+  return withStore(store => {
+    const existing = normalizeRecord(store.origins[key] ?? {})
+    return {
+      store: {
+        ...store,
+        origins: { ...store.origins, [key]: { ...existing, chainId } },
+      },
+      result: undefined,
+    }
+  })
+}
+
+export function watchPermissions(
+  callback: (store: PermissionStore) => void,
+): () => void {
+  return storage.watch<PermissionStore>(DAPP_PERMISSIONS_KEY, value => {
+    callback(value ?? EMPTY_STORE)
+  })
+}

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -11,6 +11,7 @@ import {
   type PendingApproval,
   setApprovalResult,
 } from '../../data/approval'
+import { connectAccount } from '../../data/dapp-permissions'
 import { apiClient } from '../../providers/api-client'
 
 const CHAIN_NAMES: Record<string, string> = {
@@ -83,6 +84,18 @@ export function ApprovalPage() {
   const respond = async (approved: boolean) => {
     if (!approval || isSubmitting) return
     setIsSubmitting(true)
+
+    // Persist the grant here rather than leaving it to the service worker.
+    // The worker resumes only once this window closes, and MV3 may terminate
+    // it at exactly that point -- losing the grant while the dApp had already
+    // been told it was connected, so every later load prompts again.
+    //
+    // `connectAccount`, not `grantPermission`: a record written without the
+    // approved account would later adopt whichever account the wallet happens
+    // to have selected.
+    if (approved && approval.type === 'eth_requestAccounts') {
+      await connectAccount(approval.origin, approval.address)
+    }
 
     await setApprovalResult({
       id: approval.id,

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -41,21 +41,62 @@ function hexToReadableMessage(hex: string): string {
 
 export function ApprovalPage() {
   const [approval, setApproval] = useState<PendingApproval | null>(null)
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'unavailable'>(
+    'loading',
+  )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSessionActive, setIsSessionActive] = useState(false)
-  const [isCheckingSession, setIsCheckingSession] = useState(true)
   const [isUnlocking, setIsUnlocking] = useState(false)
 
   useEffect(() => {
-    getPendingApproval().then(setApproval)
-    apiClient.session.status.query().then(status => {
-      setIsSessionActive(status.isUnlocked)
-      setIsCheckingSession(false)
-    })
+    let cancelled = false
+
+    const load = async () => {
+      // Both reads are guarded. Neither used to be, and either rejecting left
+      // the popup rendering null forever -- an empty white window with no way
+      // out. A cold service worker rejecting the first port message is enough
+      // to trigger it, which is why it looked intermittent.
+      const [pending, session] = await Promise.all([
+        getPendingApproval().catch(() => null),
+        apiClient.session.status.query().catch(() => ({ isUnlocked: false })),
+      ])
+
+      if (cancelled) return
+      setApproval(pending)
+      setIsSessionActive(session.isUnlocked)
+      setPhase(pending ? 'ready' : 'unavailable')
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  if (!approval || isCheckingSession) {
+  if (phase === 'loading') {
     return null
+  }
+
+  // The request is gone: expired, already answered, or dropped when the worker
+  // restarted. Say so rather than showing an empty window.
+  if (phase === 'unavailable' || !approval) {
+    return (
+      <div
+        data-customisation="blue"
+        className="flex h-screen flex-col items-center justify-center gap-3 bg-white-100 p-6 text-center"
+      >
+        <p className="text-15 font-semibold text-neutral-100">
+          Request no longer available
+        </p>
+        <p className="text-13 text-neutral-50">
+          It expired or was already answered. Try connecting again from the
+          site.
+        </p>
+        <Button variant="grey" onPress={() => window.close()}>
+          Close
+        </Button>
+      </div>
+    )
   }
 
   const needsPassword = !isSessionActive

--- a/apps/wallet/src/entrypoints/background.ts
+++ b/apps/wallet/src/entrypoints/background.ts
@@ -92,18 +92,6 @@ export default defineBackground({
 
     // dApp message handler (single listener to avoid Chrome port conflicts)
     chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-      if (message?.type === 'status:disconnect') {
-        const origin = message.data?.origin
-        if (typeof origin === 'string') {
-          handleRpcRequest(
-            'wallet_revokePermissions',
-            [{ eth_accounts: {} }],
-            origin,
-          )
-        }
-        return false
-      }
-
       if (message?.type !== 'status:rpc') {
         return false
       }

--- a/apps/wallet/src/entrypoints/bridge.content.ts
+++ b/apps/wallet/src/entrypoints/bridge.content.ts
@@ -30,14 +30,6 @@ export default defineContentScript({
         return
       }
 
-      if (message.type === 'status:provider:disconnect') {
-        chrome.runtime.sendMessage({
-          type: 'status:disconnect',
-          data: { origin: window.location.origin },
-        })
-        return
-      }
-
       if (message.type !== 'status:provider') {
         return
       }
@@ -70,6 +62,25 @@ export default defineContentScript({
         } satisfies ProxyMessage)
       }
     }
+
+    // Wallet-initiated events (an account switch) have no open port to answer
+    // on, so the service worker pushes them here and they are re-posted into
+    // the page for the provider to emit.
+    chrome.runtime.onMessage.addListener(message => {
+      if (message?.type !== 'status:event') {
+        return false
+      }
+
+      window.postMessage(
+        {
+          type: 'status:provider:event',
+          event: message.event,
+          data: message.data,
+        },
+        window.origin,
+      )
+      return false
+    })
 
     ctx.addEventListener(window, 'message', handleProviderMessage)
   },

--- a/apps/wallet/src/lib/dapp-events.test.ts
+++ b/apps/wallet/src/lib/dapp-events.test.ts
@@ -1,0 +1,117 @@
+import { storage } from '@wxt-dev/storage'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  connectAccount,
+  getConnectedAccounts,
+  getSelectedAddress,
+} from '../data/dapp-permissions'
+import {
+  connectAccountToDapp,
+  disconnectDapp,
+  syncAccountToDapps,
+} from './dapp-events'
+
+const ORIGIN = 'https://app.velora.xyz'
+const OTHER_ORIGIN = 'https://app.uniswap.org'
+const ACCOUNT_A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const ACCOUNT_B = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+
+type Sent = { tabId: number; message: { event: string; data: unknown } }
+
+let sent: Sent[] = []
+
+beforeEach(async () => {
+  sent = []
+  vi.stubGlobal('chrome', {
+    tabs: {
+      query: async () => [
+        { id: 1, url: `${ORIGIN}/swap?from=eth` },
+        { id: 2, url: `${OTHER_ORIGIN}/` },
+        // A tab the bridge never loaded into. Pushing to it rejects.
+        { id: 3, url: 'chrome://extensions' },
+        { id: 4 },
+      ],
+      sendMessage: async (tabId: number, message: Sent['message']) => {
+        if (tabId === 3) throw new Error('Receiving end does not exist.')
+        sent.push({ tabId, message })
+      },
+    },
+  })
+  await storage.clear('local')
+})
+
+afterEach(async () => {
+  await storage.clear('local')
+  vi.unstubAllGlobals()
+})
+
+describe('syncAccountToDapps', () => {
+  test('re-points a dApp already connected to the account and tells it', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(ORIGIN, ACCOUNT_B)
+
+    await syncAccountToDapps(ACCOUNT_A)
+
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+    expect(sent).toEqual([
+      {
+        tabId: 1,
+        message: {
+          type: 'status:event',
+          event: 'accountsChanged',
+          data: [ACCOUNT_A],
+        },
+      },
+    ])
+  })
+
+  // The whole point of the change: an account the user never connected here
+  // must not appear in the dApp just because the wallet switched to it.
+  test('leaves a dApp that was never connected to the account alone', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    await syncAccountToDapps(ACCOUNT_B)
+
+    expect(await getSelectedAddress(ORIGIN)).toBe(ACCOUNT_A)
+    expect(sent).toEqual([])
+  })
+
+  test('says nothing when the dApp already shows the account', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    await syncAccountToDapps(ACCOUNT_A)
+
+    expect(sent).toEqual([])
+  })
+
+  test('only notifies tabs on the matching origin', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+    await connectAccount(ORIGIN, ACCOUNT_B)
+    await connectAccount(OTHER_ORIGIN, ACCOUNT_A)
+    await connectAccount(OTHER_ORIGIN, ACCOUNT_B)
+    await syncAccountToDapps(ACCOUNT_A)
+
+    expect(sent.map(s => s.tabId).sort()).toEqual([1, 2])
+  })
+})
+
+describe('acting on a dApp from the wallet UI', () => {
+  test('connecting adds the account and switches the dApp live', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    await connectAccountToDapp(ORIGIN, ACCOUNT_B)
+
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([ACCOUNT_A, ACCOUNT_B])
+    expect(sent[0]?.message.data).toEqual([ACCOUNT_B])
+  })
+
+  test('disconnecting reports an empty account list', async () => {
+    await connectAccount(ORIGIN, ACCOUNT_A)
+
+    await disconnectDapp(ORIGIN)
+
+    expect(await getConnectedAccounts(ORIGIN)).toEqual([])
+    expect(sent[0]?.message.data).toEqual([])
+  })
+})

--- a/apps/wallet/src/lib/dapp-events.ts
+++ b/apps/wallet/src/lib/dapp-events.ts
@@ -1,0 +1,97 @@
+import {
+  connectAccount,
+  getPermittedOrigins,
+  normalizeOrigin,
+  revokeOrigin,
+  selectAccountForOrigin,
+} from '../data/dapp-permissions'
+
+/**
+ * Wallet-initiated EIP-1193 events.
+ *
+ * Every other dApp interaction is page-initiated: the provider opens a
+ * `MessageChannel` and the service worker answers on it. An account switch has
+ * no such request to answer, so it is pushed the other way --
+ * `chrome.tabs.sendMessage` to the bridge content script, which re-posts it to
+ * the page for the provider to emit. Without this a dApp only notices the new
+ * account on reload.
+ */
+export type DappEventMessage = {
+  type: 'status:event'
+  event: 'accountsChanged'
+  data: unknown
+}
+
+function originOf(url: string | undefined): string | null {
+  if (!url) return null
+  try {
+    return normalizeOrigin(new URL(url).origin)
+  } catch {
+    return null
+  }
+}
+
+async function broadcast(origin: string, message: DappEventMessage) {
+  const key = normalizeOrigin(origin)
+  const tabs = await chrome.tabs.query({})
+
+  await Promise.all(
+    tabs.map(tab => {
+      if (tab.id === undefined || originOf(tab.url) !== key) {
+        return
+      }
+      // Tabs loaded before the extension, discarded tabs, and privileged pages
+      // have no bridge listening. Nothing to do about it here.
+      return chrome.tabs.sendMessage(tab.id, message).catch(() => {})
+    }),
+  )
+}
+
+export function notifyAccountsChanged(
+  origin: string,
+  accounts: string[],
+): Promise<void> {
+  return broadcast(origin, {
+    type: 'status:event',
+    event: 'accountsChanged',
+    data: accounts,
+  })
+}
+
+/**
+ * Re-points every dApp already connected to `address` at it, and tells them.
+ *
+ * Origins that have never been connected to this account are deliberately left
+ * on the account they were connected with -- the user gets a Connect action in
+ * the wallet instead. Call this only from a deliberate account or wallet
+ * switch, never from a storage watcher: the extension page writes its account
+ * on mount before the persisted selection hydrates, so a watcher would re-point
+ * dApps at whichever wallet happens to be first in the list.
+ */
+export async function syncAccountToDapps(address: string): Promise<void> {
+  const origins = await getPermittedOrigins()
+
+  await Promise.all(
+    origins.map(async origin => {
+      // Refused for any origin this account was never connected to, which is
+      // what keeps the dApp on the account the user actually connected.
+      if (!(await selectAccountForOrigin(origin, address))) return
+      await notifyAccountsChanged(origin, [address])
+    }),
+  )
+}
+
+/** Connects `address` to a dApp from the wallet UI and switches it live. */
+export async function connectAccountToDapp(
+  origin: string,
+  address: string,
+): Promise<void> {
+  await connectAccount(origin, address)
+  await notifyAccountsChanged(origin, [address])
+}
+
+/** Revokes from the wallet UI. The empty array is EIP-1193 for "logged out". */
+export async function disconnectDapp(origin: string): Promise<void> {
+  await revokeOrigin(origin)
+  await notifyAccountsChanged(origin, [])
+}

--- a/apps/wallet/src/lib/provider-events.test.ts
+++ b/apps/wallet/src/lib/provider-events.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { Provider } from '@status-im/ethereum-provider'
+import { beforeAll, expect, test, vi } from 'vitest'
+
+/**
+ * The page-facing half of the wallet-initiated event path: the bridge content
+ * script re-posts what the service worker pushed, and the provider turns it
+ * into an EIP-1193 event. Covered here because it is what lets an account
+ * switch reach a dApp without a reload.
+ */
+
+const ACCOUNT = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+// happy-dom leaves `window.origin` undefined, which browsers define.
+beforeAll(() => {
+  Object.defineProperty(window, 'origin', { value: location.origin })
+})
+
+function postFromBridge(data: unknown, origin = window.origin) {
+  // Dispatched rather than posted so the sending origin can be varied;
+  // `postMessage`'s targetOrigin decides delivery, not `event.origin`.
+  window.dispatchEvent(new MessageEvent('message', { data, origin }))
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+test('a pushed account switch is emitted as accountsChanged', async () => {
+  const provider = new Provider()
+  const onAccountsChanged = vi.fn()
+  provider.on('accountsChanged', onAccountsChanged)
+
+  await postFromBridge({
+    type: 'status:provider:event',
+    event: 'accountsChanged',
+    data: [ACCOUNT],
+  })
+
+  expect(onAccountsChanged).toHaveBeenCalledWith([ACCOUNT])
+  expect(provider.connected).toBe(true)
+})
+
+test('an empty account list reads as disconnected', async () => {
+  const provider = new Provider()
+  const onAccountsChanged = vi.fn()
+  provider.on('accountsChanged', onAccountsChanged)
+
+  await postFromBridge({
+    type: 'status:provider:event',
+    event: 'accountsChanged',
+    data: [],
+  })
+
+  expect(onAccountsChanged).toHaveBeenCalledWith([])
+  expect(provider.connected).toBe(false)
+})
+
+test('unrelated page messages are ignored', async () => {
+  const provider = new Provider()
+  const onAccountsChanged = vi.fn()
+  provider.on('accountsChanged', onAccountsChanged)
+
+  await postFromBridge({ type: 'status:provider:event', event: 'chainChanged' })
+  await postFromBridge({ type: 'some-other-library', data: [ACCOUNT] })
+
+  expect(onAccountsChanged).not.toHaveBeenCalled()
+})
+
+test('a cross-origin frame cannot switch the account', async () => {
+  const provider = new Provider()
+  const onAccountsChanged = vi.fn()
+  provider.on('accountsChanged', onAccountsChanged)
+
+  await postFromBridge(
+    {
+      type: 'status:provider:event',
+      event: 'accountsChanged',
+      data: [ACCOUNT],
+    },
+    'https://evil.test',
+  )
+
+  expect(onAccountsChanged).not.toHaveBeenCalled()
+})

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -24,6 +24,9 @@ type Listener = (
 /** Approves whatever approval the handler opens a popup for. */
 let autoApprove = true
 
+/** Popups the handler opened, counted by the mock's `windows.create`. */
+let popupsOpened = 0
+
 function createChromeMock() {
   const session = new Map<string, unknown>()
   const listeners: Listener[] = []
@@ -64,6 +67,7 @@ function createChromeMock() {
       getCurrent: async () => ({ left: 0, top: 0, width: 1200 }),
       // Stands in for the user acting on the approval popup.
       create: async () => {
+        popupsOpened++
         const pending = session.get('pendingApproval') as { id: string }
         queueMicrotask(() => {
           void set({
@@ -93,6 +97,7 @@ const signed: { walletId?: string; fromAddress?: string } = {}
 
 beforeEach(async () => {
   autoApprove = true
+  popupsOpened = 0
   vi.stubGlobal('chrome', createChromeMock())
   vi.stubGlobal('api', {
     wallet: {
@@ -183,17 +188,9 @@ test('an explicit revoke disconnects', async () => {
 // They then overwrote each other's record and one window was left showing a
 // request that no longer existed -- a blank approval popup.
 test('concurrent connect requests open a single popup', async () => {
-  let popups = 0
-  const create = chrome.windows.create
-  chrome.windows.create = (async (...args: unknown[]) => {
-    popups++
-    // @ts-expect-error passthrough to the mock
-    return create(...args)
-  }) as typeof chrome.windows.create
-
   const [first, second] = await Promise.allSettled([connect(), connect()])
 
-  expect(popups).toBe(1)
+  expect(popupsOpened).toBe(1)
   expect([first.status, second.status].sort()).toEqual([
     'fulfilled',
     'rejected',

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -1,0 +1,261 @@
+import { storage } from '@wxt-dev/storage'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  connectAccount,
+  ETH_ACCOUNTS_CAPABILITY,
+  grantPermission,
+  selectAccountForOrigin,
+} from '../data/dapp-permissions'
+import { handleRpcRequest } from './rpc-handler'
+
+const ORIGIN = 'https://app.velora.xyz'
+const OTHER_ORIGIN = 'https://app.uniswap.org'
+const ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const OTHER_ADDRESS = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const WALLET_ID = 'wallet-1'
+const OTHER_WALLET_ID = 'wallet-2'
+
+type Listener = (
+  changes: Record<string, { newValue?: unknown; oldValue?: unknown }>,
+  area: string,
+) => void
+
+/** Approves whatever approval the handler opens a popup for. */
+let autoApprove = true
+
+function createChromeMock() {
+  const session = new Map<string, unknown>()
+  const listeners: Listener[] = []
+
+  const set = async (items: Record<string, unknown>) => {
+    const changes: Record<string, { newValue?: unknown }> = {}
+    for (const [k, v] of Object.entries(items)) {
+      session.set(k, v)
+      changes[k] = { newValue: v }
+    }
+    listeners.forEach(l => l(changes, 'session'))
+  }
+
+  return {
+    storage: {
+      session: {
+        get: async (keys: string | string[]) => {
+          const list = Array.isArray(keys) ? keys : [keys]
+          const out: Record<string, unknown> = {}
+          for (const k of list) if (session.has(k)) out[k] = session.get(k)
+          return out
+        },
+        set,
+        remove: async (keys: string | string[]) => {
+          for (const k of Array.isArray(keys) ? keys : [keys]) session.delete(k)
+        },
+      },
+      onChanged: {
+        addListener: (l: Listener) => listeners.push(l),
+        removeListener: (l: Listener) => {
+          const i = listeners.indexOf(l)
+          if (i >= 0) listeners.splice(i, 1)
+        },
+      },
+    },
+    runtime: { getURL: (p: string) => `chrome-extension://test/${p}` },
+    windows: {
+      getCurrent: async () => ({ left: 0, top: 0, width: 1200 }),
+      // Stands in for the user acting on the approval popup.
+      create: async () => {
+        const pending = session.get('pendingApproval') as { id: string }
+        queueMicrotask(() => {
+          void set({
+            approvalResult: { id: pending.id, approved: autoApprove },
+          })
+        })
+        return { id: 1 }
+      },
+      onRemoved: {
+        addListener: () => {},
+        removeListener: () => {},
+      },
+    },
+  }
+}
+
+/** Mirrors what `wallet-context` does when the user picks another account. */
+async function selectAccount(address: string, walletId: string) {
+  await chrome.storage.session.set({
+    dappAddress: address,
+    dappAccountName: walletId,
+    dappWalletId: walletId,
+  })
+}
+
+const signed: { walletId?: string; fromAddress?: string } = {}
+
+beforeEach(async () => {
+  autoApprove = true
+  vi.stubGlobal('chrome', createChromeMock())
+  vi.stubGlobal('api', {
+    wallet: {
+      account: {
+        ethereum: {
+          signMessage: async (input: {
+            walletId: string
+            fromAddress: string
+          }) => {
+            Object.assign(signed, input)
+            return { signature: '0xsig' }
+          },
+        },
+      },
+    },
+  })
+  await storage.clear('local')
+  await storage.clear('session')
+  await storage.setItem(
+    'local:vault:metadata',
+    JSON.stringify({
+      [WALLET_ID]: {
+        id: WALLET_ID,
+        name: 'Wallet 1',
+        type: 'mnemonic',
+        accounts: [{ address: ADDRESS }],
+        selectedAccountAddress: ADDRESS,
+      },
+      [OTHER_WALLET_ID]: {
+        id: OTHER_WALLET_ID,
+        name: 'Wallet 2',
+        type: 'mnemonic',
+        accounts: [{ address: OTHER_ADDRESS }],
+        selectedAccountAddress: OTHER_ADDRESS,
+      },
+    }),
+  )
+  // The account the wallet exposes to dApps.
+  await selectAccount(ADDRESS, WALLET_ID)
+})
+
+afterEach(async () => {
+  await storage.clear('local')
+  await storage.clear('session')
+  vi.unstubAllGlobals()
+})
+
+const connect = () => handleRpcRequest('eth_requestAccounts', [], ORIGIN)
+const accounts = () => handleRpcRequest('eth_accounts', [], ORIGIN)
+
+test('approving a connection returns the account', async () => {
+  await expect(connect()).resolves.toEqual([ADDRESS])
+})
+
+test('the grant survives a dApp reload', async () => {
+  await connect()
+
+  expect(await accounts()).toEqual([ADDRESS])
+})
+
+test('a second eth_requestAccounts does not prompt again', async () => {
+  await connect()
+
+  // If this opened a popup it would be rejected, since autoApprove is off.
+  autoApprove = false
+  await expect(connect()).resolves.toEqual([ADDRESS])
+})
+
+test('an unconnected origin gets no accounts', async () => {
+  expect(
+    await handleRpcRequest('eth_accounts', [], 'https://evil.test'),
+  ).toEqual([])
+})
+
+test('an explicit revoke disconnects', async () => {
+  await connect()
+  await handleRpcRequest(
+    'wallet_revokePermissions',
+    [{ eth_accounts: {} }],
+    ORIGIN,
+  )
+
+  expect(await accounts()).toEqual([])
+})
+
+describe('switching accounts in the wallet', () => {
+  test('an unconnected account is not exposed to the dApp', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    expect(await accounts()).toEqual([ADDRESS])
+  })
+
+  test('eth_requestAccounts agrees with eth_accounts after a switch', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    // A dApp that re-requests on mount must not be handed the other account.
+    autoApprove = false
+    expect(await connect()).toEqual([ADDRESS])
+  })
+
+  test('a previously connected account is exposed again once selected', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+    await connectAccount(ORIGIN, OTHER_ADDRESS)
+
+    expect(await accounts()).toEqual([OTHER_ADDRESS])
+
+    await selectAccountForOrigin(ORIGIN, ADDRESS)
+    expect(await accounts()).toEqual([ADDRESS])
+  })
+
+  test('each origin keeps its own account', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+    await handleRpcRequest('eth_requestAccounts', [], OTHER_ORIGIN)
+
+    expect(await accounts()).toEqual([ADDRESS])
+    expect(await handleRpcRequest('eth_accounts', [], OTHER_ORIGIN)).toEqual([
+      OTHER_ADDRESS,
+    ])
+  })
+})
+
+describe('personal_sign follows the origin, not the wallet selection', () => {
+  test('signs with the connected account and its wallet', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    await handleRpcRequest('personal_sign', ['0xdeadbeef', ADDRESS], ORIGIN)
+
+    expect(signed).toMatchObject({
+      walletId: WALLET_ID,
+      fromAddress: ADDRESS,
+    })
+  })
+
+  // Without the pinning it signed with the newly selected account while the
+  // dApp believed it had asked for -- and received -- the connected one.
+  test('rejects a request for the account the dApp cannot see', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    await expect(
+      handleRpcRequest('personal_sign', ['0xdeadbeef', OTHER_ADDRESS], ORIGIN),
+    ).rejects.toMatchObject({ code: -32602 })
+  })
+
+  test('an unconnected origin cannot sign', async () => {
+    await expect(
+      handleRpcRequest('personal_sign', ['0xdeadbeef'], 'https://evil.test'),
+    ).rejects.toMatchObject({ code: 4100 })
+  })
+})
+
+describe('records predating per-account tracking', () => {
+  test('adopt the active account once, then hold it', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+
+    expect(await accounts()).toEqual([ADDRESS])
+
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+    expect(await accounts()).toEqual([ADDRESS])
+  })
+})

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -178,6 +178,32 @@ test('an explicit revoke disconnects', async () => {
   expect(await accounts()).toEqual([])
 })
 
+// Regression: the -32002 guard read the stored approval asynchronously, so two
+// requests in the same tick both saw an empty slot and each opened a popup.
+// They then overwrote each other's record and one window was left showing a
+// request that no longer existed -- a blank approval popup.
+test('concurrent connect requests open a single popup', async () => {
+  let popups = 0
+  const create = chrome.windows.create
+  chrome.windows.create = (async (...args: unknown[]) => {
+    popups++
+    // @ts-expect-error passthrough to the mock
+    return create(...args)
+  }) as typeof chrome.windows.create
+
+  const [first, second] = await Promise.allSettled([connect(), connect()])
+
+  expect(popups).toBe(1)
+  expect([first.status, second.status].sort()).toEqual([
+    'fulfilled',
+    'rejected',
+  ])
+  const rejected = [first, second].find(r => r.status === 'rejected')
+  expect((rejected as PromiseRejectedResult).reason).toMatchObject({
+    code: -32002,
+  })
+})
+
 describe('switching accounts in the wallet', () => {
   test('an unconnected account is not exposed to the dApp', async () => {
     await connect()

--- a/apps/wallet/src/lib/rpc-handler.ts
+++ b/apps/wallet/src/lib/rpc-handler.ts
@@ -137,9 +137,31 @@ type PendingApprovalInput = PendingApproval extends infer T
     : never
   : never
 
+/**
+ * Synchronous claim on the single approval slot.
+ *
+ * The stored `pendingApproval` is read asynchronously, so two requests
+ * arriving in the same tick both saw it empty and each opened a popup, then
+ * clobbered each other's record -- one of the windows ends up showing a
+ * request that no longer exists. The service worker is single-threaded, so a
+ * plain variable closes that window; the stored record still guards across
+ * worker restarts.
+ */
+let approvalInFlight = false
+
 function requestApproval(
   approval: PendingApprovalInput,
 ): Promise<ApprovalResult | null> {
+  if (approvalInFlight) {
+    return Promise.reject(
+      new ProviderRpcError({
+        code: -32002,
+        message: 'Already processing a request.',
+      }),
+    )
+  }
+  approvalInFlight = true
+
   return new Promise(resolve => {
     const id = crypto.randomUUID()
     let popupWindowId: number | undefined
@@ -152,6 +174,7 @@ function requestApproval(
     const cleanup = () => {
       if (settled) return
       settled = true
+      approvalInFlight = false
       clearTimeout(timeout)
       chrome.storage.onChanged.removeListener(storageListener)
       chrome.windows.onRemoved.removeListener(windowListener)

--- a/apps/wallet/src/lib/rpc-handler.ts
+++ b/apps/wallet/src/lib/rpc-handler.ts
@@ -1,80 +1,139 @@
 import { ProviderRpcError } from '@status-im/ethereum-provider'
+import { storage } from '@wxt-dev/storage'
 
 import {
+  APPROVAL_TIMEOUT_MS,
   type ApprovalResult,
   clearApprovalResult,
   clearPendingApproval,
+  getApprovalResult,
   getPendingApproval,
   type PendingApproval,
   setPendingApproval,
 } from '../data/approval'
+import {
+  adoptSelectedAddress,
+  connectAccount,
+  debugLog,
+  getChainIdForOrigin,
+  getSelectedAddress,
+  isOriginPermitted,
+  isSameAddress,
+  revokeOrigin,
+  setChainIdForOrigin,
+} from '../data/dapp-permissions'
+import * as walletMetadata from '../data/wallet-metadata'
 import { publicClient } from './public-client'
+import { SELECTED_WALLET_ID_KEY } from './storage-keys'
 
-const DEFAULT_CHAIN_ID = '0x1'
 const SUPPORTED_CHAIN_IDS = new Set(['0x1', '0x6300b5ea'])
 const DEFAULT_ACCOUNT_NAME = 'Account 1'
 
-// 5 minutes in ms
-const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000
 const APPROVAL_POPUP_WIDTH = 390
 const APPROVAL_POPUP_HEIGHT = 628
 
-async function getChainIdForOrigin(origin: string): Promise<string> {
-  const result = await chrome.storage.session.get('originChainIds')
-  const map: Record<string, string> = result.originChainIds || {}
-  return map[origin] || DEFAULT_CHAIN_ID
+type ActiveAccount = {
+  address: string
+  accountName: string
+  walletId: string
 }
 
-async function setChainIdForOrigin(
-  origin: string,
-  chainId: string,
-): Promise<void> {
-  const result = await chrome.storage.session.get('originChainIds')
-  const map: Record<string, string> = result.originChainIds || {}
-  map[origin] = chainId
-  await chrome.storage.session.set({ originChainIds: map })
-}
+/**
+ * The account exposed to dApps.
+ *
+ * The extension page mirrors its selection into session storage, but that is
+ * empty after a browser restart until the page is opened. Permissions live in
+ * `local` and outlast it, so fall back to wallet metadata -- otherwise a still
+ * permitted dApp would be told there is no account. Mirrors the selection rule
+ * in `wallet-context.tsx`.
+ */
+async function getActiveAccount(): Promise<ActiveAccount | null> {
+  const session = await chrome.storage.session.get([
+    'dappAddress',
+    'dappAccountName',
+    'dappWalletId',
+  ])
 
-async function getAddress(): Promise<string | null> {
-  const result = await chrome.storage.session.get('dappAddress')
-  return (result.dappAddress as string) || null
-}
+  if (session.dappAddress && session.dappWalletId) {
+    return {
+      address: session.dappAddress as string,
+      accountName: (session.dappAccountName as string) || DEFAULT_ACCOUNT_NAME,
+      walletId: session.dappWalletId as string,
+    }
+  }
 
-async function getAccountName(): Promise<string> {
-  const result = await chrome.storage.session.get('dappAccountName')
-  return (result.dappAccountName as string) || DEFAULT_ACCOUNT_NAME
-}
+  const wallets = await walletMetadata.getAll()
+  const selectedId = await storage.getItem<string>(SELECTED_WALLET_ID_KEY)
+  const wallet = wallets.find(w => w.id === selectedId) ?? wallets[0]
+  if (!wallet) return null
 
-async function getWalletId(): Promise<string | null> {
-  const result = await chrome.storage.session.get('dappWalletId')
-  return (result.dappWalletId as string) || null
-}
+  const account =
+    wallet.accounts.find(a => a.address === wallet.selectedAccountAddress) ??
+    wallet.accounts[0]
+  if (!account) return null
 
-async function isOriginConnected(origin: string): Promise<boolean> {
-  const result = await chrome.storage.session.get('connectedOrigins')
-  const origins: string[] = result.connectedOrigins || []
-  return origins.includes(origin)
-}
-
-async function addConnectedOrigin(origin: string): Promise<void> {
-  const result = await chrome.storage.session.get('connectedOrigins')
-  const origins: string[] = result.connectedOrigins || []
-  if (!origins.includes(origin)) {
-    origins.push(origin)
-    await chrome.storage.session.set({ connectedOrigins: origins })
+  return {
+    address: account.address,
+    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
+    walletId: wallet.id,
   }
 }
 
-async function removeConnectedOrigin(origin: string): Promise<void> {
-  const result = await chrome.storage.session.get('connectedOrigins')
-  const origins: string[] = result.connectedOrigins || []
-  const filtered = origins.filter(o => o !== origin)
-  await chrome.storage.session.set({ connectedOrigins: filtered })
+async function getAddress(): Promise<string | null> {
+  return (await getActiveAccount())?.address ?? null
+}
+
+async function getAccountName(): Promise<string> {
+  return (await getActiveAccount())?.accountName ?? DEFAULT_ACCOUNT_NAME
+}
+
+/**
+ * The account this origin sees, which is not necessarily the wallet's current
+ * selection: switching to an account the user never connected here must leave
+ * the dApp on the one it was connected with.
+ *
+ * Every dApp-facing read and signature resolves through this -- reading the
+ * pinned account for `eth_accounts` while signing with the selected one would
+ * hand the dApp a signature from an account it was never shown.
+ */
+async function getOriginAddress(origin: string): Promise<string | null> {
+  if (!(await isOriginPermitted(origin))) {
+    return null
+  }
+
+  const selected = await getSelectedAddress(origin)
+  if (selected) {
+    return selected
+  }
+
+  // Connected before per-account tracking existed: the account it has been
+  // showing is the active one, so pin it there once.
+  const active = await getAddress()
+  return active ? await adoptSelectedAddress(origin, active) : null
+}
+
+/**
+ * Locates the wallet holding `address`, across all wallets -- the account a dApp
+ * is pinned to may not belong to the currently selected wallet.
+ */
+async function findWalletForAddress(
+  address: string,
+): Promise<{ walletId: string; accountName: string } | null> {
+  const wallets = await walletMetadata.getAll()
+  const wallet = wallets.find(w =>
+    w.accounts.some(account => isSameAddress(account.address, address)),
+  )
+  if (!wallet) return null
+
+  return {
+    walletId: wallet.id,
+    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
+  }
 }
 
 type PendingApprovalInput = PendingApproval extends infer T
   ? T extends PendingApproval
-    ? Omit<T, 'id'>
+    ? Omit<T, 'id' | 'createdAt'>
     : never
   : never
 
@@ -115,15 +174,26 @@ function requestApproval(
 
     const windowListener = (removedWindowId: number) => {
       if (removedWindowId !== popupWindowId) return
-      cleanup()
-      resolve(null)
+      // The approval page writes its result and then closes itself, so this
+      // can arrive before the storage change that carries the verdict.
+      // Treating the close as a rejection outright loses approvals: re-read
+      // the result and only fall back to rejection when there genuinely is
+      // none.
+      void getApprovalResult().then(result => {
+        cleanup()
+        resolve(result?.id === id && result.approved ? result : null)
+      })
     }
 
     chrome.storage.onChanged.addListener(storageListener)
     chrome.windows.onRemoved.addListener(windowListener)
     ;(async () => {
       try {
-        await setPendingApproval({ id, ...approval } as PendingApproval)
+        await setPendingApproval({
+          id,
+          createdAt: Date.now(),
+          ...approval,
+        } as PendingApproval)
         const popupUrl = chrome.runtime.getURL('approval.html')
         const currentWindow = await chrome.windows.getCurrent()
         const left =
@@ -161,18 +231,34 @@ export async function handleRpcRequest(
   origin: string,
   metadata?: { title?: string; favicon?: string },
 ): Promise<unknown> {
+  if (
+    method === 'eth_accounts' ||
+    method === 'eth_requestAccounts' ||
+    method === 'wallet_requestPermissions'
+  ) {
+    void debugLog(method, {
+      origin,
+      permitted: await isOriginPermitted(origin),
+      address: await getAddress(),
+    })
+  }
+
   switch (method) {
     case 'eth_requestAccounts': {
+      // Answer from the origin's own account when it has one, or a dApp that
+      // calls this on every mount would flip back to the wallet's selection
+      // and contradict eth_accounts.
+      const connected = await getOriginAddress(origin)
+      if (connected) {
+        return [connected]
+      }
+
       const address = await getAddress()
       if (!address) {
         throw new ProviderRpcError({
           code: 4100,
           message: 'No active account',
         })
-      }
-
-      if (await isOriginConnected(origin)) {
-        return [address]
       }
 
       const existing = await getPendingApproval()
@@ -202,15 +288,13 @@ export async function handleRpcRequest(
         })
       }
 
-      await addConnectedOrigin(origin)
+      await connectAccount(origin, address)
+      void debugLog('granted', { origin, address })
       return [address]
     }
 
     case 'eth_accounts': {
-      if (!(await isOriginConnected(origin))) {
-        return []
-      }
-      const address = await getAddress()
+      const address = await getOriginAddress(origin)
       return address ? [address] : []
     }
 
@@ -263,7 +347,7 @@ export async function handleRpcRequest(
     }
 
     case 'wallet_revokePermissions': {
-      await removeConnectedOrigin(origin)
+      await revokeOrigin(origin)
       return null
     }
 
@@ -284,24 +368,25 @@ export async function handleRpcRequest(
     case 'personal_sign': {
       const p = params as [string, string]
       const message = p[0]
-      const storedAddress = await getAddress()
-      if (!storedAddress) {
+      // The origin's own account, not the wallet's selection: signing with the
+      // selected account would return a signature from a key the dApp was
+      // never shown.
+      const signerAddress = await getOriginAddress(origin)
+      if (!signerAddress) {
         throw new ProviderRpcError({
           code: 4100,
-          message: 'No active account',
+          message: 'No connected account',
         })
       }
-      // Validate dApp-provided address matches the active account
-      if (p[1] && storedAddress.toLowerCase() !== p[1].toLowerCase()) {
+      if (p[1] && !isSameAddress(signerAddress, p[1])) {
         throw new ProviderRpcError({
           code: -32602,
-          message: `Requested address ${p[1]} does not match the active account`,
+          message: `Requested address ${p[1]} does not match the connected account`,
         })
       }
-      const signerAddress = storedAddress
 
-      const walletId = await getWalletId()
-      if (!walletId) {
+      const signer = await findWalletForAddress(signerAddress)
+      if (!signer) {
         throw new ProviderRpcError({
           code: 4100,
           message: 'No wallet available',
@@ -318,14 +403,13 @@ export async function handleRpcRequest(
       }
 
       const signChainId = await getChainIdForOrigin(origin)
-      const signAccountName = await getAccountName()
       const signResult = await requestApproval({
         type: 'personal_sign',
         origin,
         title: metadata?.title ?? origin,
         favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
         address: signerAddress,
-        accountName: signAccountName,
+        accountName: signer.accountName,
         chainId: signChainId,
         message,
       })
@@ -354,7 +438,7 @@ export async function handleRpcRequest(
           }
         }
       ).api.wallet.account.ethereum.signMessage({
-        walletId,
+        walletId: signer.walletId,
         fromAddress: signerAddress,
         message,
       })

--- a/apps/wallet/src/lib/storage-keys.ts
+++ b/apps/wallet/src/lib/storage-keys.ts
@@ -3,3 +3,4 @@ export const TX_NOTIFIED_KEY = 'local:tx-monitor:notified' as const
 export const PENDING_TXS_KEY =
   'local:pending-transactions:transactions' as const
 export const NOTIFICATION_PROMPTED_KEY = 'local:notifications:prompted' as const
+export const SELECTED_WALLET_ID_KEY = 'local:wallet:selected-id' as const

--- a/apps/wallet/src/providers/signer-context.tsx
+++ b/apps/wallet/src/providers/signer-context.tsx
@@ -72,8 +72,6 @@ export function SignerProvider({ children }: { children: React.ReactNode }) {
     } else {
       chrome.storage.session.remove(['dappAddress', 'dappAccountName'])
     }
-
-    chrome.storage.session.remove(['connectedOrigins', 'originChainIds'])
   }, [address, accountName])
 
   useEffect(() => {

--- a/apps/wallet/src/providers/wallet-context.tsx
+++ b/apps/wallet/src/providers/wallet-context.tsx
@@ -12,13 +12,14 @@ import { storage } from '@wxt-dev/storage'
 
 import { useSelectAccount } from '../hooks/use-select-account'
 import { useSynchronizedRefetch } from '../hooks/use-synchronized-refetch'
+import { syncAccountToDapps } from '../lib/dapp-events'
+import { SELECTED_WALLET_ID_KEY } from '../lib/storage-keys'
 import { apiClient } from './api-client'
 
 import type { WalletAccount, WalletMeta } from '../data/wallet-metadata'
 
 const WALLET_LIST_STALE_TIME_MS = 5 * 60 * 1000 // 5 minutes
 const WALLET_LIST_GC_TIME_MS = 60 * 60 * 1000 // 1 hour
-const SELECTED_WALLET_ID_KEY = 'local:wallet:selected-id'
 
 type Wallet = WalletMeta
 
@@ -128,9 +129,28 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     )
   }, [hasHydratedSelectedWallet, selectedWalletId])
 
-  const setCurrentWallet = useCallback((id: string) => {
-    setSelectedWalletId(id)
-  }, [])
+  /**
+   * Both setters are the only deliberate account switches in the app, which is
+   * why the dApp sync hangs off them rather than off `currentAccount`. That
+   * value also changes while the persisted wallet selection hydrates -- during
+   * which it briefly reports `wallets[0]` -- and reacting to it would re-point
+   * connected dApps at the wrong account on every page load.
+   */
+  const setCurrentWallet = useCallback(
+    (id: string) => {
+      setSelectedWalletId(id)
+
+      const wallet = wallets.find(w => w.id === id)
+      const account =
+        wallet?.accounts.find(
+          a => a.address === wallet.selectedAccountAddress,
+        ) ?? wallet?.accounts[0]
+      if (account) {
+        void syncAccountToDapps(account.address)
+      }
+    },
+    [wallets],
+  )
 
   const { selectAccount } = useSelectAccount()
 
@@ -139,6 +159,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       if (!currentWallet) return
       if (currentWallet.selectedAccountAddress === address) return
       selectAccount({ walletId: currentWallet.id, address })
+      void syncAccountToDapps(address)
     },
     [currentWallet, selectAccount],
   )

--- a/packages/ethereum-provider/src/provider.ts
+++ b/packages/ethereum-provider/src/provider.ts
@@ -40,10 +40,7 @@ function waitUntilComplete(doc: Document): Promise<void> {
   })
 }
 
-function statusLog(
-  level: 'info' | 'warn' | 'error',
-  ...args: unknown[]
-) {
+function statusLog(level: 'info' | 'warn' | 'error', ...args: unknown[]) {
   if (!(window?.localStorage.getItem('status:logging') === 'true')) {
     return
   }
@@ -84,6 +81,71 @@ export class Provider {
     this.__isProvider = false
     this.connected = false
     this.#listeners = new Map()
+
+    this.#listenForWalletEvents()
+    void this.#restoreSession()
+  }
+
+  /**
+   * Events the wallet pushes without the page having asked -- today only an
+   * account switch. Delivered by the bridge content script, which is the only
+   * thing that can reach this window from the extension.
+   */
+  #listenForWalletEvents = (): void => {
+    window.addEventListener('message', event => {
+      // Same-origin only. Deliberately not also matching `event.source` against
+      // `window`: the bridge posts from the isolated world, and a `source`
+      // mismatch there would drop every event silently.
+      if (event.origin !== window.origin) {
+        return
+      }
+
+      const message = event.data
+      if (
+        !message ||
+        message.type !== 'status:provider:event' ||
+        message.event !== 'accountsChanged'
+      ) {
+        return
+      }
+
+      const accounts = Array.isArray(message.data) ? message.data : []
+      // EIP-1193 reports a revocation as an empty account list; dApps read it
+      // as a disconnect. `disconnect` itself is not emitted -- it clears the
+      // listener map, and the page may still be reconnected from the wallet.
+      this.connected = accounts.length > 0
+
+      logger.info('accountsChanged::', accounts)
+
+      this.#emit('accountsChanged', accounts)
+    })
+  }
+
+  /**
+   * A page load creates a fresh provider, but the wallet's grant outlives it.
+   * Without asking, this instance reports itself disconnected even while
+   * `eth_accounts` returns the account -- dApps then treat the session as gone
+   * and their reconnect path starts by calling `wallet_revokePermissions`,
+   * destroying a permission the user never asked to drop.
+   */
+  #restoreSession = async (): Promise<void> => {
+    try {
+      const accounts = await this.request({ method: 'eth_accounts' })
+      if (!Array.isArray(accounts) || accounts.length === 0) {
+        return
+      }
+
+      const chainId = await this.request({ method: 'eth_chainId' })
+
+      this.connected = true
+      this.#emit('connect', { chainId })
+      this.#emit('connected', { chainId })
+      this.#emit('accountsChanged', accounts)
+
+      logger.info('session restored::', accounts)
+    } catch (error) {
+      logger.warn('session restore failed::', error)
+    }
   }
 
   #emit = (event: ProviderEvent, ...args: unknown[]): void => {
@@ -142,10 +204,19 @@ export class Provider {
               Array.isArray(message.data) &&
               message.data.length > 0
             ) {
+              const accounts = message.data
               this.connected = true
-              this.#emit('connect', { chainId: DEFAULT_CHAIN_ID })
-              this.#emit('connected', { chainId: DEFAULT_CHAIN_ID })
-              this.#emit('accountsChanged', message.data)
+
+              // The origin's chain, not an assumed mainnet: a dApp told the
+              // wrong chainId on connect can decide it is on an unsupported
+              // network and disconnect itself.
+              void this.request({ method: 'eth_chainId' })
+                .catch(() => DEFAULT_CHAIN_ID)
+                .then(chainId => {
+                  this.#emit('connect', { chainId })
+                  this.#emit('connected', { chainId })
+                  this.#emit('accountsChanged', accounts)
+                })
 
               logger.info('connected::')
             }
@@ -167,13 +238,6 @@ export class Provider {
           }
           case 'status:proxy:error': {
             logger.error(message.error)
-
-            if (
-              message.error.message === 'dApp is not permitted by user' &&
-              this.connected
-            ) {
-              this.disconnect()
-            }
 
             reject(new ProviderRpcError(message.error))
             return
@@ -200,15 +264,23 @@ export class Provider {
     })
   }
 
+  /**
+   * EIP-1193: "connected" means the provider can service RPC requests, not
+   * that accounts are authorized -- MetaMask likewise returns true once
+   * initialized. Reporting account state here made dApps treat a reload as a
+   * dropped session and disconnect themselves.
+   *
+   * @see https://eips.ethereum.org/EIPS/eip-1193#connectivity
+   */
   public isConnected = (): boolean => {
-    return this.connected
+    return true
   }
 
   public on = (
     event: ProviderEvent,
     handler: (...args: unknown[]) => void,
   ): this => {
-    logger.info( 'on::', event)
+    logger.info('on::', event)
 
     let handlers = this.#listeners.get(event)
     if (!handlers) {
@@ -221,7 +293,7 @@ export class Provider {
 
   /** @deprecated */
   public close = async (): Promise<void> => {
-    logger.info( 'close::')
+    logger.info('close::')
 
     this.disconnect()
   }
@@ -230,7 +302,7 @@ export class Provider {
     event: ProviderEvent,
     handler?: (...args: unknown[]) => void,
   ): void => {
-    logger.info( 'removeListener::', event)
+    logger.info('removeListener::', event)
 
     if (handler) {
       this.#listeners.get(event)?.delete(handler)
@@ -247,29 +319,30 @@ export class Provider {
   }
 
   public enable = async (): Promise<boolean> => {
-    logger.info( 'enable::')
+    logger.info('enable::')
 
     return true
   }
 
-  private disconnect = async (): Promise<void> => {
+  /**
+   * Tears down this page's provider session only. It deliberately does not
+   * revoke the stored permission: `close()` is a page-lifecycle call, and a
+   * reload or a library cleaning up must not cost the user their connection.
+   * To actually revoke, a dApp calls `wallet_revokePermissions` (EIP-2255),
+   * or the user disconnects from the wallet.
+   */
+  private disconnect = (): void => {
     if (!this.connected) {
       return
     }
 
     this.connected = false
 
-    logger.info( 'disconnect::')
+    logger.info('disconnect::')
 
-    await this.request({
-      method: 'wallet_revokePermissions',
-      params: [{ eth_accounts: {} }],
-    })
-
-    window.postMessage(
-      { type: 'status:provider:disconnect' },
-      window.origin,
-    )
+    // Signals transport teardown to the content script -- the connector closes
+    // its socket to Desktop on this. It must not be read as a revocation.
+    window.postMessage({ type: 'status:provider:disconnect' }, window.origin)
 
     this.#emit('disconnect')
     this.#emit('close')


### PR DESCRIPTION
Closes part of #1136.

A dApp connection survived nothing: opening the extension page, reloading the dApp, or restarting the browser all dropped it, and switching accounts silently handed the dApp an account the user never connected.

Permissions move from `chrome.storage.session` to `local`, keyed per origin and per account. Only `wallet_revokePermissions` or the wallet's Disconnect action removes one.

Per-account pinning. Each origin is pinned to the account it was connected with. `eth_accounts`, `eth_requestAccounts` and `personal_sign` all resolve through that pinned account. Switching accounts re-points only the dApps already connected to the new account and pushes `accountsChanged` to their tabs, so no page refresh is needed. Anything else is left alone; a new dApp connections menu beside the wallet selector offers Connect for those.

Provider. A fresh provider restores its session from `eth_accounts` instead of reporting itself disconnected.

Approval popup. Fixed a blank white window: the mount effect had no rejection handling, so a cold service worker left it rendering `null` forever. Also claims the single approval slot synchronously -- two requests in the same tick each opened a popup and clobbered each other's record.

---

#### How to test

- Connect a dApp. Reload it, reload the extension page, restart the browser -- stays connected at each step.
- Switch to an account not connected to that dApp: the dApp keeps showing the original account.
- Open the dApp menu (icon beside the wallet selector, see screenshot bellow) -> Connect. The dApp switches account live, no refresh needed.
- Switch back and forth between two connected accounts -- the dApp follows, no refresh.
- Disconnect from that menu; the dApp drops immediately.
- You can connect to multiple dApps at the same time.
- Lock the wallet, then connect from a dApp -- the connection popup renders with the unlock prompt.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/e5430401-ee80-4069-b7a6-5114e6bd8257" />
