### PR TITLE
fix(wallet): gate dApp RPC on granted permission

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'wallet': patch
+---
+
+fix(wallet): gate dApp RPC on the connection and add the status-go allowlist

--- a/apps/wallet/src/lib/dapp-events.ts
+++ b/apps/wallet/src/lib/dapp-events.ts
@@ -33,7 +33,10 @@ function originOf(url: string | undefined): string | null {
 
 async function broadcast(origin: string, message: DappEventMessage) {
   const key = normalizeOrigin(origin)
-  const tabs = await chrome.tabs.query({})
+  // Best-effort throughout: `wallet_revokePermissions` notifies after the
+  // permission is already gone, so a failure here must not surface as a failed
+  // revoke.
+  const tabs = await chrome.tabs.query({}).catch(() => [])
 
   await Promise.all(
     tabs.map(tab => {
@@ -90,7 +93,12 @@ export async function connectAccountToDapp(
   await notifyAccountsChanged(origin, [address])
 }
 
-/** Revokes from the wallet UI. The empty array is EIP-1193 for "logged out". */
+/**
+ * Drops the grant and tells the page. The empty array is EIP-1193 for "logged
+ * out". Both revoke paths go through here -- the wallet's Disconnect action and
+ * `wallet_revokePermissions` -- so neither can leave a page showing an account
+ * it no longer has.
+ */
 export async function disconnectDapp(origin: string): Promise<void> {
   await revokeOrigin(origin)
   await notifyAccountsChanged(origin, [])

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -40,9 +40,18 @@ let autoApprove = true
 /** Popups the handler opened, counted by the mock's `windows.create`. */
 let popupsOpened = 0
 
+type PushedEvent = {
+  tabId: number
+  message: { type: string; event: string; data: unknown }
+}
+
+/** EIP-1193 events the handler pushed at the dApp's tabs. */
+let pushedToTabs: PushedEvent[] = []
+
 function createChromeMock() {
   const session = new Map<string, unknown>()
   const listeners: Listener[] = []
+  pushedToTabs = []
 
   const set = async (items: Record<string, unknown>) => {
     const changes: Record<string, { newValue?: unknown }> = {}
@@ -76,6 +85,16 @@ function createChromeMock() {
       },
     },
     runtime: { getURL: (p: string) => `chrome-extension://test/${p}` },
+    // Wallet-initiated events reach the page through the bridge content script.
+    tabs: {
+      query: async () => [
+        { id: 1, url: `${ORIGIN}/swap` },
+        { id: 2, url: `${OTHER_ORIGIN}/` },
+      ],
+      sendMessage: async (tabId: number, message: PushedEvent['message']) => {
+        pushedToTabs.push({ tabId, message })
+      },
+    },
     windows: {
       getCurrent: async () => ({ left: 0, top: 0, width: 1200 }),
       // Stands in for the user acting on the approval popup.
@@ -195,6 +214,25 @@ test('an explicit revoke disconnects', async () => {
   )
 
   expect(await accounts()).toEqual([])
+})
+
+// The page that revoked, and every other tab on the origin, keep showing the
+// account until told otherwise -- the wallet's own Disconnect action pushes
+// this event, and the RPC path must not be the one that skips it.
+test('an explicit revoke tells the origin its accounts are gone', async () => {
+  await connect()
+  await handleRpcRequest(
+    'wallet_revokePermissions',
+    [{ eth_accounts: {} }],
+    ORIGIN,
+  )
+
+  expect(pushedToTabs).toEqual([
+    {
+      tabId: 1,
+      message: { type: 'status:event', event: 'accountsChanged', data: [] },
+    },
+  ])
 })
 
 // Regression: the -32002 guard read the stored approval asynchronously, so two

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -4,10 +4,23 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   connectAccount,
   ETH_ACCOUNTS_CAPABILITY,
+  getPermissions,
   grantPermission,
   selectAccountForOrigin,
+  setChainIdForOrigin,
 } from '../data/dapp-permissions'
-import { handleRpcRequest } from './rpc-handler'
+import { publicClient } from './public-client'
+import { handleRpcRequest, LOCAL_HANDLERS } from './rpc-handler'
+import { REMOTE_ALLOWED, UNGATED_LOCAL } from './rpc-methods'
+
+// The forwarding branch is the point of the gate, so it needs a stand-in for
+// the node. The real client is a module-level const over the authenticated
+// proxy URL.
+vi.mock('./public-client', () => ({
+  publicClient: { request: vi.fn(async () => '0x1234') },
+}))
+
+const nodeRequest = vi.mocked(publicClient.request)
 
 const ORIGIN = 'https://app.velora.xyz'
 const OTHER_ORIGIN = 'https://app.uniswap.org'
@@ -98,6 +111,7 @@ const signed: { walletId?: string; fromAddress?: string } = {}
 beforeEach(async () => {
   autoApprove = true
   popupsOpened = 0
+  nodeRequest.mockClear()
   vi.stubGlobal('chrome', createChromeMock())
   vi.stubGlobal('api', {
     wallet: {
@@ -280,5 +294,237 @@ describe('records predating per-account tracking', () => {
 
     await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
     expect(await accounts()).toEqual([ADDRESS])
+  })
+})
+
+// Ported from status-go @384a179
+// tests-functional/tests/test_status_connector.py
+describe('the status-go permission table', () => {
+  const UNCONNECTED = 'https://evil.test'
+
+  describe('before connection', () => {
+    test.each([
+      ['eth_blockNumber', []],
+      ['eth_getBalance', [ADDRESS, 'latest']],
+      ['eth_getTransactionCount', [ADDRESS, 'latest']],
+      ['eth_call', [{ to: ADDRESS }, 'latest']],
+      ['eth_estimateGas', [{ to: ADDRESS }]],
+      ['eth_getTransactionReceipt', ['0xdeadbeef']],
+      ['eth_sendTransaction', [{ from: ADDRESS, to: ADDRESS }]],
+      ['wallet_switchEthereumChain', [{ chainId: '0x1' }]],
+    ])('%s is refused', async (method, params) => {
+      await expect(
+        handleRpcRequest(method, params, UNCONNECTED),
+      ).rejects.toMatchObject({
+        code: 4100,
+        message: 'dApp is not permitted by user',
+      })
+    })
+
+    test('a refused method never reaches the node', async () => {
+      await expect(
+        handleRpcRequest('eth_blockNumber', [], UNCONNECTED),
+      ).rejects.toThrow()
+
+      expect(nodeRequest).not.toHaveBeenCalled()
+    })
+
+    test('eth_chainId resolves', async () => {
+      expect(await handleRpcRequest('eth_chainId', [], UNCONNECTED)).toBe('0x1')
+    })
+
+    test('net_version resolves', async () => {
+      expect(await handleRpcRequest('net_version', [], UNCONNECTED)).toBe('1')
+    })
+
+    test('eth_accounts is empty', async () => {
+      expect(await handleRpcRequest('eth_accounts', [], UNCONNECTED)).toEqual(
+        [],
+      )
+    })
+
+    test('wallet_getPermissions is empty', async () => {
+      expect(
+        await handleRpcRequest('wallet_getPermissions', [], UNCONNECTED),
+      ).toEqual([])
+    })
+  })
+
+  describe('after connection', () => {
+    test('an allowlisted method reaches the node unchanged', async () => {
+      await connect()
+
+      expect(await handleRpcRequest('eth_blockNumber', [], ORIGIN)).toBe(
+        '0x1234',
+      )
+      expect(nodeRequest).toHaveBeenCalledWith({
+        method: 'eth_blockNumber',
+        params: [],
+      })
+    })
+
+    test('a method off the allowlist is still refused', async () => {
+      await connect()
+
+      // Reaches the proxy today; status-go does not list it.
+      await expect(
+        handleRpcRequest('eth_getProof', [], ORIGIN),
+      ).rejects.toMatchObject({ code: -32601 })
+      expect(nodeRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  // status-go's own unknown-method case: connector_callRPC must not become a
+  // way to reach status-go service methods.
+  test('an unknown method is refused by name', async () => {
+    await connect()
+
+    await expect(
+      handleRpcRequest('wakuext_joinedCommunities', [], ORIGIN),
+    ).rejects.toMatchObject({
+      code: -32601,
+      message: 'method wakuext_joinedCommunities is not allowed',
+    })
+  })
+})
+
+describe('the method tables', () => {
+  test('no method is both local and forwarded', () => {
+    const both = Object.keys(LOCAL_HANDLERS).filter(m => REMOTE_ALLOWED.has(m))
+
+    expect(both).toEqual([])
+  })
+
+  test('every ungated method has a local handler', () => {
+    const orphans = [...UNGATED_LOCAL].filter(m => !(m in LOCAL_HANDLERS))
+
+    expect(orphans).toEqual([])
+  })
+})
+
+describe('wallet_getPermissions', () => {
+  test('reports the pinned account, not every account ever connected', async () => {
+    await connect()
+    await connectAccount(ORIGIN, OTHER_ADDRESS)
+    await selectAccountForOrigin(ORIGIN, ADDRESS)
+
+    const permissions = (await handleRpcRequest(
+      'wallet_getPermissions',
+      [],
+      ORIGIN,
+    )) as Array<{ parentCapability: string; caveats: unknown[] }>
+
+    expect(permissions).toEqual([
+      {
+        invoker: ORIGIN,
+        parentCapability: ETH_ACCOUNTS_CAPABILITY,
+        // eth_accounts returns exactly this, so the caveat must not claim the
+        // dApp may see OTHER_ADDRESS as well.
+        caveats: [{ type: 'restrictReturnedAccounts', value: [ADDRESS] }],
+      },
+    ])
+  })
+})
+
+describe('wallet_requestPermissions', () => {
+  const request = (params: unknown, origin = ORIGIN) =>
+    handleRpcRequest('wallet_requestPermissions', params, origin)
+
+  test('persists the requested capability and echoes it', async () => {
+    await connect()
+
+    await expect(
+      request([{ eth_accounts: { requiredMethods: ['personal_sign'] } }]),
+    ).resolves.toEqual([
+      {
+        invoker: ORIGIN,
+        parentCapability: 'eth_accounts',
+        caveats: [{ type: 'requiredMethods', value: ['personal_sign'] }],
+      },
+    ])
+
+    expect(await getPermissions(ORIGIN)).toEqual([
+      {
+        parentCapability: 'eth_accounts',
+        caveats: [{ type: 'requiredMethods', value: ['personal_sign'] }],
+      },
+    ])
+  })
+
+  test('a non-object caveats value means no caveats, not an error', async () => {
+    await connect()
+
+    await expect(request([{ eth_accounts: {} }])).resolves.toMatchObject([
+      { parentCapability: 'eth_accounts', caveats: [] },
+    ])
+  })
+
+  test.each([
+    ['no params', []],
+    ['a non-object param', ['eth_accounts']],
+    ['two capabilities', [{ eth_accounts: {}, eth_chainId: {} }]],
+  ])('rejects %s', async (_label, params) => {
+    await connect()
+
+    await expect(request(params)).rejects.toMatchObject({ code: -32602 })
+  })
+
+  // status-go's ErrDAppNotFound, deliberately distinct from the generic
+  // refusal so the diagnostics say which of the two happened.
+  test('an unconnected origin is refused and nothing is written', async () => {
+    await expect(
+      request([{ eth_accounts: {} }], 'https://evil.test'),
+    ).rejects.toMatchObject({
+      code: 4100,
+      message: 'dApp not found; permission not persisted',
+    })
+
+    expect(await getPermissions('https://evil.test')).toEqual([])
+  })
+
+  // Regression: guarding on "the origin has a record" rather than "the origin
+  // is permitted" was an escalation. setChainIdForOrigin creates a bare record
+  // for any origin that switched chains, and wallet_switchEthereumChain was
+  // ungated before this PR -- so such records survive the upgrade. The origin
+  // could then grant itself eth_accounts with no approval popup.
+  test('an origin with a record but no grant cannot grant itself one', async () => {
+    await setChainIdForOrigin(ORIGIN, '0x1')
+
+    await expect(request([{ eth_accounts: {} }])).rejects.toMatchObject({
+      code: 4100,
+      message: 'dApp not found; permission not persisted',
+    })
+
+    expect(await accounts()).toEqual([])
+  })
+})
+
+describe('personal_sign distinguishes its two failures', () => {
+  test('an unpermitted origin is a permission problem', async () => {
+    await expect(
+      handleRpcRequest('personal_sign', ['0xdeadbeef'], 'https://evil.test'),
+    ).rejects.toMatchObject({
+      code: 4100,
+      message: 'dApp is not permitted by user',
+    })
+  })
+
+  // A permitted origin whose pinned account no longer resolves -- the wallet
+  // holding it was deleted. Reporting this as "not permitted" would be false.
+  test('a permitted origin with no resolvable account is not', async () => {
+    await grantPermission(ORIGIN, ETH_ACCOUNTS_CAPABILITY)
+    await storage.removeItem('local:vault:metadata')
+    await chrome.storage.session.remove([
+      'dappAddress',
+      'dappAccountName',
+      'dappWalletId',
+    ])
+
+    await expect(
+      handleRpcRequest('personal_sign', ['0xdeadbeef'], ORIGIN),
+    ).rejects.toMatchObject({
+      code: 4100,
+      message: 'No connected account',
+    })
   })
 })

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -462,6 +462,36 @@ describe('wallet_getPermissions', () => {
       },
     ])
   })
+
+  test('keeps the caveats the dApp asked for alongside the derived one', async () => {
+    await connect()
+    await handleRpcRequest(
+      'wallet_requestPermissions',
+      [
+        {
+          eth_accounts: {
+            requiredMethods: ['personal_sign'],
+            // A dApp-written value for the derived caveat must not survive.
+            restrictReturnedAccounts: [OTHER_ADDRESS],
+          },
+        },
+      ],
+      ORIGIN,
+    )
+
+    await expect(
+      handleRpcRequest('wallet_getPermissions', [], ORIGIN),
+    ).resolves.toEqual([
+      {
+        invoker: ORIGIN,
+        parentCapability: ETH_ACCOUNTS_CAPABILITY,
+        caveats: [
+          { type: 'requiredMethods', value: ['personal_sign'] },
+          { type: 'restrictReturnedAccounts', value: [ADDRESS] },
+        ],
+      },
+    ])
+  })
 })
 
 describe('wallet_requestPermissions', () => {

--- a/apps/wallet/src/lib/rpc-handler.ts
+++ b/apps/wallet/src/lib/rpc-handler.ts
@@ -1,252 +1,67 @@
-import { ProviderRpcError } from '@status-im/ethereum-provider'
-import { storage } from '@wxt-dev/storage'
-
-import {
-  APPROVAL_TIMEOUT_MS,
-  type ApprovalResult,
-  clearApprovalResult,
-  clearPendingApproval,
-  getApprovalResult,
-  getPendingApproval,
-  type PendingApproval,
-  setPendingApproval,
-} from '../data/approval'
-import {
-  adoptSelectedAddress,
-  connectAccount,
-  debugLog,
-  getChainIdForOrigin,
-  getSelectedAddress,
-  isOriginPermitted,
-  isSameAddress,
-  revokeOrigin,
-  setChainIdForOrigin,
-} from '../data/dapp-permissions'
-import * as walletMetadata from '../data/wallet-metadata'
+import { debugLog, isOriginPermitted } from '../data/dapp-permissions'
 import { publicClient } from './public-client'
-import { SELECTED_WALLET_ID_KEY } from './storage-keys'
+import { getAddress } from './rpc/account'
+import { eth_accounts, eth_requestAccounts } from './rpc/accounts'
+import {
+  eth_chainId,
+  net_version,
+  wallet_addEthereumChain,
+  wallet_switchEthereumChain,
+} from './rpc/chain'
+import { methodNotAllowed, notPermitted } from './rpc/errors'
+import {
+  wallet_getCapabilities,
+  wallet_getPermissions,
+  wallet_requestPermissions,
+  wallet_revokePermissions,
+} from './rpc/permissions'
+import { eth_sendTransaction } from './rpc/send-transaction'
+import { eth_signTypedData_v4, personal_sign } from './rpc/sign'
+import { REMOTE_ALLOWED, UNGATED_LOCAL } from './rpc-methods'
 
-const SUPPORTED_CHAIN_IDS = new Set(['0x1', '0x6300b5ea'])
-const DEFAULT_ACCOUNT_NAME = 'Account 1'
-
-const APPROVAL_POPUP_WIDTH = 390
-const APPROVAL_POPUP_HEIGHT = 628
-
-type ActiveAccount = {
-  address: string
-  accountName: string
-  walletId: string
-}
+import type { LocalHandler, RpcContext } from './rpc/context'
 
 /**
- * The account exposed to dApps.
+ * The methods the wallet answers itself, as opposed to forwarding upstream.
+ * Mirrors status-go's `CommandRegistry` in `services/connector/api.go`.
  *
- * The extension page mirrors its selection into session storage, but that is
- * empty after a browser restart until the page is opened. Permissions live in
- * `local` and outlast it, so fall back to wallet metadata -- otherwise a still
- * permitted dApp would be told there is no account. Mirrors the selection rule
- * in `wallet-context.tsx`.
- */
-async function getActiveAccount(): Promise<ActiveAccount | null> {
-  const session = await chrome.storage.session.get([
-    'dappAddress',
-    'dappAccountName',
-    'dappWalletId',
-  ])
-
-  if (session.dappAddress && session.dappWalletId) {
-    return {
-      address: session.dappAddress as string,
-      accountName: (session.dappAccountName as string) || DEFAULT_ACCOUNT_NAME,
-      walletId: session.dappWalletId as string,
-    }
-  }
-
-  const wallets = await walletMetadata.getAll()
-  const selectedId = await storage.getItem<string>(SELECTED_WALLET_ID_KEY)
-  const wallet = wallets.find(w => w.id === selectedId) ?? wallets[0]
-  if (!wallet) return null
-
-  const account =
-    wallet.accounts.find(a => a.address === wallet.selectedAccountAddress) ??
-    wallet.accounts[0]
-  if (!account) return null
-
-  return {
-    address: account.address,
-    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
-    walletId: wallet.id,
-  }
-}
-
-async function getAddress(): Promise<string | null> {
-  return (await getActiveAccount())?.address ?? null
-}
-
-async function getAccountName(): Promise<string> {
-  return (await getActiveAccount())?.accountName ?? DEFAULT_ACCOUNT_NAME
-}
-
-/**
- * The account this origin sees, which is not necessarily the wallet's current
- * selection: switching to an account the user never connected here must leave
- * the dApp on the one it was connected with.
+ * This map is the registry -- there is no parallel list of case labels to keep
+ * in sync with it.
  *
- * Every dApp-facing read and signature resolves through this -- reading the
- * pinned account for `eth_accounts` while signing with the selected one would
- * hand the dApp a signature from an account it was never shown.
+ * Exported so tests can assert it against the tables in `rpc-methods.ts`.
  */
-async function getOriginAddress(origin: string): Promise<string | null> {
-  if (!(await isOriginPermitted(origin))) {
-    return null
-  }
-
-  const selected = await getSelectedAddress(origin)
-  if (selected) {
-    return selected
-  }
-
-  // Connected before per-account tracking existed: the account it has been
-  // showing is the active one, so pin it there once.
-  const active = await getAddress()
-  return active ? await adoptSelectedAddress(origin, active) : null
+export const LOCAL_HANDLERS: Record<string, LocalHandler> = {
+  eth_requestAccounts,
+  eth_accounts,
+  eth_chainId,
+  net_version,
+  wallet_switchEthereumChain,
+  wallet_addEthereumChain,
+  wallet_requestPermissions,
+  wallet_getPermissions,
+  wallet_revokePermissions,
+  wallet_getCapabilities,
+  personal_sign,
+  eth_signTypedData_v4,
+  eth_sendTransaction,
 }
 
-/**
- * Locates the wallet holding `address`, across all wallets -- the account a dApp
- * is pinned to may not belong to the currently selected wallet.
- */
-async function findWalletForAddress(
-  address: string,
-): Promise<{ walletId: string; accountName: string } | null> {
-  const wallets = await walletMetadata.getAll()
-  const wallet = wallets.find(w =>
-    w.accounts.some(account => isSameAddress(account.address, address)),
-  )
-  if (!wallet) return null
-
-  return {
-    walletId: wallet.id,
-    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
-  }
-}
-
-type PendingApprovalInput = PendingApproval extends infer T
-  ? T extends PendingApproval
-    ? Omit<T, 'id' | 'createdAt'>
-    : never
-  : never
-
-/**
- * Synchronous claim on the single approval slot.
- *
- * The stored `pendingApproval` is read asynchronously, so two requests
- * arriving in the same tick both saw it empty and each opened a popup, then
- * clobbered each other's record -- one of the windows ends up showing a
- * request that no longer exists. The service worker is single-threaded, so a
- * plain variable closes that window; the stored record still guards across
- * worker restarts.
- */
-let approvalInFlight = false
-
-function requestApproval(
-  approval: PendingApprovalInput,
-): Promise<ApprovalResult | null> {
-  if (approvalInFlight) {
-    return Promise.reject(
-      new ProviderRpcError({
-        code: -32002,
-        message: 'Already processing a request.',
-      }),
-    )
-  }
-  approvalInFlight = true
-
-  return new Promise(resolve => {
-    const id = crypto.randomUUID()
-    let popupWindowId: number | undefined
-    let settled = false
-    const timeout: ReturnType<typeof setTimeout> = setTimeout(() => {
-      cleanup()
-      resolve(null)
-    }, APPROVAL_TIMEOUT_MS)
-
-    const cleanup = () => {
-      if (settled) return
-      settled = true
-      approvalInFlight = false
-      clearTimeout(timeout)
-      chrome.storage.onChanged.removeListener(storageListener)
-      chrome.windows.onRemoved.removeListener(windowListener)
-      clearPendingApproval()
-      clearApprovalResult()
-    }
-
-    const storageListener = (
-      changes: Record<string, chrome.storage.StorageChange>,
-      area: string,
-    ) => {
-      if (area !== 'session' || !changes.approvalResult) return
-      const result = changes.approvalResult.newValue as
-        | ApprovalResult
-        | undefined
-      if (!result || result.id !== id) return
-      cleanup()
-      resolve(result.approved ? result : null)
-    }
-
-    const windowListener = (removedWindowId: number) => {
-      if (removedWindowId !== popupWindowId) return
-      // The approval page writes its result and then closes itself, so this
-      // can arrive before the storage change that carries the verdict.
-      // Treating the close as a rejection outright loses approvals: re-read
-      // the result and only fall back to rejection when there genuinely is
-      // none.
-      void getApprovalResult().then(result => {
-        cleanup()
-        resolve(result?.id === id && result.approved ? result : null)
-      })
-    }
-
-    chrome.storage.onChanged.addListener(storageListener)
-    chrome.windows.onRemoved.addListener(windowListener)
-    ;(async () => {
-      try {
-        await setPendingApproval({
-          id,
-          createdAt: Date.now(),
-          ...approval,
-        } as PendingApproval)
-        const popupUrl = chrome.runtime.getURL('approval.html')
-        const currentWindow = await chrome.windows.getCurrent()
-        const left =
-          (currentWindow.left ?? 0) +
-          (currentWindow.width ?? 0) -
-          APPROVAL_POPUP_WIDTH -
-          16
-        const top = (currentWindow.top ?? 0) + 16
-
-        const popup = await chrome.windows.create({
-          url: popupUrl,
-          type: 'popup',
-          width: APPROVAL_POPUP_WIDTH,
-          height: APPROVAL_POPUP_HEIGHT,
-          left,
-          top,
-          focused: true,
-        })
-        popupWindowId = popup?.id
-      } catch {
-        cleanup()
-        resolve(null)
-      }
-    })()
-  })
-}
+/** Methods whose traffic `debugLog` records when `local:dapp:debug` is set. */
+const DEBUG_LOGGED_METHODS = new Set([
+  'eth_accounts',
+  'eth_requestAccounts',
+  'wallet_requestPermissions',
+])
 
 /**
  * Handle an EIP-1193 RPC request from a dApp.
  * Runs in the background service worker context.
+ *
+ * Dispatch order mirrors status-go's `CallRPC`, and is observable through the
+ * errors: local registry, then the remote allowlist, then refusal. Everything
+ * outside `UNGATED_LOCAL` requires the user to have connected the origin,
+ * including the forwarded reads -- an unapproved page must not be able to
+ * spend the wallet's authenticated proxy quota.
  */
 export async function handleRpcRequest(
   method: string,
@@ -254,11 +69,7 @@ export async function handleRpcRequest(
   origin: string,
   metadata?: { title?: string; favicon?: string },
 ): Promise<unknown> {
-  if (
-    method === 'eth_accounts' ||
-    method === 'eth_requestAccounts' ||
-    method === 'wallet_requestPermissions'
-  ) {
+  if (DEBUG_LOGGED_METHODS.has(method)) {
     void debugLog(method, {
       origin,
       permitted: await isOriginPermitted(origin),
@@ -266,222 +77,26 @@ export async function handleRpcRequest(
     })
   }
 
-  switch (method) {
-    case 'eth_requestAccounts': {
-      // Answer from the origin's own account when it has one, or a dApp that
-      // calls this on every mount would flip back to the wallet's selection
-      // and contradict eth_accounts.
-      const connected = await getOriginAddress(origin)
-      if (connected) {
-        return [connected]
-      }
+  const ctx: RpcContext = { method, params, origin, metadata }
 
-      const address = await getAddress()
-      if (!address) {
-        throw new ProviderRpcError({
-          code: 4100,
-          message: 'No active account',
-        })
-      }
-
-      const existing = await getPendingApproval()
-      if (existing) {
-        throw new ProviderRpcError({
-          code: -32002,
-          message: 'Already processing a connection request.',
-        })
-      }
-
-      const chainId = await getChainIdForOrigin(origin)
-      const accountName = await getAccountName()
-      const connectResult = await requestApproval({
-        type: 'eth_requestAccounts',
-        origin,
-        title: metadata?.title ?? origin,
-        favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
-        address,
-        accountName,
-        chainId,
-      })
-
-      if (!connectResult) {
-        throw new ProviderRpcError({
-          code: 4001,
-          message: 'User rejected the request.',
-        })
-      }
-
-      await connectAccount(origin, address)
-      void debugLog('granted', { origin, address })
-      return [address]
+  const local = LOCAL_HANDLERS[method]
+  if (local) {
+    if (!UNGATED_LOCAL.has(method) && !(await isOriginPermitted(origin))) {
+      throw notPermitted()
     }
-
-    case 'eth_accounts': {
-      const address = await getOriginAddress(origin)
-      return address ? [address] : []
-    }
-
-    case 'eth_chainId': {
-      return await getChainIdForOrigin(origin)
-    }
-
-    case 'net_version': {
-      const chainId = await getChainIdForOrigin(origin)
-      return parseInt(chainId, 16).toString()
-    }
-
-    case 'wallet_switchEthereumChain': {
-      const p = params as [{ chainId: string }] | undefined
-      const requestedChainId = p?.[0]?.chainId
-      if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
-        throw new ProviderRpcError({
-          code: 4902,
-          message: `Unrecognized chain ID ${requestedChainId}. Try adding the chain using wallet_addEthereumChain first.`,
-        })
-      }
-      if (requestedChainId) {
-        await setChainIdForOrigin(origin, requestedChainId)
-      }
-      return null
-    }
-
-    case 'wallet_addEthereumChain': {
-      const p = params as [{ chainId: string }] | undefined
-      const requestedChainId = p?.[0]?.chainId
-      if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
-        throw new ProviderRpcError({
-          code: 4902,
-          message: `Chain ${requestedChainId} is not supported`,
-        })
-      }
-      if (requestedChainId) {
-        await setChainIdForOrigin(origin, requestedChainId)
-      }
-      return null
-    }
-
-    case 'wallet_requestPermissions': {
-      return [
-        {
-          parentCapability: 'eth_accounts',
-          caveats: [],
-        },
-      ]
-    }
-
-    case 'wallet_revokePermissions': {
-      await revokeOrigin(origin)
-      return null
-    }
-
-    case 'wallet_getCapabilities': {
-      const p = (params as unknown[]) || []
-      const addr = (p[0] as string) || (await getAddress())
-      if (!addr) return {}
-      const chainIds = (p[1] as string[]) || ['0x1']
-      const capabilities: Record<string, Record<string, unknown>> = {}
-      for (const chainId of chainIds) {
-        capabilities[chainId] = {
-          atomicBatch: { supported: false },
-        }
-      }
-      return capabilities
-    }
-
-    case 'personal_sign': {
-      const p = params as [string, string]
-      const message = p[0]
-      // The origin's own account, not the wallet's selection: signing with the
-      // selected account would return a signature from a key the dApp was
-      // never shown.
-      const signerAddress = await getOriginAddress(origin)
-      if (!signerAddress) {
-        throw new ProviderRpcError({
-          code: 4100,
-          message: 'No connected account',
-        })
-      }
-      if (p[1] && !isSameAddress(signerAddress, p[1])) {
-        throw new ProviderRpcError({
-          code: -32602,
-          message: `Requested address ${p[1]} does not match the connected account`,
-        })
-      }
-
-      const signer = await findWalletForAddress(signerAddress)
-      if (!signer) {
-        throw new ProviderRpcError({
-          code: 4100,
-          message: 'No wallet available',
-        })
-      }
-
-      // Guard against concurrent approval requests
-      const existingSign = await getPendingApproval()
-      if (existingSign) {
-        throw new ProviderRpcError({
-          code: -32002,
-          message: 'Already processing a request.',
-        })
-      }
-
-      const signChainId = await getChainIdForOrigin(origin)
-      const signResult = await requestApproval({
-        type: 'personal_sign',
-        origin,
-        title: metadata?.title ?? origin,
-        favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
-        address: signerAddress,
-        accountName: signer.accountName,
-        chainId: signChainId,
-        message,
-      })
-
-      if (!signResult) {
-        throw new ProviderRpcError({
-          code: 4001,
-          message: 'User rejected the request.',
-        })
-      }
-
-      const signed = await (
-        globalThis as unknown as {
-          api: {
-            wallet: {
-              account: {
-                ethereum: {
-                  signMessage: (input: {
-                    walletId: string
-                    fromAddress: string
-                    message: string
-                  }) => Promise<{ signature: string }>
-                }
-              }
-            }
-          }
-        }
-      ).api.wallet.account.ethereum.signMessage({
-        walletId: signer.walletId,
-        fromAddress: signerAddress,
-        message,
-      })
-
-      return signed.signature
-    }
-
-    case 'eth_signTypedData_v4':
-    case 'eth_sendTransaction': {
-      throw new ProviderRpcError({
-        code: 4200,
-        message: 'Not yet supported via dApp connection',
-      })
-    }
-
-    default: {
-      return await publicClient.request({
-        method: method as never,
-        params: params as never,
-      })
-    }
+    return await local(ctx)
   }
+
+  if (REMOTE_ALLOWED.has(method)) {
+    if (!(await isOriginPermitted(origin))) {
+      throw notPermitted()
+    }
+    return await publicClient.request({
+      method: method as never,
+      params: params as never,
+    })
+  }
+
+  console.warn(`[status:dapp] rejected ${method} from ${origin}`)
+  throw methodNotAllowed(method)
 }

--- a/apps/wallet/src/lib/rpc-methods.test.ts
+++ b/apps/wallet/src/lib/rpc-methods.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+
+import { REMOTE_ALLOWED } from './rpc-methods'
+
+// The table is a transcription of status-go @384a179 services/connector
+// remote.go. A silent drop is a broken dApp and a silent addition is a hole in
+// the gate, so pin the count.
+test('the remote allowlist matches status-go', () => {
+  expect(REMOTE_ALLOWED.size).toBe(35)
+})
+
+test('methods status-go deliberately excludes are absent', () => {
+  for (const method of [
+    'eth_accounts',
+    'eth_sign',
+    'eth_sendTransaction',
+    'net_version',
+  ]) {
+    expect(REMOTE_ALLOWED.has(method)).toBe(false)
+  }
+})

--- a/apps/wallet/src/lib/rpc-methods.ts
+++ b/apps/wallet/src/lib/rpc-methods.ts
@@ -1,0 +1,80 @@
+/**
+ * Which RPC methods a dApp may call, mirroring status-go's `services/connector`
+ * so the extension, desktop and mobile expose the same surface.
+ *
+ * Tables only, no handler imports -- tests assert against them directly.
+ */
+
+/**
+ * Methods forwarded to the node, transcribed from status-go @384a179
+ * `services/connector/remote.go`. Upstream's commented-out entries are kept
+ * verbatim, with their reasons, so the next sync against status-go is a
+ * readable diff rather than a re-derivation.
+ */
+export const REMOTE_ALLOWED = new Set([
+  'eth_protocolVersion',
+  'eth_syncing',
+  'eth_coinbase',
+  'eth_mining',
+  'eth_hashrate',
+  'eth_gasPrice',
+  'eth_maxPriorityFeePerGas',
+  'eth_feeHistory',
+  // 'eth_accounts', // due to sub-accounts handling
+  'eth_blockNumber',
+  'eth_getBalance',
+  'eth_getStorageAt',
+  'eth_getTransactionCount',
+  'eth_getBlockTransactionCountByHash',
+  'eth_getBlockTransactionCountByNumber',
+  'eth_getUncleCountByBlockHash',
+  'eth_getUncleCountByBlockNumber',
+  'eth_getCode',
+  // 'eth_sign', // only the local node has an injected account to sign the payload with
+  // 'eth_sendTransaction', // handled locally: estimate, sign, then eth_sendRawTransaction
+  'eth_sendRawTransaction',
+  'eth_call',
+  'eth_estimateGas',
+  'linea_estimateGas', // Status chain specific gas estimation
+  'eth_getBlockByHash',
+  'eth_getBlockByNumber',
+  'eth_getTransactionByHash',
+  'eth_getTransactionByBlockHashAndIndex',
+  'eth_getTransactionByBlockNumberAndIndex',
+  'eth_getTransactionReceipt',
+  'eth_getUncleByBlockHashAndIndex',
+  'eth_getUncleByBlockNumberAndIndex',
+  // 'eth_getCompilers', 'eth_compileLLL', 'eth_compileSolidity', 'eth_compileSerpent'
+  //   -- local-only upstream, nothing to forward
+  'eth_getLogs',
+  'eth_getWork',
+  'eth_submitWork',
+  'eth_submitHashrate',
+  // 'net_version', // must be answerable before connection, so it is local
+  'net_peerCount',
+  'net_listening',
+])
+
+/**
+ * Local methods the dispatcher does not gate, either because they are
+ * reachable before connection or because they enforce a more specific check
+ * themselves. status-go gates no registry command in `CallRPC` either -- each
+ * command validates internally.
+ *
+ * `eth_requestAccounts` is how an origin becomes permitted in the first place.
+ * `wallet_revokePermissions` is ungated because revoking is always safe and
+ * EIP-2255 does not require a connection to revoke. `wallet_requestPermissions`
+ * does check, but reports status-go's distinct `ErrDAppNotFound` rather than
+ * the generic refusal. The rest are discovery calls that expose nothing about
+ * the wallet.
+ */
+export const UNGATED_LOCAL = new Set([
+  'eth_chainId',
+  'net_version',
+  'eth_accounts',
+  'eth_requestAccounts',
+  'wallet_getPermissions',
+  'wallet_requestPermissions',
+  'wallet_revokePermissions',
+  'wallet_getCapabilities',
+])

--- a/apps/wallet/src/lib/rpc/account.ts
+++ b/apps/wallet/src/lib/rpc/account.ts
@@ -1,0 +1,111 @@
+import { storage } from '@wxt-dev/storage'
+
+import {
+  adoptSelectedAddress,
+  getSelectedAddress,
+  isOriginPermitted,
+  isSameAddress,
+} from '../../data/dapp-permissions'
+import * as walletMetadata from '../../data/wallet-metadata'
+import { SELECTED_WALLET_ID_KEY } from '../storage-keys'
+
+export const DEFAULT_ACCOUNT_NAME = 'Account 1'
+
+type ActiveAccount = {
+  address: string
+  accountName: string
+  walletId: string
+}
+
+/**
+ * The account exposed to dApps.
+ *
+ * The extension page mirrors its selection into session storage, but that is
+ * empty after a browser restart until the page is opened. Permissions live in
+ * `local` and outlast it, so fall back to wallet metadata -- otherwise a still
+ * permitted dApp would be told there is no account. Mirrors the selection rule
+ * in `wallet-context.tsx`.
+ */
+export async function getActiveAccount(): Promise<ActiveAccount | null> {
+  const session = await chrome.storage.session.get([
+    'dappAddress',
+    'dappAccountName',
+    'dappWalletId',
+  ])
+
+  if (session.dappAddress && session.dappWalletId) {
+    return {
+      address: session.dappAddress as string,
+      accountName: (session.dappAccountName as string) || DEFAULT_ACCOUNT_NAME,
+      walletId: session.dappWalletId as string,
+    }
+  }
+
+  const wallets = await walletMetadata.getAll()
+  const selectedId = await storage.getItem<string>(SELECTED_WALLET_ID_KEY)
+  const wallet = wallets.find(w => w.id === selectedId) ?? wallets[0]
+  if (!wallet) return null
+
+  const account =
+    wallet.accounts.find(a => a.address === wallet.selectedAccountAddress) ??
+    wallet.accounts[0]
+  if (!account) return null
+
+  return {
+    address: account.address,
+    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
+    walletId: wallet.id,
+  }
+}
+
+export async function getAddress(): Promise<string | null> {
+  return (await getActiveAccount())?.address ?? null
+}
+
+export async function getAccountName(): Promise<string> {
+  return (await getActiveAccount())?.accountName ?? DEFAULT_ACCOUNT_NAME
+}
+
+/**
+ * The account this origin sees, which is not necessarily the wallet's current
+ * selection: switching to an account the user never connected here must leave
+ * the dApp on the one it was connected with.
+ *
+ * Every dApp-facing read and signature resolves through this -- reading the
+ * pinned account for `eth_accounts` while signing with the selected one would
+ * hand the dApp a signature from an account it was never shown.
+ */
+export async function getOriginAddress(origin: string): Promise<string | null> {
+  if (!(await isOriginPermitted(origin))) {
+    return null
+  }
+
+  const selected = await getSelectedAddress(origin)
+  if (selected) {
+    return selected
+  }
+
+  // Connected before per-account tracking existed: the account it has been
+  // showing is the active one, so pin it there once.
+  const active = await getAddress()
+  return active ? await adoptSelectedAddress(origin, active) : null
+}
+
+/**
+ * Locates the wallet holding `address`, across all wallets -- the account a dApp
+ * is pinned to may not belong to the currently selected wallet.
+ */
+export async function findWalletForAddress(
+  address: string,
+): Promise<{ walletId: string; accountName: string } | null> {
+  const wallets = await walletMetadata.getAll()
+  const wallet = wallets.find(w =>
+    w.accounts.some(account => isSameAddress(account.address, address)),
+  )
+  if (!wallet) return null
+
+  return {
+    walletId: wallet.id,
+    accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
+  }
+}

--- a/apps/wallet/src/lib/rpc/accounts.ts
+++ b/apps/wallet/src/lib/rpc/accounts.ts
@@ -1,0 +1,69 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+import { getPendingApproval } from '../../data/approval'
+import {
+  connectAccount,
+  debugLog,
+  getChainIdForOrigin,
+} from '../../data/dapp-permissions'
+import { getAccountName, getAddress, getOriginAddress } from './account'
+import { requestApproval } from './request-approval'
+
+import type { RpcContext } from './context'
+
+export async function eth_requestAccounts({
+  origin,
+  metadata,
+}: RpcContext): Promise<string[]> {
+  // Answer from the origin's own account when it has one, or a dApp that
+  // calls this on every mount would flip back to the wallet's selection
+  // and contradict eth_accounts.
+  const connected = await getOriginAddress(origin)
+  if (connected) {
+    return [connected]
+  }
+
+  const address = await getAddress()
+  if (!address) {
+    throw new ProviderRpcError({
+      code: 4100,
+      message: 'No active account',
+    })
+  }
+
+  const existing = await getPendingApproval()
+  if (existing) {
+    throw new ProviderRpcError({
+      code: -32002,
+      message: 'Already processing a connection request.',
+    })
+  }
+
+  const chainId = await getChainIdForOrigin(origin)
+  const accountName = await getAccountName()
+  const connectResult = await requestApproval({
+    type: 'eth_requestAccounts',
+    origin,
+    title: metadata?.title ?? origin,
+    favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
+    address,
+    accountName,
+    chainId,
+  })
+
+  if (!connectResult) {
+    throw new ProviderRpcError({
+      code: 4001,
+      message: 'User rejected the request.',
+    })
+  }
+
+  await connectAccount(origin, address)
+  void debugLog('granted', { origin, address })
+  return [address]
+}
+
+export async function eth_accounts({ origin }: RpcContext): Promise<string[]> {
+  const address = await getOriginAddress(origin)
+  return address ? [address] : []
+}

--- a/apps/wallet/src/lib/rpc/chain.ts
+++ b/apps/wallet/src/lib/rpc/chain.ts
@@ -1,0 +1,55 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+import {
+  getChainIdForOrigin,
+  setChainIdForOrigin,
+} from '../../data/dapp-permissions'
+
+import type { RpcContext } from './context'
+
+const SUPPORTED_CHAIN_IDS = new Set(['0x1', '0x6300b5ea'])
+
+export async function eth_chainId({ origin }: RpcContext): Promise<string> {
+  return await getChainIdForOrigin(origin)
+}
+
+export async function net_version({ origin }: RpcContext): Promise<string> {
+  const chainId = await getChainIdForOrigin(origin)
+  return parseInt(chainId, 16).toString()
+}
+
+export async function wallet_switchEthereumChain({
+  params,
+  origin,
+}: RpcContext): Promise<null> {
+  const p = params as [{ chainId: string }] | undefined
+  const requestedChainId = p?.[0]?.chainId
+  if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
+    throw new ProviderRpcError({
+      code: 4902,
+      message: `Unrecognized chain ID ${requestedChainId}. Try adding the chain using wallet_addEthereumChain first.`,
+    })
+  }
+  if (requestedChainId) {
+    await setChainIdForOrigin(origin, requestedChainId)
+  }
+  return null
+}
+
+export async function wallet_addEthereumChain({
+  params,
+  origin,
+}: RpcContext): Promise<null> {
+  const p = params as [{ chainId: string }] | undefined
+  const requestedChainId = p?.[0]?.chainId
+  if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
+    throw new ProviderRpcError({
+      code: 4902,
+      message: `Chain ${requestedChainId} is not supported`,
+    })
+  }
+  if (requestedChainId) {
+    await setChainIdForOrigin(origin, requestedChainId)
+  }
+  return null
+}

--- a/apps/wallet/src/lib/rpc/context.ts
+++ b/apps/wallet/src/lib/rpc/context.ts
@@ -1,0 +1,8 @@
+export type RpcContext = {
+  method: string
+  params: unknown
+  origin: string
+  metadata?: { title?: string; favicon?: string }
+}
+
+export type LocalHandler = (ctx: RpcContext) => Promise<unknown>

--- a/apps/wallet/src/lib/rpc/errors.ts
+++ b/apps/wallet/src/lib/rpc/errors.ts
@@ -1,0 +1,33 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+/**
+ * The wording is status-go's `ErrDAppIsNotPermittedByUser`, asserted verbatim by
+ * `tests-functional/tests/test_status_connector.py`. It is kept for reference
+ * parity only -- nothing client-side reacts to it.
+ */
+export function notPermitted(): ProviderRpcError {
+  return new ProviderRpcError({
+    code: 4100,
+    message: 'dApp is not permitted by user',
+  })
+}
+
+/** Mirrors status-go `CallRPC`'s fallthrough for methods in neither table. */
+export function methodNotAllowed(method: string): ProviderRpcError {
+  return new ProviderRpcError({
+    code: -32601,
+    message: `method ${method} is not allowed`,
+  })
+}
+
+/**
+ * Distinct from `notPermitted`: the origin *is* permitted but its pinned
+ * account no longer resolves -- the wallet holding it was deleted. Collapsing
+ * the two would report the permission as missing when it is not.
+ */
+export function noConnectedAccount(): ProviderRpcError {
+  return new ProviderRpcError({
+    code: 4100,
+    message: 'No connected account',
+  })
+}

--- a/apps/wallet/src/lib/rpc/permissions.ts
+++ b/apps/wallet/src/lib/rpc/permissions.ts
@@ -1,0 +1,157 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+import {
+  type Caveat,
+  ETH_ACCOUNTS_CAPABILITY,
+  getOriginRecord,
+  grantPermission,
+  isOriginPermitted,
+  normalizeOrigin,
+  type Permission,
+  revokeOrigin,
+} from '../../data/dapp-permissions'
+import { getAddress, getOriginAddress } from './account'
+
+import type { RpcContext } from './context'
+
+/** EIP-2255 shape. status-go's `persistence.Permission` carries `Invoker`. */
+type PermissionResponse = Permission & { invoker: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Mirrors `RPCRequest.getRequestPermissionsParam` in status-go
+ * `commands/request_permissions.go`: `params[0]` is a single-key map of
+ * `{ methodName: caveats }`. A non-map caveats value is not an error there --
+ * it degrades to no caveats.
+ */
+function parseRequestPermissionsParam(params: unknown): {
+  methodName: string
+  caveats: Caveat[]
+} {
+  const first = Array.isArray(params) ? params[0] : undefined
+
+  if (!isRecord(first)) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message: 'invalid parameter type',
+    })
+  }
+
+  const entries = Object.entries(first)
+  if (entries.length > 1) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message: 'multiple methodNames found in request permissions params',
+    })
+  }
+
+  const entry = entries[0]
+  if (!entry) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message: 'no request permission params found',
+    })
+  }
+
+  const [methodName, caveatsValue] = entry
+  const caveats = isRecord(caveatsValue)
+    ? Object.entries(caveatsValue).map(([type, value]) => ({ type, value }))
+    : []
+
+  return { methodName, caveats }
+}
+
+/**
+ * EIP-2255. Deliberately does not prompt -- the origin must already be
+ * connected, matching `commands/request_permissions.go`, which returns
+ * `ErrDAppNotFound` rather than raising a popup.
+ */
+export async function wallet_requestPermissions({
+  params,
+  origin,
+}: RpcContext): Promise<PermissionResponse[]> {
+  const { methodName, caveats } = parseRequestPermissionsParam(params)
+
+  // The dispatch gate does not cover this method, because the error has to be
+  // status-go's distinct ErrDAppNotFound rather than the parity string.
+  //
+  // Permitted, not merely present: `setChainIdForOrigin` creates a bare record
+  // for any origin that switched chains, and records written before that call
+  // was gated outlive the upgrade. Accepting those would let a page the user
+  // never approved grant itself `eth_accounts` with no popup. status-go's
+  // `SelectDApp` likewise returns a permitted dApp, not any row.
+  if (!(await isOriginPermitted(origin))) {
+    throw new ProviderRpcError({
+      code: 4100,
+      message: 'dApp not found; permission not persisted',
+    })
+  }
+
+  // Safe only because the origin is already permitted, so the record exists
+  // with its accounts intact: `grantPermission` on a fresh origin would create
+  // one with no account, which then adopts whichever the wallet has selected.
+  await grantPermission(origin, methodName, caveats)
+
+  return [
+    { invoker: normalizeOrigin(origin), parentCapability: methodName, caveats },
+  ]
+}
+
+/**
+ * EIP-2255. Reachable before connection, returning `[]` -- `get_permissions.go`
+ * answers unconditionally too.
+ *
+ * `restrictReturnedAccounts` is derived here rather than stored: the record's
+ * `accounts` lists every account ever connected to the origin, while
+ * `eth_accounts` returns only the pinned one. Advertising the former would
+ * claim access the wallet will never grant.
+ */
+export async function wallet_getPermissions({
+  origin,
+}: RpcContext): Promise<PermissionResponse[]> {
+  const record = await getOriginRecord(origin)
+  if (!record) return []
+
+  const exposed = await getOriginAddress(origin)
+  const invoker = normalizeOrigin(origin)
+
+  return record.permissions.map(permission => ({
+    invoker,
+    parentCapability: permission.parentCapability,
+    caveats:
+      permission.parentCapability === ETH_ACCOUNTS_CAPABILITY
+        ? [
+            {
+              type: 'restrictReturnedAccounts',
+              value: exposed ? [exposed] : [],
+            },
+          ]
+        : permission.caveats,
+  }))
+}
+
+export async function wallet_revokePermissions({
+  origin,
+}: RpcContext): Promise<null> {
+  await revokeOrigin(origin)
+  return null
+}
+
+export async function wallet_getCapabilities({
+  params,
+}: RpcContext): Promise<Record<string, Record<string, unknown>>> {
+  const p = (params as unknown[]) || []
+  const addr = (p[0] as string) || (await getAddress())
+  if (!addr) return {}
+  const chainIds = (p[1] as string[]) || ['0x1']
+  const capabilities: Record<string, Record<string, unknown>> = {}
+  for (const chainId of chainIds) {
+    capabilities[chainId] = {
+      atomicBatch: { supported: false },
+    }
+  }
+  return capabilities
+}

--- a/apps/wallet/src/lib/rpc/permissions.ts
+++ b/apps/wallet/src/lib/rpc/permissions.ts
@@ -17,6 +17,8 @@ import type { RpcContext } from './context'
 /** EIP-2255 shape. status-go's `persistence.Permission` carries `Invoker`. */
 type PermissionResponse = Permission & { invoker: string }
 
+const RESTRICT_RETURNED_ACCOUNTS = 'restrictReturnedAccounts'
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -107,7 +109,9 @@ export async function wallet_requestPermissions({
  * `restrictReturnedAccounts` is derived here rather than stored: the record's
  * `accounts` lists every account ever connected to the origin, while
  * `eth_accounts` returns only the pinned one. Advertising the former would
- * claim access the wallet will never grant.
+ * claim access the wallet will never grant. Only that one caveat is derived --
+ * anything else the dApp asked for through `wallet_requestPermissions` is
+ * reported back as stored.
  */
 export async function wallet_getPermissions({
   origin,
@@ -124,8 +128,14 @@ export async function wallet_getPermissions({
     caveats:
       permission.parentCapability === ETH_ACCOUNTS_CAPABILITY
         ? [
+            // A stored `restrictReturnedAccounts` is dropped: a dApp can write
+            // one through `wallet_requestPermissions`, and it must not shadow
+            // the derived value.
+            ...permission.caveats.filter(
+              caveat => caveat.type !== RESTRICT_RETURNED_ACCOUNTS,
+            ),
             {
-              type: 'restrictReturnedAccounts',
+              type: RESTRICT_RETURNED_ACCOUNTS,
               value: exposed ? [exposed] : [],
             },
           ]

--- a/apps/wallet/src/lib/rpc/permissions.ts
+++ b/apps/wallet/src/lib/rpc/permissions.ts
@@ -8,8 +8,8 @@ import {
   isOriginPermitted,
   normalizeOrigin,
   type Permission,
-  revokeOrigin,
 } from '../../data/dapp-permissions'
+import { disconnectDapp } from '../dapp-events'
 import { getAddress, getOriginAddress } from './account'
 
 import type { RpcContext } from './context'
@@ -133,10 +133,15 @@ export async function wallet_getPermissions({
   }))
 }
 
+/**
+ * EIP-2255. Notifies as well as revokes: the calling page keeps the account it
+ * was handed until something tells it otherwise, and other tabs on the same
+ * origin never saw the request at all.
+ */
 export async function wallet_revokePermissions({
   origin,
 }: RpcContext): Promise<null> {
-  await revokeOrigin(origin)
+  await disconnectDapp(origin)
   return null
 }
 

--- a/apps/wallet/src/lib/rpc/request-approval.ts
+++ b/apps/wallet/src/lib/rpc/request-approval.ts
@@ -1,0 +1,120 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+import {
+  APPROVAL_TIMEOUT_MS,
+  type ApprovalResult,
+  clearApprovalResult,
+  clearPendingApproval,
+  getApprovalResult,
+  type PendingApproval,
+  setPendingApproval,
+} from '../../data/approval'
+
+const APPROVAL_POPUP_WIDTH = 390
+const APPROVAL_POPUP_HEIGHT = 628
+
+type PendingApprovalInput = PendingApproval extends infer T
+  ? T extends PendingApproval
+    ? Omit<T, 'id' | 'createdAt'>
+    : never
+  : never
+
+/**
+ * Synchronous claim on the single approval slot.
+ */
+let approvalInFlight = false
+
+export function requestApproval(
+  approval: PendingApprovalInput,
+): Promise<ApprovalResult | null> {
+  if (approvalInFlight) {
+    return Promise.reject(
+      new ProviderRpcError({
+        code: -32002,
+        message: 'Already processing a request.',
+      }),
+    )
+  }
+  approvalInFlight = true
+
+  return new Promise(resolve => {
+    const id = crypto.randomUUID()
+    let popupWindowId: number | undefined
+    let settled = false
+    const timeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+      cleanup()
+      resolve(null)
+    }, APPROVAL_TIMEOUT_MS)
+
+    const cleanup = () => {
+      if (settled) return
+      settled = true
+      approvalInFlight = false
+      clearTimeout(timeout)
+      chrome.storage.onChanged.removeListener(storageListener)
+      chrome.windows.onRemoved.removeListener(windowListener)
+      clearPendingApproval()
+      clearApprovalResult()
+    }
+
+    const storageListener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      area: string,
+    ) => {
+      if (area !== 'session' || !changes.approvalResult) return
+      const result = changes.approvalResult.newValue as
+        | ApprovalResult
+        | undefined
+      if (!result || result.id !== id) return
+      cleanup()
+      resolve(result.approved ? result : null)
+    }
+
+    const windowListener = (removedWindowId: number) => {
+      if (removedWindowId !== popupWindowId) return
+      // The approval page writes its result and then closes itself, so this
+      // can arrive before the storage change that carries the verdict.
+      // Treating the close as a rejection outright loses approvals: re-read
+      // the result and only fall back to rejection when there genuinely is
+      // none.
+      void getApprovalResult().then(result => {
+        cleanup()
+        resolve(result?.id === id && result.approved ? result : null)
+      })
+    }
+
+    chrome.storage.onChanged.addListener(storageListener)
+    chrome.windows.onRemoved.addListener(windowListener)
+    ;(async () => {
+      try {
+        await setPendingApproval({
+          id,
+          createdAt: Date.now(),
+          ...approval,
+        } as PendingApproval)
+        const popupUrl = chrome.runtime.getURL('approval.html')
+        const currentWindow = await chrome.windows.getCurrent()
+        const left =
+          (currentWindow.left ?? 0) +
+          (currentWindow.width ?? 0) -
+          APPROVAL_POPUP_WIDTH -
+          16
+        const top = (currentWindow.top ?? 0) + 16
+
+        const popup = await chrome.windows.create({
+          url: popupUrl,
+          type: 'popup',
+          width: APPROVAL_POPUP_WIDTH,
+          height: APPROVAL_POPUP_HEIGHT,
+          left,
+          top,
+          focused: true,
+        })
+        popupWindowId = popup?.id
+      } catch {
+        cleanup()
+        resolve(null)
+      }
+    })()
+  })
+}

--- a/apps/wallet/src/lib/rpc/send-transaction.ts
+++ b/apps/wallet/src/lib/rpc/send-transaction.ts
@@ -1,0 +1,8 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+export async function eth_sendTransaction(): Promise<never> {
+  throw new ProviderRpcError({
+    code: 4200,
+    message: 'Not yet supported via dApp connection',
+  })
+}

--- a/apps/wallet/src/lib/rpc/sign.ts
+++ b/apps/wallet/src/lib/rpc/sign.ts
@@ -1,0 +1,100 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+import { getPendingApproval } from '../../data/approval'
+import { getChainIdForOrigin, isSameAddress } from '../../data/dapp-permissions'
+import { findWalletForAddress, getOriginAddress } from './account'
+import { noConnectedAccount } from './errors'
+import { requestApproval } from './request-approval'
+
+import type { RpcContext } from './context'
+
+type SignMessageApi = {
+  wallet: {
+    account: {
+      ethereum: {
+        signMessage: (input: {
+          walletId: string
+          fromAddress: string
+          message: string
+        }) => Promise<{ signature: string }>
+      }
+    }
+  }
+}
+
+export async function personal_sign({
+  params,
+  origin,
+  metadata,
+}: RpcContext): Promise<string> {
+  const p = params as [string, string]
+  const message = p[0]
+  // The origin's own account, not the wallet's selection: signing with the
+  // selected account would return a signature from a key the dApp was
+  // never shown.
+  const signerAddress = await getOriginAddress(origin)
+  if (!signerAddress) {
+    // The dispatch gate already refused unpermitted origins, so reaching this
+    // means the origin is permitted but its pinned account no longer resolves.
+    throw noConnectedAccount()
+  }
+  if (p[1] && !isSameAddress(signerAddress, p[1])) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message: `Requested address ${p[1]} does not match the connected account`,
+    })
+  }
+
+  const signer = await findWalletForAddress(signerAddress)
+  if (!signer) {
+    throw new ProviderRpcError({
+      code: 4100,
+      message: 'No wallet available',
+    })
+  }
+
+  // Guard against concurrent approval requests
+  const existingSign = await getPendingApproval()
+  if (existingSign) {
+    throw new ProviderRpcError({
+      code: -32002,
+      message: 'Already processing a request.',
+    })
+  }
+
+  const signChainId = await getChainIdForOrigin(origin)
+  const signResult = await requestApproval({
+    type: 'personal_sign',
+    origin,
+    title: metadata?.title ?? origin,
+    favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
+    address: signerAddress,
+    accountName: signer.accountName,
+    chainId: signChainId,
+    message,
+  })
+
+  if (!signResult) {
+    throw new ProviderRpcError({
+      code: 4001,
+      message: 'User rejected the request.',
+    })
+  }
+
+  const signed = await (
+    globalThis as unknown as { api: SignMessageApi }
+  ).api.wallet.account.ethereum.signMessage({
+    walletId: signer.walletId,
+    fromAddress: signerAddress,
+    message,
+  })
+
+  return signed.signature
+}
+
+export async function eth_signTypedData_v4(): Promise<never> {
+  throw new ProviderRpcError({
+    code: 4200,
+    message: 'Not yet supported via dApp connection',
+  })
+}


### PR DESCRIPTION
Base: `fix/wallet/persist-dapp-permissions` (PR #1298). Part 2 of the RPC parity
work for #1136.

`rpc-handler.ts` ended in a `default:` branch forwarding any unrecognised method
to the node, for any origin -- connected or not. An unapproved page could read
chain state, estimate gas and spend the wallet's authenticated proxy quota.
`wallet_switchEthereumChain` and `wallet_addEthereumChain` had no check either,
and `wallet_requestPermissions` returned a hardcoded grant it never persisted.

Dispatch now mirrors status-go's `CallRPC` (`services/connector` @ `384a179`):
local registry -> remote allowlist (35 methods from `remote.go`) -> `-32601`.
Everything outside `UNGATED_LOCAL` requires the origin to be permitted.
`wallet_getPermissions` is implemented; `wallet_requestPermissions` follows
`request_permissions.go`.

Method bodies move to `lib/rpc/` with `rpc-handler.ts` reduced to a handler map,
so the gated set cannot drift from the implemented one.

---

#### How to test

- Build, load `apps/wallet/.output/chrome-mv3` unpacked, reload the extension, open any page (e.g. `www.google.com`), and in the console:

```js
const found = []
window.addEventListener('eip6963:announceProvider', e => found.push(e.detail))
window.dispatchEvent(new Event('eip6963:requestProvider'))
setTimeout(() => {
  const p = found.find(x => x.info.rdns === 'app.status').provider
  const call = m => p.request({ method: m }).then(r => ({ m, ok: r }), e => ({ m, code: e.code, msg: e.message }))
  Promise.all(['eth_chainId','eth_accounts','wallet_getPermissions','eth_blockNumber','eth_getProof'].map(call)).then(r => console.table(r))
}, 200)
```

You should get:
```json
[
    {
        "m": "eth_chainId",
        "ok": "0x1"
    },
    {
        "m": "eth_accounts",
        "ok": []
    },
    {
        "m": "wallet_getPermissions",
        "ok": []
    },
    {
        "m": "eth_blockNumber",
        "code": 4100,
        "msg": "dApp is not permitted by user"
    },
    {
        "m": "eth_getProof",
        "code": -32601,
        "msg": "method eth_getProof is not allowed"
    }
]
```

- Then connect the wallet with `await window.ethereum.request({ method: 'eth_requestAccounts' })`, run the command above again and you should get:
```json
[
    {
        "m": "eth_chainId",
        "ok": "0x1"
    },
    {
        "m": "eth_accounts",
        "ok": [
            "0xc738...9e1"
        ]
    },
    {
        "m": "wallet_getPermissions",
        "ok": [
            {
                "invoker": "https://www.google.com",
                "parentCapability": "eth_accounts",
                "caveats": [
                    {
                        "type": "restrictReturnedAccounts",
                        "value": [
                            "0xc738...9e1"
                        ]
                    }
                ]
            }
        ]
    },
    {
        "m": "eth_blockNumber",
        "ok": "0x1894fa1" (will be different for you ofc)
    },
    {
        "m": "eth_getProof",
        "code": -32601,
        "msg": "method eth_getProof is not allowed"
    }
]
```

- Then run a real dApp read-only flow (Uniswap, Velora), confirm that you can get quotes, wallet activity, etc. Same inside the wallet extension directly, especially with Li.Fi.

- Note -- to disconnect the wallet you can use:
```js
const found = []
window.addEventListener('eip6963:announceProvider', e => found.push(e.detail))
window.dispatchEvent(new Event('eip6963:requestProvider'))
setTimeout(() => found.find(x => x.info.rdns === 'app.status').provider
  .request({ method: 'wallet_revokePermissions', params: [{ eth_accounts: {} }] })
  .then(() => console.log('disconnected')), 200)
```