### PR TITLE
feat(wallet): sign EIP-712 typed data for dApps

### DIFF
--- a/.changeset/tidy-pillows-invite.md
+++ b/.changeset/tidy-pillows-invite.md
@@ -1,0 +1,5 @@
+---
+'wallet': patch
+---
+
+feat(wallet): support eth_signTypedData_v4 for dApps

--- a/apps/status.app/package.json
+++ b/apps/status.app/package.json
@@ -24,7 +24,7 @@
     "preview:docker": "pnpm build:docker && pnpm start:docker",
     "prelint": "contentlayer2 build",
     "lint": "pnpm lint:remark && pnpm lint:next",
-    "lint:next": "next lint --dir=src --ext=.ts --ext=.tsx",
+    "lint:next": "eslint src",
     "lint:remark": "remark --quiet --ext md --ext mdx content/help content/legal",
     "lint:fix": "pnpm lint:fix:remark && pnpm lint:fix:next",
     "lint:fix:next": "pnpm lint:next --fix",

--- a/apps/wallet/src/data/approval.ts
+++ b/apps/wallet/src/data/approval.ts
@@ -23,6 +23,22 @@ export type PendingApproval = { createdAt: number } & (
       chainId: string
       message: string
     }
+  | {
+      id: string
+      type: 'eth_signTypedData_v4'
+      origin: string
+      title: string
+      favicon: string
+      address: string
+      accountName: string
+      chainId: string
+      /**
+       * The EIP-712 payload, serialised. It crosses `chrome.storage`, which
+       * round-trips JSON, so the handler parses and validates once and the
+       * popup only ever renders this string back.
+       */
+      typedData: string
+    }
 )
 
 export type ApprovalResult = {

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../data/approval'
 import { connectAccount } from '../../data/dapp-permissions'
 import { apiClient } from '../../providers/api-client'
-import { clip, flattenTypedData } from './typed-data-rows'
+import { clip, flattenTypedData, signedDomainFields } from './typed-data-rows'
 
 const CHAIN_NAMES: Record<string, string> = {
   '0x1': 'Mainnet',
@@ -331,28 +331,38 @@ function TypedDataContent({
 
   const domain = (payload?.domain ?? {}) as Record<string, unknown>
   const primaryType = String(payload?.primaryType ?? 'unknown')
-  const { rows, truncated } = flattenTypedData(payload?.message)
+  const signedDomain = signedDomainFields(domain, payload?.types)
+  const { rows, truncated } = flattenTypedData(
+    payload?.message,
+    payload?.types,
+    payload?.primaryType,
+  )
 
   return (
     <>
       <p className="mb-2 text-13 font-medium text-neutral-50">Request</p>
       <div className="mb-4 flex flex-col gap-1 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
-        {domain.name !== undefined && (
+        {signedDomain.has('name') && domain.name !== undefined && (
           <TypedDataField label="Domain" value={String(domain.name)} />
         )}
-        {domain.verifyingContract !== undefined && (
-          <TypedDataField
-            label="Contract"
-            value={String(domain.verifyingContract)}
-          />
-        )}
+        {signedDomain.has('verifyingContract') &&
+          domain.verifyingContract !== undefined && (
+            <TypedDataField
+              label="Contract"
+              value={String(domain.verifyingContract)}
+            />
+          )}
         <TypedDataField label="Type" value={primaryType} />
       </div>
 
       <p className="mb-2 text-13 font-medium text-neutral-50">Message</p>
       <div className="mb-4 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
         {rows.length === 0 ? (
-          <p className="text-13 text-neutral-50">No message fields</p>
+          <p className="text-13 text-neutral-50">
+            {truncated
+              ? 'This message could not be read. Decline unless you trust this dApp.'
+              : 'No message fields'}
+          </p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {rows.map((row, index) => (
@@ -371,9 +381,9 @@ function TypedDataContent({
             ))}
           </ul>
         )}
-        {truncated && (
+        {truncated && rows.length > 0 && (
           <p className="mt-2 text-11 text-neutral-50">
-            Message shortened for display. Sign only if you trust this dApp.
+            Some signed fields are hidden. Sign only if you trust this dApp.
           </p>
         )}
       </div>

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -12,8 +12,9 @@ import {
   setApprovalResult,
 } from '../../data/approval'
 import { connectAccount } from '../../data/dapp-permissions'
+import { signedDomainFields } from '../../lib/rpc/typed-data'
 import { apiClient } from '../../providers/api-client'
-import { clip, flattenTypedData, signedDomainFields } from './typed-data-rows'
+import { clip, flattenTypedData } from './typed-data-rows'
 
 const CHAIN_NAMES: Record<string, string> = {
   '0x1': 'Mainnet',

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../data/approval'
 import { connectAccount } from '../../data/dapp-permissions'
 import { apiClient } from '../../providers/api-client'
+import { clip, flattenTypedData } from './typed-data-rows'
 
 const CHAIN_NAMES: Record<string, string> = {
   '0x1': 'Mainnet',
@@ -193,7 +194,8 @@ export function ApprovalPage() {
         </div>
       </div>
 
-      {view.content}
+      {/* Scrolls so a long payload cannot push Decline off the popup. */}
+      <div className="min-h-0 flex-1 overflow-y-auto">{view.content}</div>
 
       <div className="mt-auto grid grid-cols-2 gap-3 py-3">
         <Button
@@ -231,6 +233,13 @@ function getApprovalView(approval: PendingApproval): {
         title: 'Sign message',
         confirmLabel: 'Sign',
         content: <SignContent approval={approval} />,
+      }
+
+    case 'eth_signTypedData_v4':
+      return {
+        title: 'Sign typed data',
+        confirmLabel: 'Sign',
+        content: <TypedDataContent approval={approval} />,
       }
 
     case 'eth_requestAccounts':
@@ -305,6 +314,84 @@ function ConnectContent({ approval }: { approval: PendingApproval }) {
         </ul>
       </div>
     </>
+  )
+}
+
+function TypedDataContent({
+  approval,
+}: {
+  approval: Extract<PendingApproval, { type: 'eth_signTypedData_v4' }>
+}) {
+  let payload: Record<string, unknown> | null = null
+  try {
+    payload = JSON.parse(approval.typedData)
+  } catch {
+    payload = null
+  }
+
+  const domain = (payload?.domain ?? {}) as Record<string, unknown>
+  const primaryType = String(payload?.primaryType ?? 'unknown')
+  const { rows, truncated } = flattenTypedData(payload?.message)
+
+  return (
+    <>
+      <p className="mb-2 text-13 font-medium text-neutral-50">Request</p>
+      <div className="mb-4 flex flex-col gap-1 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
+        {domain.name !== undefined && (
+          <TypedDataField label="Domain" value={String(domain.name)} />
+        )}
+        {domain.verifyingContract !== undefined && (
+          <TypedDataField
+            label="Contract"
+            value={String(domain.verifyingContract)}
+          />
+        )}
+        <TypedDataField label="Type" value={primaryType} />
+      </div>
+
+      <p className="mb-2 text-13 font-medium text-neutral-50">Message</p>
+      <div className="mb-4 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
+        {rows.length === 0 ? (
+          <p className="text-13 text-neutral-50">No message fields</p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {rows.map((row, index) => (
+              <li
+                key={`${row.depth}-${row.key}-${index}`}
+                className="flex gap-2 text-13"
+                style={{ paddingLeft: `${row.depth * 12}px` }}
+              >
+                <span className="shrink-0 text-neutral-50">{row.key}</span>
+                {row.value !== null && (
+                  <span className="min-w-0 break-all text-neutral-100">
+                    {row.value}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {truncated && (
+          <p className="mt-2 text-11 text-neutral-50">
+            Message shortened for display. Sign only if you trust this dApp.
+          </p>
+        )}
+      </div>
+
+      <AccountInfo address={approval.address} name={approval.accountName} />
+      <NetworkInfo chainId={approval.chainId} />
+    </>
+  )
+}
+
+function TypedDataField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2 text-13">
+      <span className="shrink-0 text-neutral-50">{label}</span>
+      <span className="min-w-0 break-all font-medium text-neutral-100">
+        {clip(value)}
+      </span>
+    </div>
   )
 }
 

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 
 import { Button } from '@status-im/components'
 import { CloseIcon } from '@status-im/icons/20'
@@ -120,7 +120,7 @@ export function ApprovalPage() {
     }
   }
 
-  const isSign = approval.type === 'personal_sign'
+  const view = getApprovalView(approval)
 
   const respond = async (approved: boolean) => {
     if (!approval || isSubmitting) return
@@ -161,9 +161,7 @@ export function ApprovalPage() {
       />
 
       <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-27 font-semibold text-neutral-100">
-          {isSign ? 'Sign message' : 'Connect dApp'}
-        </h1>
+        <h1 className="text-27 font-semibold text-neutral-100">{view.title}</h1>
         <Button
           icon={<CloseIcon />}
           aria-label="Close"
@@ -195,11 +193,7 @@ export function ApprovalPage() {
         </div>
       </div>
 
-      {isSign ? (
-        <SignContent approval={approval} />
-      ) : (
-        <ConnectContent approval={approval} />
-      )}
+      {view.content}
 
       <div className="mt-auto grid grid-cols-2 gap-3 py-3">
         <Button
@@ -214,11 +208,38 @@ export function ApprovalPage() {
           onPress={() => respond(true)}
           disabled={isSubmitting}
         >
-          {isSign ? 'Sign' : 'Connect'}
+          {view.confirmLabel}
         </Button>
       </div>
     </div>
   )
+}
+
+/**
+ * One place where a request type decides what the popup says and shows.
+ * Returns rendered content rather than a component reference so each case
+ * keeps the narrowing the switch gave it.
+ */
+function getApprovalView(approval: PendingApproval): {
+  title: string
+  confirmLabel: string
+  content: ReactNode
+} {
+  switch (approval.type) {
+    case 'personal_sign':
+      return {
+        title: 'Sign message',
+        confirmLabel: 'Sign',
+        content: <SignContent approval={approval} />,
+      }
+
+    case 'eth_requestAccounts':
+      return {
+        title: 'Connect dApp',
+        confirmLabel: 'Connect',
+        content: <ConnectContent approval={approval} />,
+      }
+  }
 }
 
 function AccountInfo({ address, name }: { address: string; name: string }) {

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
@@ -6,13 +6,22 @@ import {
   MAX_DEPTH,
   MAX_ROWS,
   MAX_VALUE_LENGTH,
+  signedDomainFields,
 } from './typed-data-rows'
 
-test('a flat message becomes one row per field', () => {
-  const { rows, truncated } = flattenTypedData({
-    spender: '0xabc',
-    value: '1000',
-  })
+const permitTypes = {
+  Permit: [
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+  ],
+}
+
+test('a flat message becomes one row per declared field', () => {
+  const { rows, truncated } = flattenTypedData(
+    { spender: '0xabc', value: '1000' },
+    permitTypes,
+    'Permit',
+  )
 
   expect(rows).toEqual([
     { key: 'spender', value: '0xabc', depth: 0 },
@@ -21,8 +30,47 @@ test('a flat message becomes one row per field', () => {
   expect(truncated).toBe(false)
 })
 
-test('nested objects and arrays are indented by depth', () => {
-  const { rows } = flattenTypedData({ permitted: [{ token: '0xabc' }] })
+// The signature covers `types[primaryType]` only. Walking the message instead
+// let a dApp bury `spender` and `value` under enough unsigned padding to push
+// them past the row cap, and the user approved what they never saw.
+test('unsigned padding cannot push signed fields out of view', () => {
+  const message: Record<string, unknown> = Object.fromEntries(
+    Array.from({ length: MAX_ROWS + 50 }, (_, i) => [`filler${i}`, i]),
+  )
+  message.spender = '0xattacker'
+  message.value = '115792089237316195423570985008687907853269984665640564039457'
+
+  const { rows, truncated } = flattenTypedData(message, permitTypes, 'Permit')
+
+  expect(rows).toEqual([
+    { key: 'spender', value: '0xattacker', depth: 0 },
+    {
+      key: 'value',
+      value: '115792089237316195423570985008687907853269984665640564039457',
+      depth: 0,
+    },
+  ])
+  expect(truncated).toBe(false)
+})
+
+test('a declared field missing from the message renders as null', () => {
+  const { rows } = flattenTypedData({ spender: '0xabc' }, permitTypes, 'Permit')
+
+  expect(rows).toEqual([
+    { key: 'spender', value: '0xabc', depth: 0 },
+    { key: 'value', value: 'null', depth: 0 },
+  ])
+})
+
+test('nested structs and struct arrays are indented by depth', () => {
+  const { rows } = flattenTypedData(
+    { permitted: [{ token: '0xabc' }] },
+    {
+      PermitBatch: [{ name: 'permitted', type: 'TokenPermissions[]' }],
+      TokenPermissions: [{ name: 'token', type: 'address' }],
+    },
+    'PermitBatch',
+  )
 
   expect(rows).toEqual([
     { key: 'permitted', value: null, depth: 0 },
@@ -31,13 +79,17 @@ test('nested objects and arrays are indented by depth', () => {
   ])
 })
 
-// A hostile dApp can nest as deep as it likes. Without the cap the popup
-// renders until the Decline button is off-screen.
+// A self-referencing type is legal EIP-712 and recurses forever without the
+// cap; the depth cap is what terminates the walk.
 test('nesting past the depth cap is collapsed and flagged', () => {
-  let deep: unknown = 'bottom'
+  let deep: unknown = { nested: 'bottom' }
   for (let i = 0; i < MAX_DEPTH + 3; i++) deep = { nested: deep }
 
-  const { rows, truncated } = flattenTypedData(deep as object)
+  const { rows, truncated } = flattenTypedData(
+    deep,
+    { Node: [{ name: 'nested', type: 'Node' }] },
+    'Node',
+  )
 
   expect(truncated).toBe(true)
   expect(Math.max(...rows.map(row => row.depth))).toBe(MAX_DEPTH)
@@ -48,29 +100,46 @@ test('nesting past the depth cap is collapsed and flagged', () => {
   })
 })
 
-test('more fields than the row cap are dropped and flagged', () => {
-  const wide = Object.fromEntries(
-    Array.from({ length: MAX_ROWS + 50 }, (_, i) => [`field${i}`, i]),
-  )
+test('more declared fields than the row cap are dropped and flagged', () => {
+  const fields = Array.from({ length: MAX_ROWS + 50 }, (_, i) => ({
+    name: `field${i}`,
+    type: 'uint256',
+  }))
+  const message = Object.fromEntries(fields.map((field, i) => [field.name, i]))
 
-  const { rows, truncated } = flattenTypedData(wide)
+  const { rows, truncated } = flattenTypedData(
+    message,
+    { Wide: fields },
+    'Wide',
+  )
 
   expect(rows).toHaveLength(MAX_ROWS)
   expect(truncated).toBe(true)
 })
 
 test('an oversized value is clipped', () => {
-  const { rows } = flattenTypedData({ note: 'x'.repeat(MAX_VALUE_LENGTH + 50) })
+  const { rows } = flattenTypedData(
+    { note: 'x'.repeat(MAX_VALUE_LENGTH + 50) },
+    { Memo: [{ name: 'note', type: 'string' }] },
+    'Memo',
+  )
 
   expect(rows[0]!.value).toHaveLength(MAX_VALUE_LENGTH + 1)
   expect(rows[0]!.value!.endsWith('…')).toBe(true)
 })
 
-test('a message that is not an object renders nothing', () => {
-  expect(flattenTypedData('not an object')).toEqual({
-    rows: [],
-    truncated: false,
-  })
+// An empty row list would read as "this message signs nothing", which is a
+// claim the popup cannot make about a payload it failed to decode.
+test('an undecodable payload renders nothing and is flagged', () => {
+  expect(
+    flattenTypedData({ spender: '0xabc' }, permitTypes, 'Missing'),
+  ).toEqual({ rows: [], truncated: true })
+  expect(flattenTypedData({ spender: '0xabc' }, 'not types', 'Permit')).toEqual(
+    {
+      rows: [],
+      truncated: true,
+    },
+  )
 })
 
 // `domain.name` and `verifyingContract` render outside the row list, so they
@@ -81,4 +150,25 @@ test('clip caps any attacker-controlled string', () => {
   expect(clip('x'.repeat(MAX_VALUE_LENGTH + 10))).toHaveLength(
     MAX_VALUE_LENGTH + 1,
   )
+})
+
+test('without a declared EIP712Domain every present domain field is signed', () => {
+  const fields = signedDomainFields(
+    { name: 'Uniswap', verifyingContract: '0xabc' },
+    { Permit: [] },
+  )
+
+  expect([...fields].sort()).toEqual(['name', 'verifyingContract'])
+})
+
+// A dApp that declares EIP712Domain itself decides what the domain separator
+// covers. A `name` left out of it is never signed, so the popup must not show
+// it as the dApp's identity.
+test('a declared EIP712Domain limits the domain fields to what it names', () => {
+  const fields = signedDomainFields(
+    { name: 'Uniswap', verifyingContract: '0xabc' },
+    { EIP712Domain: [{ name: 'verifyingContract', type: 'address' }] },
+  )
+
+  expect([...fields]).toEqual(['verifyingContract'])
 })

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'vitest'
+
+import {
+  clip,
+  flattenTypedData,
+  MAX_DEPTH,
+  MAX_ROWS,
+  MAX_VALUE_LENGTH,
+} from './typed-data-rows'
+
+test('a flat message becomes one row per field', () => {
+  const { rows, truncated } = flattenTypedData({
+    spender: '0xabc',
+    value: '1000',
+  })
+
+  expect(rows).toEqual([
+    { key: 'spender', value: '0xabc', depth: 0 },
+    { key: 'value', value: '1000', depth: 0 },
+  ])
+  expect(truncated).toBe(false)
+})
+
+test('nested objects and arrays are indented by depth', () => {
+  const { rows } = flattenTypedData({ permitted: [{ token: '0xabc' }] })
+
+  expect(rows).toEqual([
+    { key: 'permitted', value: null, depth: 0 },
+    { key: '0', value: null, depth: 1 },
+    { key: 'token', value: '0xabc', depth: 2 },
+  ])
+})
+
+// A hostile dApp can nest as deep as it likes. Without the cap the popup
+// renders until the Decline button is off-screen.
+test('nesting past the depth cap is collapsed and flagged', () => {
+  let deep: unknown = 'bottom'
+  for (let i = 0; i < MAX_DEPTH + 3; i++) deep = { nested: deep }
+
+  const { rows, truncated } = flattenTypedData(deep as object)
+
+  expect(truncated).toBe(true)
+  expect(Math.max(...rows.map(row => row.depth))).toBe(MAX_DEPTH)
+  expect(rows.at(-1)).toEqual({
+    key: 'nested',
+    value: '{ … }',
+    depth: MAX_DEPTH,
+  })
+})
+
+test('more fields than the row cap are dropped and flagged', () => {
+  const wide = Object.fromEntries(
+    Array.from({ length: MAX_ROWS + 50 }, (_, i) => [`field${i}`, i]),
+  )
+
+  const { rows, truncated } = flattenTypedData(wide)
+
+  expect(rows).toHaveLength(MAX_ROWS)
+  expect(truncated).toBe(true)
+})
+
+test('an oversized value is clipped', () => {
+  const { rows } = flattenTypedData({ note: 'x'.repeat(MAX_VALUE_LENGTH + 50) })
+
+  expect(rows[0]!.value).toHaveLength(MAX_VALUE_LENGTH + 1)
+  expect(rows[0]!.value!.endsWith('…')).toBe(true)
+})
+
+test('a message that is not an object renders nothing', () => {
+  expect(flattenTypedData('not an object')).toEqual({
+    rows: [],
+    truncated: false,
+  })
+})
+
+// `domain.name` and `verifyingContract` render outside the row list, so they
+// need the same clipping -- an uncapped domain name pushed the message the
+// user is meant to read off the popup.
+test('clip caps any attacker-controlled string', () => {
+  expect(clip('short')).toBe('short')
+  expect(clip('x'.repeat(MAX_VALUE_LENGTH + 10))).toHaveLength(
+    MAX_VALUE_LENGTH + 1,
+  )
+})

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.test.ts
@@ -6,7 +6,6 @@ import {
   MAX_DEPTH,
   MAX_ROWS,
   MAX_VALUE_LENGTH,
-  signedDomainFields,
 } from './typed-data-rows'
 
 const permitTypes = {
@@ -142,6 +141,19 @@ test('an undecodable payload renders nothing and is flagged', () => {
   )
 })
 
+// A value the declared type says is atomic is summarised, not walked, so its
+// contents are as hidden as anything past a cap and must be flagged as such.
+test('a value the type does not describe is collapsed and flagged', () => {
+  const { rows, truncated } = flattenTypedData(
+    { note: { hidden: 'payload' } },
+    { Memo: [{ name: 'note', type: 'string' }] },
+    'Memo',
+  )
+
+  expect(rows).toEqual([{ key: 'note', value: '{ … }', depth: 0 }])
+  expect(truncated).toBe(true)
+})
+
 // `domain.name` and `verifyingContract` render outside the row list, so they
 // need the same clipping -- an uncapped domain name pushed the message the
 // user is meant to read off the popup.
@@ -150,25 +162,4 @@ test('clip caps any attacker-controlled string', () => {
   expect(clip('x'.repeat(MAX_VALUE_LENGTH + 10))).toHaveLength(
     MAX_VALUE_LENGTH + 1,
   )
-})
-
-test('without a declared EIP712Domain every present domain field is signed', () => {
-  const fields = signedDomainFields(
-    { name: 'Uniswap', verifyingContract: '0xabc' },
-    { Permit: [] },
-  )
-
-  expect([...fields].sort()).toEqual(['name', 'verifyingContract'])
-})
-
-// A dApp that declares EIP712Domain itself decides what the domain separator
-// covers. A `name` left out of it is never signed, so the popup must not show
-// it as the dApp's identity.
-test('a declared EIP712Domain limits the domain fields to what it names', () => {
-  const fields = signedDomainFields(
-    { name: 'Uniswap', verifyingContract: '0xabc' },
-    { EIP712Domain: [{ name: 'verifyingContract', type: 'address' }] },
-  )
-
-  expect([...fields]).toEqual(['verifyingContract'])
 })

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
@@ -1,5 +1,12 @@
+import type { TypedDataField } from '../../lib/rpc/typed-data'
+
 /**
  * Flattens an EIP-712 message into indented rows for the approval popup.
+ *
+ * Rows are driven by `types[primaryType]`, not by the message object: only the
+ * declared fields end up in the hash, so a dApp can pad `message` with
+ * hundreds of unsigned keys and push `spender` or `value` past the row cap.
+ * Walking the type ignores the padding and keeps the signed fields visible.
  *
  * The payload is attacker-controlled. React escapes the text, so the risk is
  * not injection but a popup drowned in a megabyte of nesting -- hence the caps
@@ -18,6 +25,28 @@ export type TypedDataRow = {
   depth: number
 }
 
+const ARRAY_SUFFIX = /\[\d*\]$/
+
+const DOMAIN_FIELDS = [
+  'name',
+  'version',
+  'chainId',
+  'verifyingContract',
+  'salt',
+]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isField(value: unknown): value is TypedDataField {
+  return (
+    isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.type === 'string'
+  )
+}
+
 /** Every attacker-controlled string reaching the popup goes through this. */
 export function clip(text: string): string {
   return text.length > MAX_VALUE_LENGTH
@@ -32,38 +61,99 @@ function formatLeaf(value: unknown): string {
   return clip(String(value))
 }
 
-export function flattenTypedData(message: unknown): {
+/**
+ * The domain fields that reach the domain separator. viem derives
+ * `EIP712Domain` from the keys present on `domain`, unless the dApp declares
+ * the type itself -- in which case a field can sit in `domain`, read as
+ * official in the popup, and never be signed.
+ */
+export function signedDomainFields(
+  domain: unknown,
+  types: unknown,
+): Set<string> {
+  const declared = isRecord(types) ? types.EIP712Domain : undefined
+  if (Array.isArray(declared)) {
+    return new Set(declared.filter(isField).map(field => field.name))
+  }
+
+  const record = isRecord(domain) ? domain : {}
+  return new Set(DOMAIN_FIELDS.filter(name => record[name] !== undefined))
+}
+
+export function flattenTypedData(
+  message: unknown,
+  types: unknown,
+  primaryType: unknown,
+): {
   rows: TypedDataRow[]
   truncated: boolean
 } {
+  const typeTable = isRecord(types) ? types : {}
+  const root =
+    typeof primaryType === 'string' ? typeTable[primaryType] : undefined
+
+  // Nothing decodable. Flagged rather than reported as an empty message: the
+  // popup must not look confident about a payload it cannot read.
+  if (!Array.isArray(root)) return { rows: [], truncated: true }
+
   const rows: TypedDataRow[] = []
   let truncated = false
 
-  const walk = (key: string, node: unknown, depth: number) => {
+  const walk = (key: string, type: string, node: unknown, depth: number) => {
     if (rows.length >= MAX_ROWS) {
       truncated = true
       return
     }
 
-    const isBranch = typeof node === 'object' && node !== null
-    if (!isBranch || depth >= MAX_DEPTH) {
-      if (isBranch) truncated = true
-      rows.push({ key, value: formatLeaf(node), depth })
+    const label = clip(key)
+
+    if (ARRAY_SUFFIX.test(type)) {
+      if (!Array.isArray(node)) {
+        rows.push({ key: label, value: formatLeaf(node), depth })
+        return
+      }
+      if (depth >= MAX_DEPTH) {
+        truncated = true
+        rows.push({ key: label, value: '[ … ]', depth })
+        return
+      }
+
+      const elementType = type.slice(0, type.lastIndexOf('['))
+      rows.push({ key: label, value: null, depth })
+      node.forEach((item, index) =>
+        walk(String(index), elementType, item, depth + 1),
+      )
       return
     }
 
-    rows.push({ key, value: null, depth })
-    const entries = Array.isArray(node)
-      ? node.map((item, index) => [String(index), item] as const)
-      : Object.entries(node as Record<string, unknown>)
-    for (const [childKey, child] of entries) walk(childKey, child, depth + 1)
+    // An undeclared type is an EIP-712 atomic type, so the value is a leaf.
+    // A struct whose value is not an object is a dApp bug viem will reject --
+    // shown as-is rather than dressed up as a branch with no children.
+    const struct = typeTable[type]
+    if (!Array.isArray(struct) || !isRecord(node)) {
+      rows.push({ key: label, value: formatLeaf(node), depth })
+      return
+    }
+    if (depth >= MAX_DEPTH) {
+      truncated = true
+      rows.push({ key: label, value: '{ … }', depth })
+      return
+    }
+
+    rows.push({ key: label, value: null, depth })
+    for (const field of struct) {
+      if (!isField(field)) continue
+      walk(field.name, field.type, node[field.name], depth + 1)
+    }
   }
 
-  const root =
-    typeof message === 'object' && message !== null
-      ? Object.entries(message as Record<string, unknown>)
-      : []
-  for (const [key, value] of root) walk(key, value, 0)
+  // A declared field missing from the message renders as `null`: omitting it
+  // would hide it just as effectively as burying it under padding.
+  const values = isRecord(message) ? message : {}
+  for (const field of root) {
+    if (!isField(field)) continue
+    walk(field.name, field.type, values[field.name], 0)
+  }
 
   return { rows, truncated }
 }

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
@@ -1,0 +1,69 @@
+/**
+ * Flattens an EIP-712 message into indented rows for the approval popup.
+ *
+ * The payload is attacker-controlled. React escapes the text, so the risk is
+ * not injection but a popup drowned in a megabyte of nesting -- hence the caps
+ * below, which are what stops a hostile dApp from making the Decline button
+ * unreachable.
+ */
+
+export const MAX_DEPTH = 4
+export const MAX_ROWS = 200
+export const MAX_VALUE_LENGTH = 200
+
+export type TypedDataRow = {
+  key: string
+  /** `null` for a branch: the rows beneath it carry the values. */
+  value: string | null
+  depth: number
+}
+
+/** Every attacker-controlled string reaching the popup goes through this. */
+export function clip(text: string): string {
+  return text.length > MAX_VALUE_LENGTH
+    ? `${text.slice(0, MAX_VALUE_LENGTH)}…`
+    : text
+}
+
+function formatLeaf(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'object') return Array.isArray(value) ? '[ … ]' : '{ … }'
+
+  return clip(String(value))
+}
+
+export function flattenTypedData(message: unknown): {
+  rows: TypedDataRow[]
+  truncated: boolean
+} {
+  const rows: TypedDataRow[] = []
+  let truncated = false
+
+  const walk = (key: string, node: unknown, depth: number) => {
+    if (rows.length >= MAX_ROWS) {
+      truncated = true
+      return
+    }
+
+    const isBranch = typeof node === 'object' && node !== null
+    if (!isBranch || depth >= MAX_DEPTH) {
+      if (isBranch) truncated = true
+      rows.push({ key, value: formatLeaf(node), depth })
+      return
+    }
+
+    rows.push({ key, value: null, depth })
+    const entries = Array.isArray(node)
+      ? node.map((item, index) => [String(index), item] as const)
+      : Object.entries(node as Record<string, unknown>)
+    for (const [childKey, child] of entries) walk(childKey, child, depth + 1)
+  }
+
+  const root =
+    typeof message === 'object' && message !== null
+      ? Object.entries(message as Record<string, unknown>)
+      : []
+  for (const [key, value] of root) walk(key, value, 0)
+
+  return { rows, truncated }
+}

--- a/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
+++ b/apps/wallet/src/entrypoints/approval/typed-data-rows.ts
@@ -27,14 +27,6 @@ export type TypedDataRow = {
 
 const ARRAY_SUFFIX = /\[\d*\]$/
 
-const DOMAIN_FIELDS = [
-  'name',
-  'version',
-  'chainId',
-  'verifyingContract',
-  'salt',
-]
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -61,25 +53,6 @@ function formatLeaf(value: unknown): string {
   return clip(String(value))
 }
 
-/**
- * The domain fields that reach the domain separator. viem derives
- * `EIP712Domain` from the keys present on `domain`, unless the dApp declares
- * the type itself -- in which case a field can sit in `domain`, read as
- * official in the popup, and never be signed.
- */
-export function signedDomainFields(
-  domain: unknown,
-  types: unknown,
-): Set<string> {
-  const declared = isRecord(types) ? types.EIP712Domain : undefined
-  if (Array.isArray(declared)) {
-    return new Set(declared.filter(isField).map(field => field.name))
-  }
-
-  const record = isRecord(domain) ? domain : {}
-  return new Set(DOMAIN_FIELDS.filter(name => record[name] !== undefined))
-}
-
 export function flattenTypedData(
   message: unknown,
   types: unknown,
@@ -99,6 +72,13 @@ export function flattenTypedData(
   const rows: TypedDataRow[] = []
   let truncated = false
 
+  // The type and the value disagree, so the value is summarised rather than
+  // walked. Flagged: its contents are as invisible as anything past a cap.
+  const pushLeaf = (key: string, node: unknown, depth: number) => {
+    if (typeof node === 'object' && node !== null) truncated = true
+    rows.push({ key, value: formatLeaf(node), depth })
+  }
+
   const walk = (key: string, type: string, node: unknown, depth: number) => {
     if (rows.length >= MAX_ROWS) {
       truncated = true
@@ -109,7 +89,7 @@ export function flattenTypedData(
 
     if (ARRAY_SUFFIX.test(type)) {
       if (!Array.isArray(node)) {
-        rows.push({ key: label, value: formatLeaf(node), depth })
+        pushLeaf(label, node, depth)
         return
       }
       if (depth >= MAX_DEPTH) {
@@ -131,7 +111,7 @@ export function flattenTypedData(
     // shown as-is rather than dressed up as a branch with no children.
     const struct = typeTable[type]
     if (!Array.isArray(struct) || !isRecord(node)) {
-      rows.push({ key: label, value: formatLeaf(node), depth })
+      pushLeaf(label, node, depth)
       return
     }
     if (depth >= MAX_DEPTH) {

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -797,6 +797,25 @@ describe('the domain chain', () => {
       signTypedData(ADDRESS, withDomain({ name: 'snapshot' })),
     ).resolves.toBe('0xtypedsig'))
 
+  // A chainId the dApp leaves out of its own EIP712Domain is not in the
+  // separator: the check above would pass on a signature bound to no chain.
+  test('a chain the payload does not sign is refused', async () => {
+    await expect(
+      signTypedData(
+        ADDRESS,
+        JSON.stringify({
+          ...TYPED_DATA,
+          domain: { chainId: 1 },
+          types: {
+            ...TYPED_DATA.types,
+            EIP712Domain: [{ name: 'name', type: 'string' }],
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: -32602 })
+    expect(signedTypedData).toBeNull()
+  })
+
   test('a chain other than the one the origin is on is refused', async () => {
     await expect(
       signTypedData(ADDRESS, withDomain({ chainId: 137 })),

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -797,6 +797,20 @@ describe('the domain chain', () => {
       signTypedData(ADDRESS, withDomain({ name: 'snapshot' })),
     ).resolves.toBe('0xtypedsig'))
 
+  // Most dApps never declare EIP712Domain; viem derives it from the keys the
+  // domain carries, so a chainId sitting there is signed and the check applies.
+  test('an undeclared EIP712Domain leaves the chain signed', () =>
+    expect(
+      signTypedData(
+        ADDRESS,
+        JSON.stringify({
+          ...TYPED_DATA,
+          domain: { chainId: 1 },
+          types: { Permit: TYPED_DATA.types.Permit },
+        }),
+      ),
+    ).resolves.toBe('0xtypedsig'))
+
   // A chainId the dApp leaves out of its own EIP712Domain is not in the
   // separator: the check above would pass on a signature bound to no chain.
   test('a chain the payload does not sign is refused', async () => {

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -126,10 +126,12 @@ async function selectAccount(address: string, walletId: string) {
 }
 
 const signed: { walletId?: string; fromAddress?: string } = {}
+let signedTypedData: Record<string, unknown> | null = null
 
 beforeEach(async () => {
   autoApprove = true
   popupsOpened = 0
+  signedTypedData = null
   nodeRequest.mockClear()
   vi.stubGlobal('chrome', createChromeMock())
   vi.stubGlobal('api', {
@@ -142,6 +144,10 @@ beforeEach(async () => {
           }) => {
             Object.assign(signed, input)
             return { signature: '0xsig' }
+          },
+          signTypedData: async (input: Record<string, unknown>) => {
+            signedTypedData = input
+            return { signature: '0xtypedsig' }
           },
         },
       },
@@ -594,5 +600,222 @@ describe('personal_sign distinguishes its two failures', () => {
       code: 4100,
       message: 'No connected account',
     })
+  })
+})
+
+const TYPED_DATA = {
+  domain: {
+    name: 'Permit2',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+  },
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Permit: [
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+    ],
+  },
+  primaryType: 'Permit',
+  message: { spender: OTHER_ADDRESS, value: '1000' },
+}
+
+const signTypedData = (address: unknown, typedData: unknown, origin = ORIGIN) =>
+  handleRpcRequest('eth_signTypedData_v4', [address, typedData], origin)
+
+/** `TYPED_DATA` with a replaced domain, still valid everywhere else. */
+const withDomain = (domain: Record<string, unknown>) =>
+  JSON.stringify({ ...TYPED_DATA, domain })
+
+describe('eth_signTypedData_v4', () => {
+  test('signs with the account the origin is pinned to', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    await expect(
+      signTypedData(ADDRESS, JSON.stringify(TYPED_DATA)),
+    ).resolves.toBe('0xtypedsig')
+    expect(signedTypedData).toMatchObject({
+      walletId: WALLET_ID,
+      fromAddress: ADDRESS,
+      primaryType: 'Permit',
+    })
+  })
+
+  // Most dApps stringify, wagmi and viem pass the object through.
+  test('accepts the payload as an object as well as a string', async () => {
+    await connect()
+
+    await expect(signTypedData(ADDRESS, TYPED_DATA)).resolves.toBe('0xtypedsig')
+  })
+
+  test('rejects a request for the account the dApp cannot see', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    await expect(
+      signTypedData(OTHER_ADDRESS, JSON.stringify(TYPED_DATA)),
+    ).rejects.toMatchObject({ code: -32602 })
+  })
+
+  test('an unconnected origin cannot sign', async () => {
+    await expect(
+      signTypedData(ADDRESS, JSON.stringify(TYPED_DATA), 'https://evil.test'),
+    ).rejects.toMatchObject({
+      code: 4100,
+      message: 'dApp is not permitted by user',
+    })
+    expect(popupsOpened).toBe(0)
+  })
+
+  test('the user declining is a rejection, not a signature', async () => {
+    await connect()
+    autoApprove = false
+
+    await expect(
+      signTypedData(ADDRESS, JSON.stringify(TYPED_DATA)),
+    ).rejects.toMatchObject({ code: 4001 })
+    expect(signedTypedData).toBeNull()
+  })
+
+  test('a second request while one is pending is refused', async () => {
+    await connect()
+
+    const [first, second] = await Promise.allSettled([
+      signTypedData(ADDRESS, JSON.stringify(TYPED_DATA)),
+      signTypedData(ADDRESS, JSON.stringify(TYPED_DATA)),
+    ])
+
+    expect([first.status, second.status].sort()).toEqual([
+      'fulfilled',
+      'rejected',
+    ])
+    const rejected = [first, second].find(r => r.status === 'rejected')
+    expect((rejected as PromiseRejectedResult).reason).toMatchObject({
+      code: -32002,
+    })
+  })
+})
+
+// status-go `commands/sign.go` takes the address first and the payload second,
+// the opposite of `personal_sign`. Sniffing which argument looks like an
+// address would paper over a dApp that has them the wrong way round -- and
+// hand it a signature over whatever it did send.
+describe('the swapped parameter order', () => {
+  test('eth_signTypedData_v4 takes the address first', async () => {
+    await connect()
+    popupsOpened = 0
+
+    await expect(
+      signTypedData(JSON.stringify(TYPED_DATA), ADDRESS),
+    ).rejects.toMatchObject({
+      code: -32602,
+      message: expect.stringContaining('expects the address as the first'),
+    })
+    expect(popupsOpened).toBe(0)
+  })
+
+  test('personal_sign takes the message first', async () => {
+    await connect()
+
+    await expect(
+      handleRpcRequest('personal_sign', ['0xdeadbeef', ADDRESS], ORIGIN),
+    ).resolves.toBe('0xsig')
+  })
+})
+
+// Everything here would otherwise surface as an opaque -32603 from zod or
+// viem, after the user had already been shown a popup.
+describe('malformed typed data is refused before the popup', () => {
+  beforeEach(async () => {
+    await connect()
+    popupsOpened = 0
+  })
+
+  const refuses = async (typedData: unknown) => {
+    await expect(signTypedData(ADDRESS, typedData)).rejects.toMatchObject({
+      code: -32602,
+    })
+    expect(popupsOpened).toBe(0)
+  }
+
+  test('a payload that is not JSON', () => refuses('{ not json'))
+
+  test('a payload that is not an object', () => refuses('"a string"'))
+
+  test('a missing primaryType', () =>
+    refuses(JSON.stringify({ ...TYPED_DATA, primaryType: undefined })))
+
+  test('a primaryType absent from types', () =>
+    refuses(JSON.stringify({ ...TYPED_DATA, primaryType: 'Nope' })))
+
+  test('a missing message', () =>
+    refuses(JSON.stringify({ ...TYPED_DATA, message: undefined })))
+
+  test('types that are not {name, type} lists', () =>
+    refuses(JSON.stringify({ ...TYPED_DATA, types: { Permit: 'nope' } })))
+
+  test('a payload too large to hold in session storage', () =>
+    refuses(
+      JSON.stringify({
+        ...TYPED_DATA,
+        message: { spender: OTHER_ADDRESS, value: 'x'.repeat(200_000) },
+      }),
+    ))
+})
+
+// Not a status-go check. The domain is the only place the payload names the
+// chain it binds to, and dApps spell the value three different ways.
+describe('the domain chain', () => {
+  beforeEach(() => connect())
+
+  test('a number matching the origin chain is accepted', () =>
+    expect(signTypedData(ADDRESS, withDomain({ chainId: 1 }))).resolves.toBe(
+      '0xtypedsig',
+    ))
+
+  test('a hex string matching the origin chain is accepted', () =>
+    expect(
+      signTypedData(ADDRESS, withDomain({ chainId: '0x1' })),
+    ).resolves.toBe('0xtypedsig'))
+
+  test('a decimal string matching the origin chain is accepted', () =>
+    expect(signTypedData(ADDRESS, withDomain({ chainId: '1' }))).resolves.toBe(
+      '0xtypedsig',
+    ))
+
+  // EIP-712 makes every domain field optional and plenty of dApps omit this
+  // one, so an absent chain must not become a refusal.
+  test('an absent chain is not checked', () =>
+    expect(
+      signTypedData(ADDRESS, withDomain({ name: 'snapshot' })),
+    ).resolves.toBe('0xtypedsig'))
+
+  test('a chain other than the one the origin is on is refused', async () => {
+    await expect(
+      signTypedData(ADDRESS, withDomain({ chainId: 137 })),
+    ).rejects.toMatchObject({ code: -32602 })
+    expect(signedTypedData).toBeNull()
+  })
+
+  test('the origin chain is the switched-to one, not mainnet', async () => {
+    await handleRpcRequest(
+      'wallet_switchEthereumChain',
+      [{ chainId: '0x6300b5ea' }],
+      ORIGIN,
+    )
+
+    await expect(
+      signTypedData(ADDRESS, withDomain({ chainId: 1 })),
+    ).rejects.toMatchObject({ code: -32602 })
+    await expect(
+      signTypedData(ADDRESS, withDomain({ chainId: 0x6300b5ea })),
+    ).resolves.toBe('0xtypedsig')
   })
 })

--- a/apps/wallet/src/lib/rpc/sign.ts
+++ b/apps/wallet/src/lib/rpc/sign.ts
@@ -161,7 +161,7 @@ export async function eth_signTypedData_v4({
   // Parsed once. The approval record carries the serialised form because it
   // crosses chrome.storage; the signing call takes the structured one.
   const typedData = parseTypedData(p[1])
-  assertDomainChainId(typedData.domain, chainId)
+  assertDomainChainId(typedData, chainId)
   const serialized = serializeTypedData(typedData)
 
   const signer = await requireWalletFor(signerAddress)

--- a/apps/wallet/src/lib/rpc/sign.ts
+++ b/apps/wallet/src/lib/rpc/sign.ts
@@ -5,10 +5,15 @@ import { getChainIdForOrigin, isSameAddress } from '../../data/dapp-permissions'
 import { findWalletForAddress, getOriginAddress } from './account'
 import { noConnectedAccount } from './errors'
 import { requestApproval } from './request-approval'
+import {
+  assertDomainChainId,
+  parseTypedData,
+  serializeTypedData,
+} from './typed-data'
 
 import type { RpcContext } from './context'
 
-type SignMessageApi = {
+type SigningApi = {
   wallet: {
     account: {
       ethereum: {
@@ -17,8 +22,60 @@ type SignMessageApi = {
           fromAddress: string
           message: string
         }) => Promise<{ signature: string }>
+        signTypedData: (input: {
+          walletId: string
+          fromAddress: string
+          domain: Record<string, unknown>
+          types: Record<string, Array<{ name: string; type: string }>>
+          primaryType: string
+          message: Record<string, unknown>
+        }) => Promise<{ signature: string }>
       }
     }
+  }
+}
+
+function signingApi(): SigningApi {
+  return (globalThis as unknown as { api: SigningApi }).api
+}
+
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
+
+/**
+ * The account the origin is pinned to. Signing with the wallet's selection
+ * instead would return a signature from a key the dApp was never shown.
+ */
+async function requireOriginAddress(origin: string): Promise<string> {
+  const address = await getOriginAddress(origin)
+  if (!address) {
+    // The dispatch gate already refused unpermitted origins, so reaching this
+    // means the origin is permitted but its pinned account no longer resolves.
+    throw noConnectedAccount()
+  }
+  return address
+}
+
+/** The pinned account may belong to a wallet other than the selected one. */
+async function requireWalletFor(
+  address: string,
+): Promise<{ walletId: string; accountName: string }> {
+  const wallet = await findWalletForAddress(address)
+  if (!wallet) {
+    throw new ProviderRpcError({
+      code: 4100,
+      message: 'No wallet available',
+    })
+  }
+  return wallet
+}
+
+/** The approval slot holds one request; a second must not replace it. */
+async function assertNoPendingApproval(): Promise<void> {
+  if (await getPendingApproval()) {
+    throw new ProviderRpcError({
+      code: -32002,
+      message: 'Already processing a request.',
+    })
   }
 }
 
@@ -29,15 +86,7 @@ export async function personal_sign({
 }: RpcContext): Promise<string> {
   const p = params as [string, string]
   const message = p[0]
-  // The origin's own account, not the wallet's selection: signing with the
-  // selected account would return a signature from a key the dApp was
-  // never shown.
-  const signerAddress = await getOriginAddress(origin)
-  if (!signerAddress) {
-    // The dispatch gate already refused unpermitted origins, so reaching this
-    // means the origin is permitted but its pinned account no longer resolves.
-    throw noConnectedAccount()
-  }
+  const signerAddress = await requireOriginAddress(origin)
   if (p[1] && !isSameAddress(signerAddress, p[1])) {
     throw new ProviderRpcError({
       code: -32602,
@@ -45,22 +94,8 @@ export async function personal_sign({
     })
   }
 
-  const signer = await findWalletForAddress(signerAddress)
-  if (!signer) {
-    throw new ProviderRpcError({
-      code: 4100,
-      message: 'No wallet available',
-    })
-  }
-
-  // Guard against concurrent approval requests
-  const existingSign = await getPendingApproval()
-  if (existingSign) {
-    throw new ProviderRpcError({
-      code: -32002,
-      message: 'Already processing a request.',
-    })
-  }
+  const signer = await requireWalletFor(signerAddress)
+  await assertNoPendingApproval()
 
   const signChainId = await getChainIdForOrigin(origin)
   const signResult = await requestApproval({
@@ -81,9 +116,7 @@ export async function personal_sign({
     })
   }
 
-  const signed = await (
-    globalThis as unknown as { api: SignMessageApi }
-  ).api.wallet.account.ethereum.signMessage({
+  const signed = await signingApi().wallet.account.ethereum.signMessage({
     walletId: signer.walletId,
     fromAddress: signerAddress,
     message,
@@ -92,9 +125,74 @@ export async function personal_sign({
   return signed.signature
 }
 
-export async function eth_signTypedData_v4(): Promise<never> {
-  throw new ProviderRpcError({
-    code: 4200,
-    message: 'Not yet supported via dApp connection',
+/**
+ * EIP-712. The parameters are swapped relative to `personal_sign` -- address
+ * first, payload second, per status-go `commands/sign.go`. Nothing here sniffs
+ * which argument looks like an address: a dApp sending them the other way
+ * round is told so rather than quietly served.
+ */
+export async function eth_signTypedData_v4({
+  params,
+  origin,
+  metadata,
+}: RpcContext): Promise<string> {
+  const p = Array.isArray(params) ? params : []
+  const requestedAddress = p[0]
+  if (
+    typeof requestedAddress !== 'string' ||
+    !ADDRESS_PATTERN.test(requestedAddress)
+  ) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message:
+        'eth_signTypedData_v4 expects the address as the first parameter and the typed data as the second',
+    })
+  }
+
+  const signerAddress = await requireOriginAddress(origin)
+  if (!isSameAddress(signerAddress, requestedAddress)) {
+    throw new ProviderRpcError({
+      code: -32602,
+      message: `Requested address ${requestedAddress} does not match the connected account`,
+    })
+  }
+
+  const chainId = await getChainIdForOrigin(origin)
+  // Parsed once. The approval record carries the serialised form because it
+  // crosses chrome.storage; the signing call takes the structured one.
+  const typedData = parseTypedData(p[1])
+  assertDomainChainId(typedData.domain, chainId)
+  const serialized = serializeTypedData(typedData)
+
+  const signer = await requireWalletFor(signerAddress)
+  await assertNoPendingApproval()
+
+  const result = await requestApproval({
+    type: 'eth_signTypedData_v4',
+    origin,
+    title: metadata?.title ?? origin,
+    favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
+    address: signerAddress,
+    accountName: signer.accountName,
+    chainId,
+    typedData: serialized,
   })
+
+  if (!result) {
+    throw new ProviderRpcError({
+      code: 4001,
+      message: 'User rejected the request.',
+    })
+  }
+
+  const signed = await signingApi().wallet.account.ethereum.signTypedData({
+    walletId: signer.walletId,
+    fromAddress: signerAddress,
+    domain: typedData.domain,
+    types: typedData.types,
+    primaryType: typedData.primaryType,
+    message: typedData.message,
+  })
+
+  return signed.signature
 }

--- a/apps/wallet/src/lib/rpc/typed-data.test.ts
+++ b/apps/wallet/src/lib/rpc/typed-data.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+
+import { signedDomainFields } from './typed-data'
+
+test('without a declared EIP712Domain every present domain field is signed', () => {
+  const fields = signedDomainFields(
+    { name: 'Uniswap', verifyingContract: '0xabc' },
+    { Permit: [] },
+  )
+
+  expect([...fields].sort()).toEqual(['name', 'verifyingContract'])
+})
+
+// A dApp that declares EIP712Domain itself decides what the domain separator
+// covers. A `name` left out of it is never signed, so nothing downstream may
+// present it as the dApp's identity.
+test('a declared EIP712Domain limits the domain fields to what it names', () => {
+  const fields = signedDomainFields(
+    { name: 'Uniswap', verifyingContract: '0xabc' },
+    { EIP712Domain: [{ name: 'verifyingContract', type: 'address' }] },
+  )
+
+  expect([...fields]).toEqual(['verifyingContract'])
+})
+
+// Declared and present can diverge either way; the set answers only what the
+// type declares, and callers pair it with the value they actually have.
+test('a declared field absent from the domain stays in the set', () => {
+  const fields = signedDomainFields(
+    { name: 'Uniswap' },
+    {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'salt', type: 'bytes32' },
+      ],
+    },
+  )
+
+  expect([...fields].sort()).toEqual(['name', 'salt'])
+})

--- a/apps/wallet/src/lib/rpc/typed-data.ts
+++ b/apps/wallet/src/lib/rpc/typed-data.ts
@@ -1,0 +1,150 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
+
+export type TypedDataField = { name: string; type: string }
+
+export type TypedData = {
+  domain: Record<string, unknown>
+  types: Record<string, TypedDataField[]>
+  primaryType: string
+  message: Record<string, unknown>
+}
+
+/**
+ * Refused before the popup rather than truncated inside it: the approval window
+ * is the user's only look at what they are signing, and a payload no reviewer
+ * can read is not something to render at all. Far beyond any legitimate
+ * EIP-712 message. The display caps in `approval/typed-data-rows.ts` handle
+ * what gets through.
+ */
+const MAX_SERIALIZED_LENGTH = 128 * 1024
+
+function invalidParams(message: string): ProviderRpcError {
+  return new ProviderRpcError({ code: -32602, message })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Validates the EIP-712 payload against what
+ * `wallet.account.ethereum.signTypedData` accepts. Every rejection here is one
+ * the dApp would otherwise get as an opaque `-32603` from zod or from viem,
+ * after the user had already been shown a popup.
+ *
+ * Accepts the payload as a JSON string, which is what most dApps send, or as
+ * an object, which wagmi and viem send.
+ */
+export function parseTypedData(value: unknown): TypedData {
+  let raw = value
+
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw)
+    } catch {
+      throw invalidParams('typed data is not valid JSON')
+    }
+  }
+
+  if (!isRecord(raw)) {
+    throw invalidParams('typed data must be an object')
+  }
+
+  const { domain, types, primaryType, message } = raw
+
+  if (!isRecord(domain)) {
+    throw invalidParams('typed data is missing a domain')
+  }
+  if (!isRecord(types)) {
+    throw invalidParams('typed data is missing types')
+  }
+  if (typeof primaryType !== 'string' || !primaryType) {
+    throw invalidParams('typed data is missing a primaryType')
+  }
+  if (!isRecord(message)) {
+    throw invalidParams('typed data is missing a message')
+  }
+
+  const parsedTypes: Record<string, TypedDataField[]> = {}
+  for (const [name, fields] of Object.entries(types)) {
+    if (
+      !Array.isArray(fields) ||
+      !fields.every(
+        field =>
+          isRecord(field) &&
+          typeof field.name === 'string' &&
+          typeof field.type === 'string',
+      )
+    ) {
+      throw invalidParams(`type ${name} is not a list of {name, type} fields`)
+    }
+    parsedTypes[name] = fields as TypedDataField[]
+  }
+
+  // viem throws when the primary type is not defined, which would reach the
+  // dApp as -32603 after the user had already approved.
+  if (!(primaryType in parsedTypes)) {
+    throw invalidParams(`primaryType ${primaryType} is not defined in types`)
+  }
+
+  return { domain, types: parsedTypes, primaryType, message }
+}
+
+export function serializeTypedData(typedData: TypedData): string {
+  const serialized = JSON.stringify(typedData)
+  if (serialized.length > MAX_SERIALIZED_LENGTH) {
+    throw invalidParams('typed data payload is too large')
+  }
+  return serialized
+}
+
+/**
+ * `chainId` is optional in EIP-712 and dApps spell it as a number, a decimal
+ * string or a hex string, so both sides are normalised and an absent value is
+ * left alone.
+ */
+function parseDomainChainId(value: unknown): number | null {
+  if (value === undefined || value === null) return null
+
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    const asNumber = Number(value)
+    if (!Number.isSafeInteger(asNumber)) {
+      throw invalidParams('typed data declares an unreadable domain.chainId')
+    }
+    return asNumber
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const asNumber = /^0x/i.test(trimmed)
+      ? Number.parseInt(trimmed, 16)
+      : Number(trimmed)
+    if (!Number.isSafeInteger(asNumber)) {
+      throw invalidParams('typed data declares an unreadable domain.chainId')
+    }
+    return asNumber
+  }
+
+  throw invalidParams('typed data declares an unreadable domain.chainId')
+}
+
+/**
+ * status-go does not check this. The domain is the only place the payload
+ * names the chain it binds to, and a signature the user believes is for the
+ * chain they are on but is not is a phishing shape worth closing.
+ */
+export function assertDomainChainId(
+  domain: Record<string, unknown>,
+  originChainId: string,
+): void {
+  const declared = parseDomainChainId(domain.chainId)
+  if (declared === null) return
+
+  const current = Number.parseInt(originChainId, 16)
+  if (declared !== current) {
+    throw invalidParams(
+      `typed data is for chain ${declared}, but this dApp is connected to chain ${current}`,
+    )
+  }
+}

--- a/apps/wallet/src/lib/rpc/typed-data.ts
+++ b/apps/wallet/src/lib/rpc/typed-data.ts
@@ -26,6 +26,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function isField(value: unknown): value is TypedDataField {
+  return (
+    isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.type === 'string'
+  )
+}
+
+const DOMAIN_FIELDS = [
+  'name',
+  'version',
+  'chainId',
+  'verifyingContract',
+  'salt',
+]
+
+/**
+ * The domain fields that reach the domain separator. viem derives
+ * `EIP712Domain` from the keys present on `domain`, unless the dApp declares
+ * the type itself -- in which case a field can sit in `domain`, read as
+ * official, and never be signed.
+ */
+export function signedDomainFields(
+  domain: unknown,
+  types: unknown,
+): Set<string> {
+  const declared = isRecord(types) ? types.EIP712Domain : undefined
+  if (Array.isArray(declared)) {
+    return new Set(declared.filter(isField).map(field => field.name))
+  }
+
+  const record = isRecord(domain) ? domain : {}
+  return new Set(DOMAIN_FIELDS.filter(name => record[name] !== undefined))
+}
+
 /**
  * Validates the EIP-712 payload against what
  * `wallet.account.ethereum.signTypedData` accepts. Every rejection here is one
@@ -135,11 +170,18 @@ function parseDomainChainId(value: unknown): number | null {
  * chain they are on but is not is a phishing shape worth closing.
  */
 export function assertDomainChainId(
-  domain: Record<string, unknown>,
+  { domain, types }: TypedData,
   originChainId: string,
 ): void {
   const declared = parseDomainChainId(domain.chainId)
   if (declared === null) return
+
+  // A chainId the dApp leaves out of its own EIP712Domain is not in the
+  // separator, so the signature binds to no chain at all while this check
+  // reads as satisfied.
+  if (!signedDomainFields(domain, types).has('chainId')) {
+    throw invalidParams('typed data declares a chainId it does not sign')
+  }
 
   const current = Number.parseInt(originChainId, 16)
   if (declared !== current) {


### PR DESCRIPTION
Base: `fix/wallet/gate-dapp-rpc-methods` (#1299). Part 3 of the RPC parity work for #1136.

`eth_signTypedData_v4` threw `4200`. It now signs through the same per-origin pinning and approval path as `personal_sign`.

Parameters are swapped relative to `personal_sign` -- address first, payload second, per status-go `commands/sign.go`. Nothing sniffs which argument looks like an address; a dApp with them the wrong way round is told so. The payload is parsed and validated before the popup opens, so malformed input cannot reach viem as an opaque `-32603` after the user has already approved. `domain.chainId` is checked against the origin's chain, normalising the number / hex / decimal spellings dApps use and skipping an absent one. The popup renders the payload as hostile input, capped by depth, row count and value length.

The approval popup's `isSign` boolean landed first as an exhaustive switch, in its own no-op commit.

---

#### How to test

Load `apps/wallet/.output/chrome-mv3` unpacked, open any page (e.g. `www.google.com`), then in the console:

```js
const found = []
window.addEventListener('eip6963:announceProvider', e => found.push(e.detail))
window.dispatchEvent(new Event('eip6963:requestProvider'))
setTimeout(async () => {
  const p = found.find(x => x.info.rdns === 'app.status').provider
  const [addr] = await p.request({ method: 'eth_requestAccounts' })
  const permit = { domain: { name: 'Permit2', version: '1', chainId: 1, verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3' }, types: { EIP712Domain: [{ name: 'name', type: 'string' }, { name: 'version', type: 'string' }, { name: 'chainId', type: 'uint256' }, { name: 'verifyingContract', type: 'address' }], PermitDetails: [{ name: 'token', type: 'address' }, { name: 'amount', type: 'uint160' }, { name: 'expiration', type: 'uint48' }, { name: 'nonce', type: 'uint48' }], PermitSingle: [{ name: 'details', type: 'PermitDetails' }, { name: 'spender', type: 'address' }, { name: 'sigDeadline', type: 'uint256' }] }, primaryType: 'PermitSingle', message: { details: { token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', amount: '1461501637330902918203684832716283019655932542975', expiration: '1735689600', nonce: '0' }, spender: '0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD', sigDeadline: '1733097600' } }
  const call = (label, params) => p.request({ method: 'eth_signTypedData_v4', params }).then(r => ({ label, ok: r }), e => ({ label, code: e.code, msg: e.message }))
  console.log(await call('valid', [addr, JSON.stringify(permit)]))
  console.log(await call('swapped', [JSON.stringify(permit), addr]))
  console.log(await call('wrong account', ['0x'+'1'.repeat(40), JSON.stringify(permit)]))
  console.log(await call('bad json', [addr, '{ not json']))
  console.log(await call('other chain', [addr, JSON.stringify({ ...permit, domain: { ...permit.domain, chainId: 137 } })]))
}, 200)
```

You should get:

```js
{label: 'valid', ok: '0xf60e...11c'} // (this one should be the only one popping an approval window)
{label: 'swapped', code: -32602, msg: 'eth_signTypedData_v4 expects the address as the first parameter and the typed data as the second'}
{label: 'wrong account', code: -32602, msg: 'Requested address 0x1111111111111111111111111111111111111111 does not match the connected account'}
{label: 'bad json', code: -32602, msg: 'typed data is not valid JSON'}
{label: 'other chain', code: -32602, msg: 'typed data is for chain 137, but this dApp is connected to chain 1'}
```