### PR TITLE
feat(wallet): support eth_sendTransaction for dApps

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'wallet': patch
+---
+
+feat(wallet): support eth_sendTransaction for dApps

--- a/apps/wallet/src/data/approval.ts
+++ b/apps/wallet/src/data/approval.ts
@@ -39,6 +39,27 @@ export type PendingApproval = { createdAt: number } & (
        */
       typedData: string
     }
+  | {
+      id: string
+      type: 'eth_sendTransaction'
+      origin: string
+      title: string
+      favicon: string
+      address: string
+      accountName: string
+      chainId: string
+      to: string
+      /** Wei, hex. A bigint would not survive the `chrome.storage` JSON round trip. */
+      value: string
+      /** Calldata, or null for a plain transfer. */
+      data: string | null
+      /**
+       * The ETH ceiling of `maxFeePerGas * gasLimit`, resolved before the popup
+       * opens. The handler sends with the same numbers, so what the user
+       * approves is what gets broadcast.
+       */
+      maxFeeEth: string
+    }
 )
 
 export type ApprovalResult = {

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useEffect, useState } from 'react'
 import { Button } from '@status-im/components'
 import { CloseIcon } from '@status-im/icons/20'
 import { PasswordModal } from '@status-im/wallet/components'
+import { formatEther } from 'viem/utils'
 
 import ethereumIcon from '../../assets/networks/ethereum.png'
 import statusNetworkIcon from '../../assets/networks/status-network.png'
@@ -243,6 +244,13 @@ function getApprovalView(approval: PendingApproval): {
         content: <TypedDataContent approval={approval} />,
       }
 
+    case 'eth_sendTransaction':
+      return {
+        title: 'Confirm transaction',
+        confirmLabel: 'Confirm',
+        content: <TransactionContent approval={approval} />,
+      }
+
     case 'eth_requestAccounts':
       return {
         title: 'Connect dApp',
@@ -344,16 +352,16 @@ function TypedDataContent({
       <p className="mb-2 text-13 font-medium text-neutral-50">Request</p>
       <div className="mb-4 flex flex-col gap-1 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
         {signedDomain.has('name') && domain.name !== undefined && (
-          <TypedDataField label="Domain" value={String(domain.name)} />
+          <DetailRow label="Domain" value={String(domain.name)} />
         )}
         {signedDomain.has('verifyingContract') &&
           domain.verifyingContract !== undefined && (
-            <TypedDataField
+            <DetailRow
               label="Contract"
               value={String(domain.verifyingContract)}
             />
           )}
-        <TypedDataField label="Type" value={primaryType} />
+        <DetailRow label="Type" value={primaryType} />
       </div>
 
       <p className="mb-2 text-13 font-medium text-neutral-50">Message</p>
@@ -395,7 +403,48 @@ function TypedDataContent({
   )
 }
 
-function TypedDataField({ label, value }: { label: string; value: string }) {
+function TransactionContent({
+  approval,
+}: {
+  approval: Extract<PendingApproval, { type: 'eth_sendTransaction' }>
+}) {
+  const value = formatEther(BigInt(approval.value))
+
+  return (
+    <>
+      <div className="mb-4 flex flex-col gap-1 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <p className="text-13 font-medium text-neutral-50">Transaction</p>
+          {approval.data && (
+            <span className="rounded-6 bg-neutral-10 px-1.5 py-0.5 text-11 font-medium text-neutral-100">
+              Contract interaction
+            </span>
+          )}
+        </div>
+        <DetailRow label="To" value={approval.to} />
+        <DetailRow label="Amount" value={`${value} ETH`} />
+        <DetailRow label="Max fee" value={`${approval.maxFeeEth} ETH`} />
+      </div>
+
+      {approval.data && (
+        <>
+          <p className="mb-2 text-13 font-medium text-neutral-50">Data</p>
+          <div className="mb-4 rounded-16 border border-neutral-10 bg-neutral-2.5 px-4 py-3">
+            <p className="break-all font-mono text-11 text-neutral-100">
+              {clip(approval.data)}
+            </p>
+          </div>
+        </>
+      )}
+
+      <AccountInfo address={approval.address} name={approval.accountName} />
+      <NetworkInfo chainId={approval.chainId} />
+    </>
+  )
+}
+
+/** A label/value line, shared by the typed-data and transaction views. */
+function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex gap-2 text-13">
       <span className="shrink-0 text-neutral-50">{label}</span>

--- a/apps/wallet/src/hooks/use-gas-fees.ts
+++ b/apps/wallet/src/hooks/use-gas-fees.ts
@@ -4,26 +4,18 @@ import { GasShiftedError } from '@status-im/wallet/constants'
 import { useQuery } from '@tanstack/react-query'
 import { Interface, isAddress } from 'ethers'
 
-import { fetchTrpcData } from '@/utils/trpc'
+import {
+  type GasFeeRequestParams,
+  type GasFees,
+  requestFeeRate,
+} from '@/lib/gas-fees'
+
+export type { GasFeeRequestParams, GasFees }
 
 const GAS_FEES_STALE_TIME = 8 * 1000
 const GAS_FEES_REFETCH_INTERVAL = 12 * 1000
 const ALLOWED_GAS_SLIPPAGE_PERCENT = 30n
-const GAS_LIMIT_BUFFER_PERCENT = 10n
 const erc20 = new Interface(['function transfer(address to, uint256 amount)'])
-
-export type GasFees = {
-  feeEth: number
-  feeEur: number
-  maxFeeEth: number
-  maxFeeEur: number
-  confirmationTime: string
-  txParams: {
-    gasLimit: string
-    maxFeePerGas: string
-    maxPriorityFeePerGas: string
-  }
-}
 
 type GasInput = {
   to: string
@@ -36,19 +28,6 @@ type UseGasFeesOptions = {
   isNative?: boolean
   contractAddress?: string
   includeGasLimitBuffer?: boolean
-}
-
-export type GasFeeRequestParams = {
-  from: string
-  to: string
-  value?: string
-  data?: string
-}
-
-function toRpcHex(value: string): string {
-  if (value.startsWith('0x')) return value
-  if (value === '') return '0x0'
-  return `0x${value}`
 }
 
 function buildGasFeeParams(
@@ -74,41 +53,6 @@ function buildGasFeeParams(
     to: contractAddress,
     value: '0x0',
     data,
-  }
-}
-
-async function requestFeeRate(
-  params: GasFeeRequestParams,
-  includeGasLimitBuffer: boolean = true,
-): Promise<GasFees> {
-  const normalizedParams: GasFeeRequestParams = {
-    ...params,
-    value: params.value ? toRpcHex(params.value) : params.value,
-  }
-
-  const gasFees = await fetchTrpcData<GasFees>(
-    'nodes.getFeeRate',
-    {
-      network: 'ethereum',
-      params: normalizedParams,
-    },
-    'Failed to fetch gas fees',
-  )
-
-  if (!includeGasLimitBuffer) {
-    return gasFees
-  }
-
-  const estimatedGasLimit = BigInt(gasFees.txParams.gasLimit)
-  const gasLimitWithBuffer =
-    estimatedGasLimit + (estimatedGasLimit * GAS_LIMIT_BUFFER_PERCENT) / 100n
-
-  return {
-    ...gasFees,
-    txParams: {
-      ...gasFees.txParams,
-      gasLimit: `0x${gasLimitWithBuffer.toString(16)}`,
-    },
   }
 }
 

--- a/apps/wallet/src/lib/gas-fees.ts
+++ b/apps/wallet/src/lib/gas-fees.ts
@@ -1,0 +1,71 @@
+import { fetchTrpcData } from '../utils/trpc'
+
+const GAS_LIMIT_BUFFER_PERCENT = 10n
+
+export type GasFees = {
+  feeEth: number
+  feeEur: number
+  maxFeeEth: number
+  maxFeeEur: number
+  confirmationTime: string
+  txParams: {
+    gasLimit: string
+    maxFeePerGas: string
+    maxPriorityFeePerGas: string
+  }
+}
+
+export type GasFeeRequestParams = {
+  from: string
+  to: string
+  value?: string
+  data?: string
+}
+
+function toRpcHex(value: string): string {
+  if (value.startsWith('0x')) return value
+  if (value === '') return '0x0'
+  return `0x${value}`
+}
+
+/**
+ * Lives outside `use-gas-fees.ts` so the service worker can price a dApp's
+ * `eth_sendTransaction` without pulling React, react-query and ethers into the
+ * background bundle.
+ *
+ * `network` stays hardcoded: `nodes.getFeeRate` pins `z.enum(['ethereum'])`.
+ */
+export async function requestFeeRate(
+  params: GasFeeRequestParams,
+  includeGasLimitBuffer: boolean = true,
+): Promise<GasFees> {
+  const normalizedParams: GasFeeRequestParams = {
+    ...params,
+    value: params.value ? toRpcHex(params.value) : params.value,
+  }
+
+  const gasFees = await fetchTrpcData<GasFees>(
+    'nodes.getFeeRate',
+    {
+      network: 'ethereum',
+      params: normalizedParams,
+    },
+    'Failed to fetch gas fees',
+  )
+
+  if (!includeGasLimitBuffer) {
+    return gasFees
+  }
+
+  const estimatedGasLimit = BigInt(gasFees.txParams.gasLimit)
+  const gasLimitWithBuffer =
+    estimatedGasLimit + (estimatedGasLimit * GAS_LIMIT_BUFFER_PERCENT) / 100n
+
+  return {
+    ...gasFees,
+    txParams: {
+      ...gasFees.txParams,
+      gasLimit: `0x${gasLimitWithBuffer.toString(16)}`,
+    },
+  }
+}

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -1015,6 +1015,54 @@ describe('eth_sendTransaction', () => {
     expect(sentTransactions[0].via).toBe('send')
   })
 
+  // Dropping these would change what the transaction does while the popup
+  // still showed what the dApp asked for.
+  describe('fields the send path cannot honour are refused', () => {
+    // The wallet's nonce tracker assigns its own, so a resubmit meant to
+    // replace or cancel a pending transaction would become a second spend.
+    test('nonce', async () => {
+      await connect()
+
+      await expect(
+        sendTransaction({ to: OTHER_ADDRESS, value: '0x1', nonce: '0x3' }),
+      ).rejects.toMatchObject({ code: -32602 })
+      expect(sentTransactions).toEqual([])
+    })
+
+    test('gasPrice', async () => {
+      await connect()
+
+      await expect(
+        sendTransaction({
+          to: OTHER_ADDRESS,
+          value: '0x1',
+          gasPrice: '0x77359400',
+        }),
+      ).rejects.toMatchObject({ code: -32602 })
+      expect(sentTransactions).toEqual([])
+    })
+
+    test('a non-empty accessList', async () => {
+      await connect()
+
+      await expect(
+        sendTransaction({
+          to: OTHER_ADDRESS,
+          value: '0x1',
+          accessList: [{ address: OTHER_ADDRESS, storageKeys: [] }],
+        }),
+      ).rejects.toMatchObject({ code: -32602 })
+    })
+
+    test('an empty accessList is not a request for anything', async () => {
+      await connect()
+
+      await expect(
+        sendTransaction({ to: OTHER_ADDRESS, value: '0x1', accessList: [] }),
+      ).resolves.toBe(TX_HASH)
+    })
+  })
+
   test('the approved fee is the fee that is sent', async () => {
     await connect()
 

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -963,6 +963,49 @@ describe('eth_sendTransaction', () => {
     expect(sentTransactions[0].via).toBe('sendErc20')
   })
 
+  // `sendErc20` re-encodes from the recipient and amount words alone, so it
+  // would sign neither the trailing bytes nor the value the popup displayed.
+  describe('calldata that sendErc20 would not reproduce keeps its bytes', () => {
+    test('trailing bytes after the amount word', async () => {
+      await connect()
+      const data = `${ERC20_TRANSFER}deadbeef`
+
+      await sendTransaction({ to: OTHER_ADDRESS, data })
+
+      expect(sentTransactions[0]).toMatchObject({
+        via: 'sendContractCall',
+        input: { data },
+      })
+    })
+
+    test('a transfer carrying ETH value', async () => {
+      await connect()
+
+      await sendTransaction({
+        to: OTHER_ADDRESS,
+        value: '0x1',
+        data: ERC20_TRANSFER,
+      })
+
+      expect(sentTransactions[0]).toMatchObject({
+        via: 'sendContractCall',
+        input: { data: ERC20_TRANSFER, value: '1' },
+      })
+    })
+
+    test('a recipient word with non-zero padding', async () => {
+      await connect()
+      const data = `0xa9059cbb${'11'.repeat(12)}${'22'.repeat(20)}${'00'.repeat(32)}`
+
+      await sendTransaction({ to: OTHER_ADDRESS, data })
+
+      expect(sentTransactions[0]).toMatchObject({
+        via: 'sendContractCall',
+        input: { data },
+      })
+    })
+  })
+
   // '0x' is what dApps send for "no calldata", and it is truthy.
   test("data of '0x' is a plain transfer", async () => {
     await connect()

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -1015,6 +1015,34 @@ describe('eth_sendTransaction', () => {
     expect(sentTransactions[0].via).toBe('send')
   })
 
+  // geth treats `input` as an alias for `data`; reading only `data` would turn
+  // a contract call into a bare transfer to the contract.
+  describe('the input alias', () => {
+    test('is used when data is absent', async () => {
+      await connect()
+
+      await sendTransaction({ to: OTHER_ADDRESS, input: '0xdeadbeef' })
+
+      expect(sentTransactions[0]).toMatchObject({
+        via: 'sendContractCall',
+        input: { data: '0xdeadbeef' },
+      })
+    })
+
+    test('is refused when it disagrees with data', async () => {
+      await connect()
+
+      await expect(
+        sendTransaction({
+          to: OTHER_ADDRESS,
+          data: '0xdeadbeef',
+          input: '0xfeedface',
+        }),
+      ).rejects.toMatchObject({ code: -32602 })
+      expect(sentTransactions).toEqual([])
+    })
+  })
+
   // Dropping these would change what the transaction does while the popup
   // still showed what the dApp asked for.
   describe('fields the send path cannot honour are refused', () => {

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -9,6 +9,7 @@ import {
   selectAccountForOrigin,
   setChainIdForOrigin,
 } from '../data/dapp-permissions'
+import { requestFeeRate } from './gas-fees'
 import { publicClient } from './public-client'
 import { handleRpcRequest, LOCAL_HANDLERS } from './rpc-handler'
 import { REMOTE_ALLOWED, UNGATED_LOCAL } from './rpc-methods'
@@ -20,7 +21,31 @@ vi.mock('./public-client', () => ({
   publicClient: { request: vi.fn(async () => '0x1234') },
 }))
 
+// `eth_sendTransaction` prices itself against the wallet's own estimator,
+// which is an authenticated HTTP call.
+vi.mock('./gas-fees', () => ({
+  requestFeeRate: vi.fn(),
+}))
+
 const nodeRequest = vi.mocked(publicClient.request)
+const feeRequest = vi.mocked(requestFeeRate)
+
+/** 21000 gas at 1 gwei: a max fee of 0.000021 ETH. */
+const GAS_FEES = {
+  feeEth: 0.0000105,
+  feeEur: 0.03,
+  maxFeeEth: 0.000021,
+  maxFeeEur: 0.06,
+  confirmationTime: '~12s',
+  txParams: {
+    gasLimit: '0x5208',
+    maxFeePerGas: '0x3b9aca00',
+    maxPriorityFeePerGas: '0x3b9aca0',
+  },
+}
+
+const TX_HASH = `0x${'ab'.repeat(32)}`
+const ERC20_TRANSFER = `0xa9059cbb${'00'.repeat(64)}`
 
 const ORIGIN = 'https://app.velora.xyz'
 const OTHER_ORIGIN = 'https://app.uniswap.org'
@@ -127,12 +152,17 @@ async function selectAccount(address: string, walletId: string) {
 
 const signed: { walletId?: string; fromAddress?: string } = {}
 let signedTypedData: Record<string, unknown> | null = null
+let sentTransactions: Array<{ via: string; input: Record<string, unknown> }> =
+  []
 
 beforeEach(async () => {
   autoApprove = true
   popupsOpened = 0
   signedTypedData = null
+  sentTransactions = []
   nodeRequest.mockClear()
+  feeRequest.mockReset()
+  feeRequest.mockResolvedValue(GAS_FEES)
   vi.stubGlobal('chrome', createChromeMock())
   vi.stubGlobal('api', {
     wallet: {
@@ -148,6 +178,18 @@ beforeEach(async () => {
           signTypedData: async (input: Record<string, unknown>) => {
             signedTypedData = input
             return { signature: '0xtypedsig' }
+          },
+          send: async (input: Record<string, unknown>) => {
+            sentTransactions.push({ via: 'send', input })
+            return { id: { txid: TX_HASH } }
+          },
+          sendErc20: async (input: Record<string, unknown>) => {
+            sentTransactions.push({ via: 'sendErc20', input })
+            return { id: { txid: TX_HASH } }
+          },
+          sendContractCall: async (input: Record<string, unknown>) => {
+            sentTransactions.push({ via: 'sendContractCall', input })
+            return { id: { txid: TX_HASH } }
           },
         },
       },
@@ -850,5 +892,233 @@ describe('the domain chain', () => {
     await expect(
       signTypedData(ADDRESS, withDomain({ chainId: 0x6300b5ea })),
     ).resolves.toBe('0xtypedsig')
+  })
+})
+
+const sendTransaction = (
+  tx: Record<string, unknown>,
+  origin = ORIGIN,
+): Promise<unknown> => handleRpcRequest('eth_sendTransaction', [tx], origin)
+
+describe('eth_sendTransaction', () => {
+  test('sends a plain transfer and returns the hash', async () => {
+    await connect()
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x64' }),
+    ).resolves.toBe(TX_HASH)
+    expect(sentTransactions).toMatchObject([
+      {
+        via: 'send',
+        input: { walletId: WALLET_ID, fromAddress: ADDRESS, amount: '64' },
+      },
+    ])
+  })
+
+  test('spends from the account the origin is pinned to', async () => {
+    await connect()
+    await selectAccount(OTHER_ADDRESS, OTHER_WALLET_ID)
+
+    await sendTransaction({ to: OTHER_ADDRESS, value: '0x1' })
+
+    expect(sentTransactions[0].input).toMatchObject({
+      walletId: WALLET_ID,
+      fromAddress: ADDRESS,
+    })
+  })
+
+  // `approve`, `transfer` and every other non-payable call omit it, and
+  // `nodes.getFeeRate` requires it.
+  test('an omitted value is sent as zero', async () => {
+    await connect()
+
+    await sendTransaction({ to: OTHER_ADDRESS })
+
+    expect(feeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ value: '0' }),
+    )
+    expect(sentTransactions[0].input).toMatchObject({ amount: '0' })
+  })
+
+  test('calldata routes through sendContractCall', async () => {
+    await connect()
+
+    await sendTransaction({
+      to: OTHER_ADDRESS,
+      value: '0x0',
+      data: '0xdeadbeef',
+    })
+
+    expect(sentTransactions[0]).toMatchObject({
+      via: 'sendContractCall',
+      input: { data: '0xdeadbeef', value: '0' },
+    })
+  })
+
+  test('an ERC20 transfer routes through sendErc20', async () => {
+    await connect()
+
+    await sendTransaction({ to: OTHER_ADDRESS, data: ERC20_TRANSFER })
+
+    expect(sentTransactions[0].via).toBe('sendErc20')
+  })
+
+  // '0x' is what dApps send for "no calldata", and it is truthy.
+  test("data of '0x' is a plain transfer", async () => {
+    await connect()
+
+    await sendTransaction({ to: OTHER_ADDRESS, value: '0x1', data: '0x' })
+
+    expect(sentTransactions[0].via).toBe('send')
+  })
+
+  test('the approved fee is the fee that is sent', async () => {
+    await connect()
+
+    await sendTransaction({ to: OTHER_ADDRESS, value: '0x1' })
+
+    expect(feeRequest).toHaveBeenCalledTimes(1)
+    expect(sentTransactions[0].input).toMatchObject({
+      gasLimit: GAS_FEES.txParams.gasLimit,
+      maxFeePerGas: GAS_FEES.txParams.maxFeePerGas,
+      maxInclusionFeePerGas: GAS_FEES.txParams.maxPriorityFeePerGas,
+    })
+  })
+
+  test('fee fields the dApp pinned are not overwritten by the estimate', async () => {
+    await connect()
+
+    await sendTransaction({
+      to: OTHER_ADDRESS,
+      value: '0x1',
+      gas: '0x5208',
+      maxFeePerGas: '0x77359400',
+      maxPriorityFeePerGas: '0x3b9aca00',
+    })
+
+    expect(sentTransactions[0].input).toMatchObject({
+      maxFeePerGas: '0x77359400',
+      maxInclusionFeePerGas: '0x3b9aca00',
+    })
+  })
+
+  // Estimation is also the revert check, so it runs even when the dApp priced
+  // the transaction itself -- otherwise a reverting call reaches the popup and
+  // only fails at broadcast.
+  test('a reverting call is caught even when the dApp priced it', async () => {
+    await connect()
+    feeRequest.mockRejectedValue(new Error('execution reverted'))
+
+    await expect(
+      sendTransaction({
+        to: OTHER_ADDRESS,
+        value: '0x1',
+        gas: '0x5208',
+        maxFeePerGas: '0x77359400',
+        maxPriorityFeePerGas: '0x3b9aca00',
+      }),
+    ).rejects.toMatchObject({ code: -32603 })
+  })
+
+  test('a from that is not the pinned account is refused', async () => {
+    await connect()
+
+    await expect(
+      sendTransaction({ from: OTHER_ADDRESS, to: OTHER_ADDRESS, value: '0x1' }),
+    ).rejects.toMatchObject({ code: -32602 })
+    expect(sentTransactions).toEqual([])
+  })
+
+  test('an omitted from defaults to the pinned account', async () => {
+    await connect()
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x1' }),
+    ).resolves.toBe(TX_HASH)
+  })
+
+  test('a bare decimal quantity is refused rather than guessed at', async () => {
+    await connect()
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '100' }),
+    ).rejects.toMatchObject({ code: -32602 })
+  })
+
+  test('a to that is not an address is refused', async () => {
+    await connect()
+
+    await expect(
+      sendTransaction({ to: '0xnothing', value: '0x1' }),
+    ).rejects.toMatchObject({ code: -32602 })
+  })
+
+  test('contract deployment is refused by name', async () => {
+    await connect()
+
+    await expect(sendTransaction({ value: '0x1' })).rejects.toMatchObject({
+      code: 4200,
+      message: 'Contract deployment is not supported',
+    })
+  })
+
+  // The backend pins `z.enum(['ethereum'])` on every route a send needs, so an
+  // off-mainnet request cannot be honoured whatever the client does.
+  test('a dApp on another chain is told why', async () => {
+    await connect()
+    await handleRpcRequest(
+      'wallet_switchEthereumChain',
+      [{ chainId: '0x6300b5ea' }],
+      ORIGIN,
+    )
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x1' }),
+    ).rejects.toMatchObject({ code: 4200 })
+    expect(feeRequest).not.toHaveBeenCalled()
+  })
+
+  test('a rejected approval is 4001', async () => {
+    await connect()
+    autoApprove = false
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x1' }),
+    ).rejects.toMatchObject({ code: 4001 })
+    expect(sentTransactions).toEqual([])
+  })
+
+  // A reverting call fails at estimation. The user should see why rather than
+  // approve an empty popup and get an opaque failure afterwards.
+  test('an estimation failure is reported before the popup', async () => {
+    await connect()
+    const popupsBefore = popupsOpened
+    feeRequest.mockRejectedValue(new Error('execution reverted'))
+
+    await expect(
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x1' }),
+    ).rejects.toMatchObject({
+      code: -32603,
+      message: expect.stringContaining('execution reverted'),
+    })
+    expect(popupsOpened).toBe(popupsBefore)
+  })
+
+  test('a second request while one is pending is -32002', async () => {
+    await connect()
+
+    const [first, second] = await Promise.allSettled([
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x1' }),
+      sendTransaction({ to: OTHER_ADDRESS, value: '0x2' }),
+    ])
+
+    expect([first.status, second.status].sort()).toEqual([
+      'fulfilled',
+      'rejected',
+    ])
+    const rejected = [first, second].find(r => r.status === 'rejected')
+    expect((rejected as PromiseRejectedResult).reason).toMatchObject({
+      code: -32002,
+    })
   })
 })

--- a/apps/wallet/src/lib/rpc/account.ts
+++ b/apps/wallet/src/lib/rpc/account.ts
@@ -1,3 +1,4 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
 import { storage } from '@wxt-dev/storage'
 
 import {
@@ -8,6 +9,7 @@ import {
 } from '../../data/dapp-permissions'
 import * as walletMetadata from '../../data/wallet-metadata'
 import { SELECTED_WALLET_ID_KEY } from '../storage-keys'
+import { noConnectedAccount } from './errors'
 
 export const DEFAULT_ACCOUNT_NAME = 'Account 1'
 
@@ -108,4 +110,32 @@ export async function findWalletForAddress(
     walletId: wallet.id,
     accountName: wallet.name || DEFAULT_ACCOUNT_NAME,
   }
+}
+
+/**
+ * The account the origin is pinned to. Signing or spending with the wallet's
+ * selection instead would act on a key the dApp was never shown.
+ */
+export async function requireOriginAddress(origin: string): Promise<string> {
+  const address = await getOriginAddress(origin)
+  if (!address) {
+    // The dispatch gate already refused unpermitted origins, so reaching this
+    // means the origin is permitted but its pinned account no longer resolves.
+    throw noConnectedAccount()
+  }
+  return address
+}
+
+/** The pinned account may belong to a wallet other than the selected one. */
+export async function requireWalletFor(
+  address: string,
+): Promise<{ walletId: string; accountName: string }> {
+  const wallet = await findWalletForAddress(address)
+  if (!wallet) {
+    throw new ProviderRpcError({
+      code: 4100,
+      message: 'No wallet available',
+    })
+  }
+  return wallet
 }

--- a/apps/wallet/src/lib/rpc/request-approval.ts
+++ b/apps/wallet/src/lib/rpc/request-approval.ts
@@ -6,6 +6,7 @@ import {
   clearApprovalResult,
   clearPendingApproval,
   getApprovalResult,
+  getPendingApproval,
   type PendingApproval,
   setPendingApproval,
 } from '../../data/approval'
@@ -23,6 +24,20 @@ type PendingApprovalInput = PendingApproval extends infer T
  * Synchronous claim on the single approval slot.
  */
 let approvalInFlight = false
+
+/**
+ * The slot holds one request; a second must not replace it. Checked before any
+ * work the user would have to wait through, so a dApp firing two requests is
+ * told immediately rather than after an estimate.
+ */
+export async function assertNoPendingApproval(): Promise<void> {
+  if (await getPendingApproval()) {
+    throw new ProviderRpcError({
+      code: -32002,
+      message: 'Already processing a request.',
+    })
+  }
+}
 
 export function requestApproval(
   approval: PendingApprovalInput,

--- a/apps/wallet/src/lib/rpc/send-transaction.ts
+++ b/apps/wallet/src/lib/rpc/send-transaction.ts
@@ -33,6 +33,25 @@ type DappTransaction = {
   gas?: string
   maxFeePerGas?: string
   maxPriorityFeePerGas?: string
+  nonce?: string
+  gasPrice?: string
+  accessList?: unknown
+}
+
+/**
+ * Fields the send path cannot honor, refused rather than dropped: a dropped
+ * field changes what the transaction does, and the popup would still show the
+ * request the dApp made. `nonceTracker` assigns its own nonce, so a resubmit
+ * meant to replace or cancel a pending transaction would broadcast as a second
+ * spend at the next nonce instead. `gasPrice` has no route to the backend,
+ * which takes only the EIP-1559 pair, so it would be silently replaced by our
+ * own estimate. `type` is not listed: every transaction we sign is Enveloped,
+ * so a dApp asking for `0x2` is describing what it already gets.
+ */
+const UNSUPPORTED_FIELDS: Record<string, string> = {
+  nonce: 'nonce is not supported; the wallet assigns the nonce',
+  gasPrice:
+    'gasPrice is not supported; use maxFeePerGas and maxPriorityFeePerGas',
 }
 
 function invalidParams(message: string): ProviderRpcError {
@@ -80,6 +99,21 @@ function parseCalldata(value: unknown): Hex | undefined {
   return value as Hex
 }
 
+function assertSupportedFields(request: DappTransaction): void {
+  for (const [field, message] of Object.entries(UNSUPPORTED_FIELDS)) {
+    const value = request[field as keyof DappTransaction]
+    if (value !== undefined && value !== null) {
+      throw invalidParams(message)
+    }
+  }
+
+  // An empty list is what a dApp defaulting the field sends, and dropping it
+  // changes nothing.
+  if (Array.isArray(request.accessList) && request.accessList.length > 0) {
+    throw invalidParams('accessList is not supported')
+  }
+}
+
 /**
  * Typed against the real caller rather than a hand-written shape, so a change
  * to a send procedure's input schema breaks the build instead of failing
@@ -110,6 +144,8 @@ export async function eth_sendTransaction({
     throw invalidParams('eth_sendTransaction expects a transaction object')
   }
   const request = p[0] as DappTransaction
+
+  assertSupportedFields(request)
 
   if (!request.to) {
     // status-go has the same gap: `broadcastTransaction` is the only route out

--- a/apps/wallet/src/lib/rpc/send-transaction.ts
+++ b/apps/wallet/src/lib/rpc/send-transaction.ts
@@ -30,6 +30,7 @@ type DappTransaction = {
   to?: string
   value?: string
   data?: string
+  input?: string
   gas?: string
   maxFeePerGas?: string
   maxPriorityFeePerGas?: string
@@ -115,6 +116,25 @@ function assertSupportedFields(request: DappTransaction): void {
 }
 
 /**
+ * geth accepts `input` as an alias for `data` and some libraries send only it.
+ * Reading `data` alone would turn a contract call into a bare transfer to the
+ * contract. Two values that disagree is geth's error case, not a precedence
+ * rule -- there is no way to tell which one the dApp meant.
+ */
+function selectCalldata(request: DappTransaction): unknown {
+  const { data, input } = request
+  if (data === undefined || input === undefined) return data ?? input
+  if (
+    typeof data === 'string' &&
+    typeof input === 'string' &&
+    data.toLowerCase() === input.toLowerCase()
+  ) {
+    return data
+  }
+  throw invalidParams('data and input are both set and disagree')
+}
+
+/**
  * Typed against the real caller rather than a hand-written shape, so a change
  * to a send procedure's input schema breaks the build instead of failing
  * inside the worker after the user has already approved.
@@ -177,7 +197,7 @@ export async function eth_sendTransaction({
     // `nodes.getFeeRate` requires it, so default it as `send_transaction.go`
     // does rather than letting zod reject server-side.
     value: parseQuantity(request.value, 'value') ?? 0n,
-    data: parseCalldata(request.data),
+    data: parseCalldata(selectCalldata(request)),
     gas: parseQuantity(request.gas, 'gas'),
     maxFeePerGas: parseQuantity(request.maxFeePerGas, 'maxFeePerGas'),
     maxPriorityFeePerGas: parseQuantity(

--- a/apps/wallet/src/lib/rpc/send-transaction.ts
+++ b/apps/wallet/src/lib/rpc/send-transaction.ts
@@ -1,8 +1,222 @@
 import { ProviderRpcError } from '@status-im/ethereum-provider'
 
-export async function eth_sendTransaction(): Promise<never> {
-  throw new ProviderRpcError({
-    code: 4200,
-    message: 'Not yet supported via dApp connection',
+import { getChainIdForOrigin, isSameAddress } from '../../data/dapp-permissions'
+import { requestFeeRate } from '../gas-fees'
+import {
+  buildAndSendTransaction,
+  maxFeeEth,
+  resolveFeeParams,
+  type TransactionRequest,
+  type TransactionSenders,
+} from '../send-transaction'
+import { requireOriginAddress, requireWalletFor } from './account'
+import { assertNoPendingApproval, requestApproval } from './request-approval'
+
+import type { createAPI } from '../../data/api'
+import type { RpcContext } from './context'
+import type { Address, Hex } from 'viem'
+
+/**
+ * Signing is fenced to mainnet at the backend, not just here:
+ * `nodes.getFeeRate` / `broadcastTransaction` / `getNonce` all pin
+ * `z.enum(['ethereum'])`, and `api.ts` hardcodes `chainID: '01'`. Lifting the
+ * fence is a backend change, so a dApp on another chain is told why rather
+ * than served a mainnet transaction it did not ask for.
+ */
+const SIGNABLE_CHAIN_ID = '0x1'
+
+type DappTransaction = {
+  from?: string
+  to?: string
+  value?: string
+  data?: string
+  gas?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
+}
+
+function invalidParams(message: string): ProviderRpcError {
+  return new ProviderRpcError({ code: -32602, message })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
+
+/**
+ * A field the dApp did not send stays `undefined` so the fee policy can tell
+ * "omitted" from "zero" -- the two mean different things there.
+ *
+ * The `0x` prefix is required, as `hexutil.Big` requires it in status-go's
+ * `send_transaction.go`. A bare `'64'` is ambiguous between decimal and hex,
+ * and guessing wrong on `value` sends the wrong amount.
+ */
+function parseQuantity(value: unknown, field: string): bigint | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return BigInt(value)
+  }
+  if (typeof value !== 'string' || !/^0x[0-9a-fA-F]+$/.test(value)) {
+    throw invalidParams(`${field} is not a hex quantity`)
+  }
+  return BigInt(value)
+}
+
+/**
+ * `'0x'` is what dApps send for "no calldata", and it is truthy. Left as-is it
+ * would route a plain transfer through `sendContractCall`.
+ */
+function parseCalldata(value: unknown): Hex | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') {
+    throw invalidParams('data is not a hex string')
+  }
+  if (value === '' || value === '0x') return undefined
+  if (!/^0x([0-9a-fA-F]{2})+$/.test(value)) {
+    throw invalidParams('data is not a hex string')
+  }
+  return value as Hex
+}
+
+/**
+ * Typed against the real caller rather than a hand-written shape, so a change
+ * to a send procedure's input schema breaks the build instead of failing
+ * inside the worker after the user has already approved.
+ */
+function sendingApi(): TransactionSenders {
+  const api = (
+    globalThis as unknown as { api: Awaited<ReturnType<typeof createAPI>> }
+  ).api
+  return api.wallet.account.ethereum
+}
+
+export async function eth_sendTransaction({
+  params,
+  origin,
+  metadata,
+}: RpcContext): Promise<string> {
+  const chainId = await getChainIdForOrigin(origin)
+  if (chainId !== SIGNABLE_CHAIN_ID) {
+    throw new ProviderRpcError({
+      code: 4200,
+      message: `Transactions can only be sent on Ethereum mainnet. This dApp is connected to chain ${parseInt(chainId, 16)}.`,
+    })
+  }
+
+  const p = Array.isArray(params) ? params : []
+  if (!isRecord(p[0])) {
+    throw invalidParams('eth_sendTransaction expects a transaction object')
+  }
+  const request = p[0] as DappTransaction
+
+  if (!request.to) {
+    // status-go has the same gap: `broadcastTransaction` is the only route out
+    // and it carries no deployment path.
+    throw new ProviderRpcError({
+      code: 4200,
+      message: 'Contract deployment is not supported',
+    })
+  }
+
+  if (!ADDRESS_PATTERN.test(request.to)) {
+    throw invalidParams(`to ${request.to} is not an address`)
+  }
+
+  const signerAddress = await requireOriginAddress(origin)
+  if (request.from && !isSameAddress(signerAddress, request.from)) {
+    // status-go: `from parameter address is not dApp's shared account`.
+    throw invalidParams(
+      `from parameter address ${request.from} is not the dApp's shared account`,
+    )
+  }
+
+  const signer = await requireWalletFor(signerAddress)
+  await assertNoPendingApproval()
+
+  const tx: TransactionRequest = {
+    to: request.to as Address,
+    // Omitted on `approve`, `transfer`, and every other non-payable call.
+    // `nodes.getFeeRate` requires it, so default it as `send_transaction.go`
+    // does rather than letting zod reject server-side.
+    value: parseQuantity(request.value, 'value') ?? 0n,
+    data: parseCalldata(request.data),
+    gas: parseQuantity(request.gas, 'gas'),
+    maxFeePerGas: parseQuantity(request.maxFeePerGas, 'maxFeePerGas'),
+    maxPriorityFeePerGas: parseQuantity(
+      request.maxPriorityFeePerGas,
+      'maxPriorityFeePerGas',
+    ),
+  }
+
+  // Priced before the popup so it can show the fee, and the resolved values are
+  // fed back into the send below: estimating again there would broadcast at a
+  // price the user never saw. Run even when the dApp priced the transaction
+  // itself, because this is also where a reverting call is caught.
+  let fees
+  try {
+    fees = await requestFeeRate({
+      from: signerAddress,
+      to: tx.to,
+      value: tx.value.toString(16),
+      data: tx.data,
+    })
+  } catch (error) {
+    // A reverting call fails here. Surfacing the reason beats an empty popup
+    // followed by an opaque failure.
+    throw new ProviderRpcError({
+      code: -32603,
+      message: `Could not estimate the transaction: ${error instanceof Error ? error.message : String(error)}`,
+    })
+  }
+
+  const feeParams = resolveFeeParams(tx, fees)
+
+  const result = await requestApproval({
+    type: 'eth_sendTransaction',
+    origin,
+    title: metadata?.title ?? origin,
+    favicon: metadata?.favicon ?? `${origin}/favicon.ico`,
+    address: signerAddress,
+    accountName: signer.accountName,
+    chainId,
+    to: tx.to,
+    value: `0x${tx.value.toString(16)}`,
+    data: tx.data ?? null,
+    maxFeeEth: maxFeeEth(feeParams),
   })
+
+  if (!result) {
+    throw new ProviderRpcError({
+      code: 4001,
+      message: 'User rejected the request.',
+    })
+  }
+
+  const ethereum = sendingApi()
+  try {
+    return await buildAndSendTransaction(
+      {
+        ...tx,
+        gas: BigInt(feeParams.gasLimit),
+        maxFeePerGas: BigInt(feeParams.maxFeePerGas),
+        maxPriorityFeePerGas: BigInt(feeParams.maxPriorityFeePerGas),
+      },
+      {
+        walletId: signer.walletId,
+        address: signerAddress as Address,
+        // Every fee field is pinned above, so the policy short-circuits and
+        // this is not reached. Serving the estimate the user was shown, rather
+        // than fetching a fresh one, is the point of resolving it early.
+        fetchGasFees: async () => fees,
+      },
+      ethereum,
+    )
+  } catch (error) {
+    throw new ProviderRpcError({
+      code: -32603,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
 }

--- a/apps/wallet/src/lib/rpc/sign.ts
+++ b/apps/wallet/src/lib/rpc/sign.ts
@@ -1,10 +1,8 @@
 import { ProviderRpcError } from '@status-im/ethereum-provider'
 
-import { getPendingApproval } from '../../data/approval'
 import { getChainIdForOrigin, isSameAddress } from '../../data/dapp-permissions'
-import { findWalletForAddress, getOriginAddress } from './account'
-import { noConnectedAccount } from './errors'
-import { requestApproval } from './request-approval'
+import { requireOriginAddress, requireWalletFor } from './account'
+import { assertNoPendingApproval, requestApproval } from './request-approval'
 import {
   assertDomainChainId,
   parseTypedData,
@@ -40,44 +38,6 @@ function signingApi(): SigningApi {
 }
 
 const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
-
-/**
- * The account the origin is pinned to. Signing with the wallet's selection
- * instead would return a signature from a key the dApp was never shown.
- */
-async function requireOriginAddress(origin: string): Promise<string> {
-  const address = await getOriginAddress(origin)
-  if (!address) {
-    // The dispatch gate already refused unpermitted origins, so reaching this
-    // means the origin is permitted but its pinned account no longer resolves.
-    throw noConnectedAccount()
-  }
-  return address
-}
-
-/** The pinned account may belong to a wallet other than the selected one. */
-async function requireWalletFor(
-  address: string,
-): Promise<{ walletId: string; accountName: string }> {
-  const wallet = await findWalletForAddress(address)
-  if (!wallet) {
-    throw new ProviderRpcError({
-      code: 4100,
-      message: 'No wallet available',
-    })
-  }
-  return wallet
-}
-
-/** The approval slot holds one request; a second must not replace it. */
-async function assertNoPendingApproval(): Promise<void> {
-  if (await getPendingApproval()) {
-    throw new ProviderRpcError({
-      code: -32002,
-      message: 'Already processing a request.',
-    })
-  }
-}
 
 export async function personal_sign({
   params,

--- a/apps/wallet/src/lib/send-transaction.test.ts
+++ b/apps/wallet/src/lib/send-transaction.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  buildAndSendTransaction,
+  needsFeeEstimate,
+  resolveFeeParams,
+  type TransactionSenders,
+} from './send-transaction'
+
+import type { GasFees } from './gas-fees'
+
+/** What the wallet's own estimator returns: 2*baseFee + its own priority. */
+const ESTIMATE: GasFees = {
+  feeEth: 0,
+  feeEur: 0,
+  maxFeeEth: 0,
+  maxFeeEur: 0,
+  confirmationTime: '~12s',
+  txParams: {
+    gasLimit: '0x5208',
+    // 4 gwei ceiling over a 1 gwei tip, so 3 gwei of base-fee headroom.
+    maxFeePerGas: '0xee6b2800',
+    maxPriorityFeePerGas: '0x3b9aca00',
+  },
+}
+
+const TO = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as const
+const HASH = `0x${'cd'.repeat(32)}`
+
+describe('resolveFeeParams', () => {
+  test('a wallet-originated transaction is priced entirely by the estimator', () => {
+    expect(resolveFeeParams({ to: TO, value: 1n }, ESTIMATE)).toEqual({
+      gasLimit: '0x5208',
+      maxFeePerGas: '0xee6b2800',
+      maxPriorityFeePerGas: '0x3b9aca00',
+    })
+  })
+
+  // The LiFi swap path: the SDK strips maxFeePerGas but keeps the quoted
+  // priority, so the ceiling must clear it or the node rejects the broadcast.
+  test('a quoted priority fee keeps the estimator base-fee headroom', () => {
+    const quotedPriority = 2_000_000_000n
+
+    const fees = resolveFeeParams(
+      { to: TO, value: 1n, maxPriorityFeePerGas: quotedPriority },
+      ESTIMATE,
+    )
+
+    // 3 gwei headroom + the 2 gwei quoted tip.
+    expect(fees.maxFeePerGas).toBe('0x12a05f200')
+    expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
+    expect(BigInt(fees.maxFeePerGas)).toBeGreaterThan(quotedPriority)
+  })
+
+  test('caller-provided fields are not overwritten', () => {
+    expect(
+      resolveFeeParams(
+        {
+          to: TO,
+          value: 1n,
+          gas: 0x30000n,
+          maxFeePerGas: 0x12a05f200n,
+          maxPriorityFeePerGas: 0x3b9aca00n,
+        },
+        null,
+      ),
+    ).toEqual({
+      gasLimit: '0x30000',
+      maxFeePerGas: '0x12a05f200',
+      maxPriorityFeePerGas: '0x3b9aca00',
+    })
+  })
+
+  test('a tip above the ceiling is clamped to it', () => {
+    const fees = resolveFeeParams(
+      { to: TO, value: 1n, maxFeePerGas: 1_000_000_000n },
+      ESTIMATE,
+    )
+
+    expect(fees.maxPriorityFeePerGas).toBe(fees.maxFeePerGas)
+  })
+
+  test('a zero priority fee is honoured rather than treated as absent', () => {
+    expect(
+      resolveFeeParams(
+        { to: TO, value: 1n, maxPriorityFeePerGas: 0n },
+        ESTIMATE,
+      ).maxPriorityFeePerGas,
+    ).toBe('0x0')
+  })
+})
+
+describe('needsFeeEstimate', () => {
+  test('is true unless every fee field is present', () => {
+    expect(needsFeeEstimate({ to: TO, value: 1n })).toBe(true)
+    expect(
+      needsFeeEstimate({ to: TO, value: 1n, gas: 1n, maxFeePerGas: 1n }),
+    ).toBe(true)
+    expect(
+      needsFeeEstimate({
+        to: TO,
+        value: 1n,
+        gas: 1n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 0n,
+      }),
+    ).toBe(false)
+  })
+})
+
+function createSenders(): TransactionSenders & {
+  calls: Array<{ via: string; input: Record<string, unknown> }>
+} {
+  const calls: Array<{ via: string; input: Record<string, unknown> }> = []
+  const record = (via: string) => async (input: Record<string, unknown>) => {
+    calls.push({ via, input })
+    return { id: { txid: HASH } }
+  }
+  return {
+    calls,
+    send: record('send'),
+    sendErc20: record('sendErc20'),
+    sendContractCall: record('sendContractCall'),
+  } as TransactionSenders & { calls: typeof calls }
+}
+
+describe('buildAndSendTransaction', () => {
+  const ctx = {
+    walletId: 'wallet-1',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as const,
+    fetchGasFees: vi.fn(async () => ESTIMATE),
+  }
+
+  test('an ERC20 transfer takes the token route', async () => {
+    const senders = createSenders()
+
+    await expect(
+      buildAndSendTransaction(
+        { to: TO, value: 0n, data: `0xa9059cbb${'00'.repeat(64)}` },
+        ctx,
+        senders,
+      ),
+    ).resolves.toBe(HASH)
+    expect(senders.calls[0].via).toBe('sendErc20')
+  })
+
+  test('a failed broadcast surfaces the node error', async () => {
+    const senders = createSenders()
+    senders.send = async () => ({
+      id: {
+        txid: {
+          error:
+            'insufficient funds for gas * price + value: have 1 want 1000000000000000000',
+        },
+      },
+    })
+
+    await expect(
+      buildAndSendTransaction({ to: TO, value: 1n }, ctx, senders),
+    ).rejects.toThrow(/Insufficient funds for gas/)
+  })
+
+  test('a response carrying no usable hash is a failure', async () => {
+    const senders = createSenders()
+    senders.send = async () => ({ id: { txid: null } })
+
+    await expect(
+      buildAndSendTransaction({ to: TO, value: 1n }, ctx, senders),
+    ).rejects.toThrow('Transaction failed')
+  })
+})

--- a/apps/wallet/src/lib/send-transaction.ts
+++ b/apps/wallet/src/lib/send-transaction.ts
@@ -1,0 +1,233 @@
+import {
+  getTransactionHash,
+  isEthereumTransactionHash,
+} from '@status-im/wallet/utils'
+import { formatEther } from 'viem/utils'
+
+import type { GasFeeRequestParams, GasFees } from './gas-fees'
+import type { Address, Hex } from 'viem'
+
+const ERC20_TRANSFER_SIGNATURE = '0xa9059cbb'
+
+export type TransactionRequest = {
+  to: Address
+  value: bigint
+  data?: Hex
+  gas?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+}
+
+export type FeeParams = {
+  gasLimit: string
+  maxFeePerGas: string
+  maxPriorityFeePerGas: string
+}
+
+/** The `{ id: { txid } }` envelope every `wallet.account.ethereum.send*` returns. */
+type SendResult = {
+  id: { txid?: { error?: unknown } | string | null }
+}
+
+type SendInput = {
+  walletId: string
+  fromAddress: string
+  toAddress: string
+  gasLimit: string
+  maxFeePerGas: string
+  maxInclusionFeePerGas: string
+}
+
+/**
+ * The three transports, injected rather than imported: the extension page holds
+ * a tRPC proxy client and the service worker holds a caller, and both must
+ * reach the identical policy above.
+ */
+export type TransactionSenders = {
+  send: (input: SendInput & { amount: string }) => Promise<SendResult>
+  sendErc20: (input: SendInput & { data: string }) => Promise<SendResult>
+  sendContractCall: (
+    input: SendInput & { data: string; value?: string },
+  ) => Promise<SendResult>
+}
+
+export type TransactionContext = {
+  walletId: string
+  address: Address
+  fetchGasFees: (params: GasFeeRequestParams) => Promise<GasFees>
+}
+
+const toHex = (value: bigint) => `0x${value.toString(16)}`
+
+/** Whether any fee field is missing and an estimate has to be fetched. */
+export function needsFeeEstimate(tx: TransactionRequest): boolean {
+  return !tx.maxFeePerGas || tx.maxPriorityFeePerGas === undefined || !tx.gas
+}
+
+/**
+ * Fee policy: transactions created by the wallet itself carry no fee fields and
+ * are priced entirely by the internal estimator. External callers (e.g. the
+ * LiFi widget for swaps) are trusted for every field they provide -- only
+ * genuinely missing pieces are filled in.
+ *
+ * Pure, so a caller that has to show the fee before sending (the dApp approval
+ * popup) can resolve it once and hand the result back as a fully specified
+ * transaction, instead of estimating twice and displaying a price other than
+ * the one it broadcasts.
+ */
+export function resolveFeeParams(
+  tx: TransactionRequest,
+  fees: GasFees | null,
+): FeeParams {
+  let maxFeePerGas = tx.maxFeePerGas ? toHex(tx.maxFeePerGas) : undefined
+  let maxPriorityFeePerGas =
+    tx.maxPriorityFeePerGas !== undefined
+      ? toHex(tx.maxPriorityFeePerGas)
+      : undefined
+  let gasLimit = tx.gas ? toHex(tx.gas) : undefined
+
+  if (fees) {
+    if (!maxFeePerGas && tx.maxPriorityFeePerGas !== undefined) {
+      // LiFi quotes carry a quote-time maxPriorityFeePerGas but the SDK
+      // strips maxFeePerGas, leaving the ceiling to the wallet. Building
+      // it from our own estimate alone can undercut the quoted priority
+      // (invalid EIP-1559 tx, rejected at broadcast), so honor the quoted
+      // priority and add the estimator's base-fee headroom on top
+      // (its maxFeePerGas = 2*baseFee + own priority).
+      const baseFeeHeadroom =
+        BigInt(fees.txParams.maxFeePerGas) -
+        BigInt(fees.txParams.maxPriorityFeePerGas)
+      maxFeePerGas = toHex(baseFeeHeadroom + tx.maxPriorityFeePerGas)
+    }
+
+    maxFeePerGas ??= fees.txParams.maxFeePerGas
+    maxPriorityFeePerGas ??= fees.txParams.maxPriorityFeePerGas
+    gasLimit ??= fees.txParams.gasLimit
+  }
+
+  if (!maxFeePerGas || !maxPriorityFeePerGas || !gasLimit) {
+    throw new Error('Gas fees not available')
+  }
+
+  // EIP-1559 invariant: a tip above the fee ceiling is rejected by nodes.
+  // Only reachable when the caller pinned maxFeePerGas but left the
+  // priority fee to the (potentially higher) internal estimate.
+  if (BigInt(maxPriorityFeePerGas) > BigInt(maxFeePerGas)) {
+    maxPriorityFeePerGas = maxFeePerGas
+  }
+
+  return { gasLimit, maxFeePerGas, maxPriorityFeePerGas }
+}
+
+/** The ceiling the account must be able to cover, for display before signing. */
+export function maxFeeEth(fees: FeeParams): string {
+  return formatEther(BigInt(fees.maxFeePerGas) * BigInt(fees.gasLimit))
+}
+
+export function parseInsufficientFundsError(error: unknown): Error | null {
+  const errorObj =
+    typeof error === 'object' && error !== null && 'message' in error
+      ? error
+      : null
+  const errorMessage =
+    errorObj && typeof errorObj.message === 'string'
+      ? errorObj.message
+      : typeof error === 'string'
+        ? error
+        : null
+  if (!errorMessage) return null
+  const match = errorMessage.match(
+    /insufficient funds for gas \* price \+ value: have (\d+) want (\d+)/,
+  )
+  if (!match) return null
+  const haveWei = BigInt(match[1])
+  const wantWei = BigInt(match[2])
+  const haveEth = formatEther(haveWei)
+  const wantEth = formatEther(wantWei)
+  const shortfallEth = formatEther(wantWei - haveWei)
+  return new Error(
+    `Insufficient funds for gas. Have ${haveEth} ETH, need up to ${wantEth} ETH (max fee). Short ${shortfallEth} ETH.`,
+  )
+}
+
+function handleTransactionError(error: unknown, context: string): never {
+  console.error(`${context} error:`, error)
+  const parsedError = parseInsufficientFundsError(error)
+  if (parsedError) throw parsedError
+  throw new Error(
+    typeof error === 'object' && error !== null && 'message' in error
+      ? String(error.message)
+      : String(error),
+  )
+}
+
+function requireHash(result: SendResult, context: string): Hex {
+  const txid = result.id.txid
+  if (txid && typeof txid === 'object' && txid.error) {
+    handleTransactionError(txid.error, context)
+  }
+
+  const txHash = getTransactionHash(txid)
+  if (!isEthereumTransactionHash(txHash)) {
+    throw new Error('Transaction failed')
+  }
+  return txHash as Hex
+}
+
+/**
+ * Prices, signs and broadcasts a transaction. Unlocking is the caller's job:
+ * the extension page prompts through the password modal, the dApp path through
+ * the approval popup.
+ */
+export async function buildAndSendTransaction(
+  tx: TransactionRequest,
+  ctx: TransactionContext,
+  senders: TransactionSenders,
+): Promise<Hex> {
+  const fees = needsFeeEstimate(tx)
+    ? await ctx.fetchGasFees({
+        from: ctx.address,
+        to: tx.to,
+        value: tx.value.toString(16),
+        data: tx.data,
+      })
+    : null
+
+  const { gasLimit, maxFeePerGas, maxPriorityFeePerGas } = resolveFeeParams(
+    tx,
+    fees,
+  )
+
+  const common = {
+    walletId: ctx.walletId,
+    fromAddress: ctx.address,
+    toAddress: tx.to,
+    gasLimit,
+    maxFeePerGas,
+    maxInclusionFeePerGas: maxPriorityFeePerGas,
+  }
+
+  if (tx.data) {
+    const isErc20Transfer = tx.data
+      .toLowerCase()
+      .startsWith(ERC20_TRANSFER_SIGNATURE)
+
+    if (isErc20Transfer) {
+      const result = await senders.sendErc20({ ...common, data: tx.data })
+      return requireHash(result, 'ERC20 transfer')
+    }
+
+    const result = await senders.sendContractCall({
+      ...common,
+      data: tx.data,
+      value: tx.value.toString(16),
+    })
+    return requireHash(result, 'Contract call')
+  }
+
+  const result = await senders.send({
+    ...common,
+    amount: tx.value.toString(16),
+  })
+  return requireHash(result, 'Send transaction')
+}

--- a/apps/wallet/src/lib/send-transaction.ts
+++ b/apps/wallet/src/lib/send-transaction.ts
@@ -8,6 +8,8 @@ import type { GasFeeRequestParams, GasFees } from './gas-fees'
 import type { Address, Hex } from 'viem'
 
 const ERC20_TRANSFER_SIGNATURE = '0xa9059cbb'
+/** `0x` + selector + 32-byte recipient word + 32-byte amount word. */
+const ERC20_TRANSFER_CALLDATA_LENGTH = 2 + 8 + 64 + 64
 
 export type TransactionRequest = {
   to: Address
@@ -175,6 +177,24 @@ function requireHash(result: SendResult, context: string): Hex {
 }
 
 /**
+ * `sendErc20` does not sign the calldata it is handed: it reads the recipient
+ * and amount back out of it and re-encodes an `erc20Transfer`, a shape that
+ * carries no ETH value. Anything the re-encoding would not reproduce -- bytes
+ * past the amount word, a non-zero value, a recipient word with dirty padding
+ * -- would be dropped after the user had already approved it, so only a
+ * transfer that survives the round trip byte-for-byte takes that route. The
+ * rest go through `sendContractCall`, which signs the calldata verbatim.
+ */
+function isCanonicalErc20Transfer(data: Hex, value: bigint): boolean {
+  return (
+    value === 0n &&
+    data.length === ERC20_TRANSFER_CALLDATA_LENGTH &&
+    data.toLowerCase().startsWith(ERC20_TRANSFER_SIGNATURE) &&
+    data.slice(10, 34) === '0'.repeat(24)
+  )
+}
+
+/**
  * Prices, signs and broadcasts a transaction. Unlocking is the caller's job:
  * the extension page prompts through the password modal, the dApp path through
  * the approval popup.
@@ -208,11 +228,7 @@ export async function buildAndSendTransaction(
   }
 
   if (tx.data) {
-    const isErc20Transfer = tx.data
-      .toLowerCase()
-      .startsWith(ERC20_TRANSFER_SIGNATURE)
-
-    if (isErc20Transfer) {
+    if (isCanonicalErc20Transfer(tx.data, tx.value)) {
       const result = await senders.sendErc20({ ...common, data: tx.data })
       return requireHash(result, 'ERC20 transfer')
     }

--- a/apps/wallet/src/providers/signer-context.tsx
+++ b/apps/wallet/src/providers/signer-context.tsx
@@ -6,14 +6,13 @@ import {
   useMemo,
 } from 'react'
 
-import {
-  getTransactionHash,
-  isEthereumTransactionHash,
-} from '@status-im/wallet/utils'
 import { type Address, type Hex } from 'viem'
-import { formatEther } from 'viem/utils'
 
 import { useGasFees } from '../hooks/use-gas-fees'
+import {
+  buildAndSendTransaction,
+  type TransactionRequest,
+} from '../lib/send-transaction'
 import { apiClient } from './api-client'
 import { usePassword } from './password-context'
 import { useWallet } from './wallet-context'
@@ -23,14 +22,7 @@ type SignerContextValue = {
   isUnlocked: boolean
   unlock: () => Promise<boolean>
   lock: () => void
-  signAndSendTransaction: (tx: {
-    to: Address
-    value: bigint
-    data?: Hex
-    gas?: bigint
-    maxFeePerGas?: bigint
-    maxPriorityFeePerGas?: bigint
-  }) => Promise<Hex>
+  signAndSendTransaction: (tx: TransactionRequest) => Promise<Hex>
   signMessage: (message: Hex) => Promise<Hex>
   signTypedData: (typedData: string) => Promise<Hex>
   requestUnlock: () => Promise<boolean>
@@ -106,191 +98,27 @@ export function SignerProvider({ children }: { children: React.ReactNode }) {
     if (!isUnlocked) throw new Error('Wallet not unlocked')
   }, [hasActiveSession, requestPassword])
 
-  const parseInsufficientFundsError = useCallback(
-    (error: unknown): Error | null => {
-      const errorObj =
-        typeof error === 'object' && error !== null && 'message' in error
-          ? error
-          : null
-      const errorMessage =
-        errorObj && typeof errorObj.message === 'string'
-          ? errorObj.message
-          : typeof error === 'string'
-            ? error
-            : null
-      if (!errorMessage) return null
-      const match = errorMessage.match(
-        /insufficient funds for gas \* price \+ value: have (\d+) want (\d+)/,
-      )
-      if (!match) return null
-      const haveWei = BigInt(match[1])
-      const wantWei = BigInt(match[2])
-      const haveEth = formatEther(haveWei)
-      const wantEth = formatEther(wantWei)
-      const shortfallEth = formatEther(wantWei - haveWei)
-      return new Error(
-        `Insufficient funds for gas. Have ${haveEth} ETH, need up to ${wantEth} ETH (max fee). Short ${shortfallEth} ETH.`,
-      )
-    },
-    [],
-  )
-
-  const handleTransactionError = useCallback(
-    (error: unknown, context: string): never => {
-      console.error(`${context} error:`, error)
-      const parsedError = parseInsufficientFundsError(error)
-      if (parsedError) throw parsedError
-      throw new Error(
-        typeof error === 'object' && error !== null && 'message' in error
-          ? String(error.message)
-          : String(error),
-      )
-    },
-    [parseInsufficientFundsError],
-  )
-
   const signAndSendTransaction = useCallback(
-    async (tx: {
-      to: Address
-      value: bigint
-      data?: Hex
-      gas?: bigint
-      maxFeePerGas?: bigint
-      maxPriorityFeePerGas?: bigint
-    }): Promise<Hex> => {
+    async (tx: TransactionRequest): Promise<Hex> => {
       if (!currentWallet?.id || !address) {
         throw new Error('No wallet connected')
       }
 
       await ensureUnlocked()
 
-      const toHex = (value: bigint) => `0x${value.toString(16)}`
-
-      // Fee policy: transactions created by the wallet itself carry no fee
-      // fields and are priced entirely by the internal estimator. External
-      // callers (e.g. the LiFi widget for swaps) are trusted for every field
-      // they provide — only genuinely missing pieces are filled in.
-      let maxFeePerGas = tx.maxFeePerGas ? toHex(tx.maxFeePerGas) : undefined
-      let maxPriorityFeePerGas =
-        tx.maxPriorityFeePerGas !== undefined
-          ? toHex(tx.maxPriorityFeePerGas)
-          : undefined
-      let gasLimit = tx.gas ? toHex(tx.gas) : undefined
-
-      if (!maxFeePerGas || !maxPriorityFeePerGas || !gasLimit) {
-        const fees = await fetchGasFees({
-          from: address,
-          to: tx.to,
-          value: tx.value.toString(16),
-          data: tx.data,
-        })
-
-        if (!maxFeePerGas && tx.maxPriorityFeePerGas !== undefined) {
-          // LiFi quotes carry a quote-time maxPriorityFeePerGas but the SDK
-          // strips maxFeePerGas, leaving the ceiling to the wallet. Building
-          // it from our own estimate alone can undercut the quoted priority
-          // (invalid EIP-1559 tx, rejected at broadcast), so honor the quoted
-          // priority and add the estimator's base-fee headroom on top
-          // (its maxFeePerGas = 2*baseFee + own priority).
-          const baseFeeHeadroom =
-            BigInt(fees.txParams.maxFeePerGas) -
-            BigInt(fees.txParams.maxPriorityFeePerGas)
-          maxFeePerGas = toHex(baseFeeHeadroom + tx.maxPriorityFeePerGas)
-        }
-
-        maxFeePerGas ??= fees.txParams.maxFeePerGas
-        maxPriorityFeePerGas ??= fees.txParams.maxPriorityFeePerGas
-        gasLimit ??= fees.txParams.gasLimit
-      }
-
-      // EIP-1559 invariant: a tip above the fee ceiling is rejected by nodes.
-      // Only reachable when the caller pinned maxFeePerGas but left the
-      // priority fee to the (potentially higher) internal estimate.
-      if (BigInt(maxPriorityFeePerGas) > BigInt(maxFeePerGas)) {
-        maxPriorityFeePerGas = maxFeePerGas
-      }
-
-      if (tx.data) {
-        const ERC20_TRANSFER_SIGNATURE = '0xa9059cbb'
-        const isErc20Transfer = tx.data
-          .toLowerCase()
-          .startsWith(ERC20_TRANSFER_SIGNATURE)
-
-        if (isErc20Transfer) {
-          const result =
-            await apiClient.wallet.account.ethereum.sendErc20.mutate({
-              walletId: currentWallet.id,
-              fromAddress: address,
-              toAddress: tx.to,
-              gasLimit,
-              maxFeePerGas,
-              maxInclusionFeePerGas: maxPriorityFeePerGas,
-              data: tx.data,
-            })
-
-          if (result.id.txid?.error) {
-            handleTransactionError(result.id.txid.error, 'ERC20 transfer')
-          }
-
-          const txHash = getTransactionHash(result.id.txid)
-          if (!isEthereumTransactionHash(txHash)) {
-            throw new Error('Transaction failed')
-          }
-          return txHash as Hex
-        }
-
-        const valueHex = tx.value.toString(16)
-        const result =
-          await apiClient.wallet.account.ethereum.sendContractCall.mutate({
-            walletId: currentWallet.id,
-            fromAddress: address,
-            toAddress: tx.to,
-            gasLimit,
-            maxFeePerGas,
-            maxInclusionFeePerGas: maxPriorityFeePerGas,
-            data: tx.data,
-            value: valueHex,
-          })
-
-        if (result.id.txid?.error) {
-          handleTransactionError(result.id.txid.error, 'Contract call')
-        }
-
-        const txHash = getTransactionHash(result.id.txid)
-        if (!isEthereumTransactionHash(txHash)) {
-          throw new Error('Transaction failed')
-        }
-        return txHash as Hex
-      }
-
-      const amountHex = tx.value.toString(16)
-      const result = await apiClient.wallet.account.ethereum.send.mutate({
-        walletId: currentWallet.id,
-        fromAddress: address,
-        toAddress: tx.to,
-        amount: amountHex,
-        gasLimit,
-        maxFeePerGas,
-        maxInclusionFeePerGas: maxPriorityFeePerGas,
-      })
-
-      if (result.id.txid?.error) {
-        handleTransactionError(result.id.txid.error, 'Send transaction')
-      }
-
-      const txHash = getTransactionHash(result.id.txid)
-      if (!isEthereumTransactionHash(txHash)) {
-        throw new Error('Transaction failed')
-      }
-      return txHash as Hex
+      return await buildAndSendTransaction(
+        tx,
+        { walletId: currentWallet.id, address, fetchGasFees },
+        {
+          send: input => apiClient.wallet.account.ethereum.send.mutate(input),
+          sendErc20: input =>
+            apiClient.wallet.account.ethereum.sendErc20.mutate(input),
+          sendContractCall: input =>
+            apiClient.wallet.account.ethereum.sendContractCall.mutate(input),
+        },
+      )
     },
-    [
-      currentWallet?.id,
-      address,
-      ensureUnlocked,
-      handleTransactionError,
-      fetchGasFees,
-    ],
+    [currentWallet?.id, address, ensureUnlocked, fetchGasFees],
   )
 
   const signMessage = useCallback(


### PR DESCRIPTION
Fourth PR of the status-go connector parity series (#1136), on top of #1301.

Replaces the `4200` stub with a real `eth_sendTransaction`. The send policy is extracted, not reimplemented: the fee backfill, LiFi quoted-priority rule, EIP-1559 clamp and ERC20/contract/native branch move out of `signer-context.tsx` into `lib/send-transaction.ts`, with the three transports injected so the extension page (tRPC proxy client) and the service worker (tRPC caller) share one policy.

`requestFeeRate` moves into a new `lib/gas-fees.ts` rather than being exported from `use-gas-fees.ts`; that hook pulls React, react-query and `new ethers.Interface(...)` at module load, all of which would land in the background bundle.

---

#### How to test

- Build, load `apps/wallet/.output/chrome-mv3` unpacked, reload the extension, connect a dApp (e.g. `app.uniswap.org`), and from its console:
```js
await ethereum.request({ method: 'eth_requestAccounts' })
await ethereum.request({
  method: 'eth_sendTransaction',
  params: [{ to: '0x0000000000000000000000000000000000000001', value: '0x1' }],
})
```
Check: popup shows To / Amount / Max fee / network / account; approve -> tx hash is printed to the console, check on `etherscan.io` that it passes (it will spend ETH but a very small amount less that $0.002 for fees + value). The tx can take a few minutes to resolve, you can also check in the wallet's extension "history" tab after a few minutes, it should be displayed here.

- Now run in the console:
```js
await ethereum.request({ method: 'eth_requestAccounts' })
await ethereum.request({ method: 'eth_sendTransaction', params: [{
  to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
  data: '0x095ea7b3'
    + '000000000000000000000000000000000000000000000000000000000000dead'
    + '0000000000000000000000000000000000000000000000000000000000000001',
}] })
```
Check: you get the same popup as before but with an extra "data" field (you can decline).

- Run:
```js
await ethereum.request({ method: 'eth_requestAccounts' })
await ethereum.request({
  method: 'eth_sendTransaction',
  params: [{ to: '0x0000000000000000000000000000000000000001' }],
})
```
Check: same popup, no data field but value is 0 ETH (you can decline).

- Run:
```js
await ethereum.request({ method: 'eth_requestAccounts' })
await ethereum.request({
  method: 'eth_sendTransaction',
  params: [{ from: '0x59CadF9199248b50d40a6891c9E329eA13a88d31', to: '0x0000000000000000000000000000000000000001', value: '0x1' }],
})
```
Check: you get the "from parameter address 0x59CadF9199248b50d40a6891c9E329eA13a88d31 is not the dApp's shared account" error message.

- Run:
```js
await ethereum.request({ method: 'eth_requestAccounts' })
await ethereum.request({
  method: 'eth_sendTransaction',
  params: [{ value: '0x1' }],
})
```
Check: you get the "Contract deployment is not supported" error message.

- If possible, run a real swap with a small amount (like 0.0001 ETH) on a dapp, it should pass.