### PR TITLE
feat(wallet): route dApp reads to the chain the dApp is on

### DIFF
--- a/.changeset/lucky-jars-travel.md
+++ b/.changeset/lucky-jars-travel.md
@@ -1,0 +1,10 @@
+---
+'wallet': patch
+---
+
+feat(wallet): route dApp reads to the chain the dApp is on
+
+Reads for a connected dApp now go to the chain it switched to instead of always
+to Ethereum mainnet. Status Network Sepolia has no upstream proxy route yet, so
+reads there fail with "chain is not available" where they previously returned
+mainnet data.

--- a/apps/wallet/src/entrypoints/approval/approval-page.tsx
+++ b/apps/wallet/src/entrypoints/approval/approval-page.tsx
@@ -5,26 +5,16 @@ import { CloseIcon } from '@status-im/icons/20'
 import { PasswordModal } from '@status-im/wallet/components'
 import { formatEther } from 'viem/utils'
 
-import ethereumIcon from '../../assets/networks/ethereum.png'
-import statusNetworkIcon from '../../assets/networks/status-network.png'
 import {
   getPendingApproval,
   type PendingApproval,
   setApprovalResult,
 } from '../../data/approval'
 import { connectAccount } from '../../data/dapp-permissions'
+import { getChainByHex, toChainId } from '../../lib/chains'
 import { signedDomainFields } from '../../lib/rpc/typed-data'
 import { apiClient } from '../../providers/api-client'
 import { clip, flattenTypedData } from './typed-data-rows'
-
-const CHAIN_NAMES: Record<string, string> = {
-  '0x1': 'Mainnet',
-  '0x6300b5ea': 'Status Network Sepolia',
-}
-
-function getChainName(chainId: string): string {
-  return CHAIN_NAMES[chainId] ?? `Chain ${parseInt(chainId, 16)}`
-}
 
 function truncateAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-3)}`
@@ -281,13 +271,9 @@ function AccountInfo({ address, name }: { address: string; name: string }) {
   )
 }
 
-const CHAIN_ICONS: Record<string, string> = {
-  '0x1': ethereumIcon,
-  '0x6300b5ea': statusNetworkIcon,
-}
-
 function NetworkInfo({ chainId }: { chainId: string }) {
-  const icon = CHAIN_ICONS[chainId]
+  const chain = getChainByHex(chainId)
+  const icon = chain?.icon
 
   return (
     <>
@@ -302,7 +288,7 @@ function NetworkInfo({ chainId }: { chainId: string }) {
             </span>
           )}
           <p className="text-15 font-semibold text-neutral-100">
-            {getChainName(chainId)}
+            {chain?.name ?? `Chain ${toChainId(chainId)}`}
           </p>
         </div>
       </div>

--- a/apps/wallet/src/lib/chains.ts
+++ b/apps/wallet/src/lib/chains.ts
@@ -1,0 +1,88 @@
+import { numberToHex } from 'viem'
+import { mainnet, statusNetworkSepolia } from 'viem/chains'
+
+import ethereumIcon from '../assets/networks/ethereum.png'
+import statusNetworkIcon from '../assets/networks/status-network.png'
+
+import type { Chain } from 'viem'
+
+export type ChainEntry = {
+  chainId: number
+  /** Canonical EIP-695 form, which is what dApps and `chrome.storage` see. */
+  hex: string
+  name: string
+  icon: string
+  viemChain: Chain
+  /**
+   * What `rpc.proxy` is asked for, or null when the wallet's proxy has no
+   * upstream route for the chain. `CHAIN_ID_TO_PROXY_PATH` in
+   * `packages/wallet/src/data/api/routers/rpc.ts` is the other half of this --
+   * a chain is only readable once both are filled in.
+   */
+  proxyChainId: number | null
+  /**
+   * Sends are fenced at the backend, not here: `nodes.getFeeRate`,
+   * `broadcastTransaction` and `getNonce` all pin `z.enum(['ethereum'])`.
+   */
+  canSign: boolean
+}
+
+type ChainDefinition = Omit<ChainEntry, 'chainId' | 'hex' | 'viemChain'>
+
+function defineEntry(chain: Chain, definition: ChainDefinition): ChainEntry {
+  return {
+    chainId: chain.id,
+    hex: numberToHex(chain.id),
+    viemChain: chain,
+    ...definition,
+  }
+}
+
+/**
+ * Every chain the wallet advertises to dApps, and everything the extension
+ * needs to know about each. Replaces the three disagreeing lists this used to
+ * be spread across: the switchable set in `rpc/chain.ts`, the mainnet pin in
+ * `public-client.ts`, and the name/icon maps in the approval popup.
+ */
+export const CHAINS: ChainEntry[] = [
+  defineEntry(mainnet, {
+    name: 'Mainnet',
+    icon: ethereumIcon,
+    proxyChainId: mainnet.id,
+    canSign: true,
+  }),
+  defineEntry(statusNetworkSepolia, {
+    name: 'Status Network Sepolia',
+    icon: statusNetworkIcon,
+    // No upstream proxy path is known for 1660990954 -- the backend's `374:
+    // 'status/hoodi'` is a different network. The chain stays advertised and
+    // switchable; reads on it fail loudly until this and the matching entry in
+    // `routers/rpc.ts` land together.
+    proxyChainId: null,
+    canSign: false,
+  }),
+]
+
+const BY_CHAIN_ID = new Map(CHAINS.map(chain => [chain.chainId, chain]))
+
+export function getChain(chainId: number): ChainEntry | undefined {
+  return BY_CHAIN_ID.get(chainId)
+}
+
+/**
+ * The one place the hex chain ids dApps speak become numbers. Malformed input
+ * is NaN rather than a prefix -- `parseInt` would read `'0x1zzz'` and a bare
+ * `'1'` as mainnet, and these params come from the page.
+ */
+export function toChainId(hex: string): number {
+  return /^0x[0-9a-fA-F]+$/.test(hex) ? Number.parseInt(hex, 16) : NaN
+}
+
+/**
+ * Looked up by value rather than by string, so `'0x6300B5EA'` and
+ * `'0x06300b5ea'` resolve like the canonical spelling instead of reading as
+ * unknown chains.
+ */
+export function getChainByHex(hex: string): ChainEntry | undefined {
+  return getChain(toChainId(hex))
+}

--- a/apps/wallet/src/lib/public-client.test.ts
+++ b/apps/wallet/src/lib/public-client.test.ts
@@ -14,8 +14,6 @@ describe('getPublicClient', () => {
     expect(getPublicClient(1)).toBe(getPublicClient(1))
   })
 
-  // Advertised and switchable, but the wallet's proxy has no upstream route
-  // for it. Answering from mainnet instead is the bug this replaces.
   test('refuses a chain with no upstream route', () => {
     expect(() => getPublicClient(1660990954)).toThrowError(
       expect.objectContaining({

--- a/apps/wallet/src/lib/public-client.test.ts
+++ b/apps/wallet/src/lib/public-client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+
+import { getPublicClient } from './public-client'
+
+describe('getPublicClient', () => {
+  test('routes a chain through its own proxy path', () => {
+    const client = getPublicClient(1)
+
+    expect(client.chain?.id).toBe(1)
+    expect(client.transport.url).toContain('chainId=1')
+  })
+
+  test('reuses the client for a chain', () => {
+    expect(getPublicClient(1)).toBe(getPublicClient(1))
+  })
+
+  // Advertised and switchable, but the wallet's proxy has no upstream route
+  // for it. Answering from mainnet instead is the bug this replaces.
+  test('refuses a chain with no upstream route', () => {
+    expect(() => getPublicClient(1660990954)).toThrowError(
+      expect.objectContaining({
+        code: 4901,
+        message: 'Chain 1660990954 is not available',
+      }),
+    )
+  })
+
+  test('refuses a chain the wallet does not know', () => {
+    expect(() => getPublicClient(137)).toThrow(/not available/)
+  })
+})

--- a/apps/wallet/src/lib/public-client.ts
+++ b/apps/wallet/src/lib/public-client.ts
@@ -1,9 +1,44 @@
+import { ProviderRpcError } from '@status-im/ethereum-provider'
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 
+import { getChain } from './chains'
 import { getRpcProxyUrl } from './rpc-proxy'
 
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(getRpcProxyUrl(mainnet.id)),
-})
+import type { PublicClient } from 'viem'
+
+const clients = new Map<number, PublicClient>()
+
+/**
+ * The read client for one chain, over the wallet's authenticated proxy.
+ *
+ * A dApp that switched chains has to be read on the chain it switched to;
+ * serving it mainnet was the silent wrongness this replaces. Chains the proxy
+ * has no route for are refused here rather than answered from the wrong node.
+ */
+export function getPublicClient(chainId: number): PublicClient {
+  const cached = clients.get(chainId)
+  if (cached) {
+    return cached
+  }
+
+  const chain = getChain(chainId)
+  if (!chain?.proxyChainId) {
+    // 4901, not 4902: the chain is recognised and switchable, there is just no
+    // route to it. 4902 invites the dApp to add the chain and retry, which
+    // succeeds and then fails again the same way.
+    throw new ProviderRpcError({
+      code: 4901,
+      message: `Chain ${chainId} is not available`,
+    })
+  }
+
+  const client = createPublicClient({
+    chain: chain.viemChain,
+    transport: http(getRpcProxyUrl(chain.proxyChainId)),
+  })
+  clients.set(chainId, client)
+  return client
+}
+
+export const publicClient = getPublicClient(mainnet.id)

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -10,16 +10,32 @@ import {
   setChainIdForOrigin,
 } from '../data/dapp-permissions'
 import { requestFeeRate } from './gas-fees'
-import { publicClient } from './public-client'
+import { getPublicClient } from './public-client'
 import { handleRpcRequest, LOCAL_HANDLERS } from './rpc-handler'
 import { REMOTE_ALLOWED, UNGATED_LOCAL } from './rpc-methods'
 
 // The forwarding branch is the point of the gate, so it needs a stand-in for
-// the node. The real client is a module-level const over the authenticated
-// proxy URL.
-vi.mock('./public-client', () => ({
-  publicClient: { request: vi.fn(async () => '0x1234') },
-}))
+// the node. Only the transport is stubbed: which chains have a route is still
+// the registry's answer, so the test cannot drift from it. One shared `request`
+// spy keeps "which chain was asked" assertable apart from "what was asked".
+vi.mock('./public-client', async () => {
+  const { ProviderRpcError } = await import('@status-im/ethereum-provider')
+  const { getChain } = await import('./chains')
+  const request = vi.fn(async () => '0x1234')
+
+  return {
+    getPublicClient: vi.fn((chainId: number) => {
+      if (!getChain(chainId)?.proxyChainId) {
+        throw new ProviderRpcError({
+          code: 4901,
+          message: `Chain ${chainId} is not available`,
+        })
+      }
+      return { request }
+    }),
+    publicClient: { request },
+  }
+})
 
 // `eth_sendTransaction` prices itself against the wallet's own estimator,
 // which is an authenticated HTTP call.
@@ -27,7 +43,8 @@ vi.mock('./gas-fees', () => ({
   requestFeeRate: vi.fn(),
 }))
 
-const nodeRequest = vi.mocked(publicClient.request)
+const clientFor = vi.mocked(getPublicClient)
+const nodeRequest = vi.mocked(clientFor(1).request)
 const feeRequest = vi.mocked(requestFeeRate)
 
 /** 21000 gas at 1 gwei: a max fee of 0.000021 ETH. */
@@ -161,6 +178,7 @@ beforeEach(async () => {
   signedTypedData = null
   sentTransactions = []
   nodeRequest.mockClear()
+  clientFor.mockClear()
   feeRequest.mockReset()
   feeRequest.mockResolvedValue(GAS_FEES)
   vi.stubGlobal('chrome', createChromeMock())

--- a/apps/wallet/src/lib/rpc-handler.test.ts
+++ b/apps/wallet/src/lib/rpc-handler.test.ts
@@ -244,7 +244,8 @@ afterEach(async () => {
   vi.unstubAllGlobals()
 })
 
-const connect = () => handleRpcRequest('eth_requestAccounts', [], ORIGIN)
+const connect = (origin = ORIGIN) =>
+  handleRpcRequest('eth_requestAccounts', [], origin)
 const accounts = () => handleRpcRequest('eth_accounts', [], ORIGIN)
 
 test('approving a connection returns the account', async () => {
@@ -475,6 +476,66 @@ describe('the status-go permission table', () => {
         handleRpcRequest('eth_getProof', [], ORIGIN),
       ).rejects.toMatchObject({ code: -32601 })
       expect(nodeRequest).not.toHaveBeenCalled()
+    })
+
+    test('a forwarded read is routed to the chain the origin is on', async () => {
+      await connect()
+
+      await handleRpcRequest('eth_blockNumber', [], ORIGIN)
+
+      expect(clientFor).toHaveBeenCalledWith(1)
+    })
+
+    // The chain is advertised and switchable, but the wallet's proxy has no
+    // upstream route for it. Before per-chain routing this read was answered
+    // by mainnet, which is a wrong answer rather than a missing one.
+    test('a read on a chain with no route fails instead of hitting mainnet', async () => {
+      await connect()
+      await handleRpcRequest(
+        'wallet_switchEthereumChain',
+        [{ chainId: '0x6300b5ea' }],
+        ORIGIN,
+      )
+
+      await expect(
+        handleRpcRequest('eth_getBalance', [ADDRESS, 'latest'], ORIGIN),
+      ).rejects.toMatchObject({ code: 4901 })
+      expect(clientFor).toHaveBeenCalledWith(1660990954)
+      expect(nodeRequest).not.toHaveBeenCalled()
+    })
+
+    // EIP-695 spells chain ids in lowercase, but dApps are not obliged to.
+    // Matching the request against the registry by value rather than by string
+    // keeps one chain from reading as two.
+    test('a chain id in mixed case is the same chain', async () => {
+      await connect()
+
+      await handleRpcRequest(
+        'wallet_switchEthereumChain',
+        [{ chainId: '0x6300B5EA' }],
+        ORIGIN,
+      )
+
+      expect(await handleRpcRequest('eth_chainId', [], ORIGIN)).toBe(
+        '0x6300b5ea',
+      )
+    })
+
+    // Two origins, two chains: the chain is per-origin state, so one switching
+    // must not re-route the other's reads.
+    test('one origin switching chains leaves another routed where it was', async () => {
+      await connect()
+      await connect(OTHER_ORIGIN)
+      await handleRpcRequest(
+        'wallet_switchEthereumChain',
+        [{ chainId: '0x6300b5ea' }],
+        OTHER_ORIGIN,
+      )
+
+      await handleRpcRequest('eth_blockNumber', [], ORIGIN)
+
+      expect(clientFor).toHaveBeenCalledWith(1)
+      expect(clientFor).not.toHaveBeenCalledWith(1660990954)
     })
   })
 

--- a/apps/wallet/src/lib/rpc-handler.ts
+++ b/apps/wallet/src/lib/rpc-handler.ts
@@ -1,5 +1,10 @@
-import { debugLog, isOriginPermitted } from '../data/dapp-permissions'
-import { publicClient } from './public-client'
+import {
+  debugLog,
+  getChainIdForOrigin,
+  isOriginPermitted,
+} from '../data/dapp-permissions'
+import { toChainId } from './chains'
+import { getPublicClient } from './public-client'
 import { getAddress } from './rpc/account'
 import { eth_accounts, eth_requestAccounts } from './rpc/accounts'
 import {
@@ -91,7 +96,11 @@ export async function handleRpcRequest(
     if (!(await isOriginPermitted(origin))) {
       throw notPermitted()
     }
-    return await publicClient.request({
+    // Read on the chain the origin switched to. A chain the proxy has no route
+    // for throws here, which reads as a new failure but is the previously
+    // silent one surfacing: every such read used to be answered by mainnet.
+    const chainId = await getChainIdForOrigin(origin)
+    return await getPublicClient(toChainId(chainId)).request({
       method: method as never,
       params: params as never,
     })

--- a/apps/wallet/src/lib/rpc-handler.ts
+++ b/apps/wallet/src/lib/rpc-handler.ts
@@ -96,9 +96,6 @@ export async function handleRpcRequest(
     if (!(await isOriginPermitted(origin))) {
       throw notPermitted()
     }
-    // Read on the chain the origin switched to. A chain the proxy has no route
-    // for throws here, which reads as a new failure but is the previously
-    // silent one surfacing: every such read used to be answered by mainnet.
     const chainId = await getChainIdForOrigin(origin)
     return await getPublicClient(toChainId(chainId)).request({
       method: method as never,

--- a/apps/wallet/src/lib/rpc/chain.ts
+++ b/apps/wallet/src/lib/rpc/chain.ts
@@ -4,10 +4,9 @@ import {
   getChainIdForOrigin,
   setChainIdForOrigin,
 } from '../../data/dapp-permissions'
+import { getChainByHex, toChainId } from '../chains'
 
 import type { RpcContext } from './context'
-
-const SUPPORTED_CHAIN_IDS = new Set(['0x1', '0x6300b5ea'])
 
 export async function eth_chainId({ origin }: RpcContext): Promise<string> {
   return await getChainIdForOrigin(origin)
@@ -15,7 +14,7 @@ export async function eth_chainId({ origin }: RpcContext): Promise<string> {
 
 export async function net_version({ origin }: RpcContext): Promise<string> {
   const chainId = await getChainIdForOrigin(origin)
-  return parseInt(chainId, 16).toString()
+  return toChainId(chainId).toString()
 }
 
 export async function wallet_switchEthereumChain({
@@ -24,15 +23,22 @@ export async function wallet_switchEthereumChain({
 }: RpcContext): Promise<null> {
   const p = params as [{ chainId: string }] | undefined
   const requestedChainId = p?.[0]?.chainId
-  if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
+  if (!requestedChainId) {
+    return null
+  }
+
+  const chain = getChainByHex(requestedChainId)
+  if (!chain) {
     throw new ProviderRpcError({
       code: 4902,
       message: `Unrecognized chain ID ${requestedChainId}. Try adding the chain using wallet_addEthereumChain first.`,
     })
   }
-  if (requestedChainId) {
-    await setChainIdForOrigin(origin, requestedChainId)
-  }
+
+  // The registry's spelling, not the dApp's, so an origin that asked for
+  // `0x6300B5EA` is not a different chain from one that asked for `0x6300b5ea`
+  // everywhere downstream.
+  await setChainIdForOrigin(origin, chain.hex)
   return null
 }
 
@@ -42,14 +48,18 @@ export async function wallet_addEthereumChain({
 }: RpcContext): Promise<null> {
   const p = params as [{ chainId: string }] | undefined
   const requestedChainId = p?.[0]?.chainId
-  if (requestedChainId && !SUPPORTED_CHAIN_IDS.has(requestedChainId)) {
+  if (!requestedChainId) {
+    return null
+  }
+
+  const chain = getChainByHex(requestedChainId)
+  if (!chain) {
     throw new ProviderRpcError({
       code: 4902,
       message: `Chain ${requestedChainId} is not supported`,
     })
   }
-  if (requestedChainId) {
-    await setChainIdForOrigin(origin, requestedChainId)
-  }
+
+  await setChainIdForOrigin(origin, chain.hex)
   return null
 }

--- a/apps/wallet/src/lib/rpc/send-transaction.ts
+++ b/apps/wallet/src/lib/rpc/send-transaction.ts
@@ -1,6 +1,7 @@
 import { ProviderRpcError } from '@status-im/ethereum-provider'
 
 import { getChainIdForOrigin, isSameAddress } from '../../data/dapp-permissions'
+import { getChainByHex } from '../chains'
 import { requestFeeRate } from '../gas-fees'
 import {
   buildAndSendTransaction,
@@ -15,15 +16,6 @@ import { assertNoPendingApproval, requestApproval } from './request-approval'
 import type { createAPI } from '../../data/api'
 import type { RpcContext } from './context'
 import type { Address, Hex } from 'viem'
-
-/**
- * Signing is fenced to mainnet at the backend, not just here:
- * `nodes.getFeeRate` / `broadcastTransaction` / `getNonce` all pin
- * `z.enum(['ethereum'])`, and `api.ts` hardcodes `chainID: '01'`. Lifting the
- * fence is a backend change, so a dApp on another chain is told why rather
- * than served a mainnet transaction it did not ask for.
- */
-const SIGNABLE_CHAIN_ID = '0x1'
 
 type DappTransaction = {
   from?: string
@@ -151,11 +143,17 @@ export async function eth_sendTransaction({
   origin,
   metadata,
 }: RpcContext): Promise<string> {
+  // Fenced at the backend, not just here: `nodes.getFeeRate` /
+  // `broadcastTransaction` / `getNonce` all pin `z.enum(['ethereum'])`, and
+  // `api.ts` hardcodes `chainID: '01'`. Lifting the fence is a backend change,
+  // so a dApp on another chain is told why rather than served a mainnet
+  // transaction it did not ask for.
   const chainId = await getChainIdForOrigin(origin)
-  if (chainId !== SIGNABLE_CHAIN_ID) {
+  const chain = getChainByHex(chainId)
+  if (!chain?.canSign) {
     throw new ProviderRpcError({
       code: 4200,
-      message: `Transactions can only be sent on Ethereum mainnet. This dApp is connected to chain ${parseInt(chainId, 16)}.`,
+      message: `Transactions can only be sent on Ethereum mainnet. This dApp is connected to ${chain?.name ?? `chain ${chainId}`}.`,
     })
   }
 

--- a/apps/wallet/src/lib/rpc/typed-data.ts
+++ b/apps/wallet/src/lib/rpc/typed-data.ts
@@ -1,5 +1,7 @@
 import { ProviderRpcError } from '@status-im/ethereum-provider'
 
+import { getChain, toChainId } from '../chains'
+
 export type TypedDataField = { name: string; type: string }
 
 export type TypedData = {
@@ -183,10 +185,10 @@ export function assertDomainChainId(
     throw invalidParams('typed data declares a chainId it does not sign')
   }
 
-  const current = Number.parseInt(originChainId, 16)
+  const current = toChainId(originChainId)
   if (declared !== current) {
     throw invalidParams(
-      `typed data is for chain ${declared}, but this dApp is connected to chain ${current}`,
+      `typed data is for chain ${declared}, but this dApp is connected to ${getChain(current)?.name ?? `chain ${originChainId}`}`,
     )
   }
 }

--- a/packages/wallet/src/data/api/routers/rpc.ts
+++ b/packages/wallet/src/data/api/routers/rpc.ts
@@ -14,6 +14,11 @@ const PROXY_AUTH = {
   password: serverEnv.ETH_RPC_PROXY_AUTH_PASSWORD,
 }
 
+/**
+ * The upstream half of the wallet extension's chain registry
+ * (`apps/wallet/src/lib/chains.ts`): a chain is only readable once it has an
+ * entry here and a matching `proxyChainId` there.
+ */
 const CHAIN_ID_TO_PROXY_PATH: Record<number, string> = {
   1: 'ethereum/mainnet',
   59144: 'linea/mainnet',


### PR DESCRIPTION
PR5 of the dApp RPC parity work (#1136), on top of #1302.

Forwarded reads went to a module-level mainnet client whatever chain the dApp
had switched to, so `wallet_switchEthereumChain` "succeeded" and every read
afterwards silently answered from mainnet.

- New `apps/wallet/src/lib/chains.ts`: one registry holding chain id, name,
  icon, viem chain, proxy route and `canSign`. Replaces three lists that
  disagreed -- the switchable set in `rpc/chain.ts`, the mainnet pin in
  `public-client.ts`, and `CHAIN_NAMES`/`CHAIN_ICONS` in the approval popup.
- `getPublicClient(chainId)` memoizes one client per chain over that chain's
  proxy route. `publicClient` stays exported as `getPublicClient(1)`.
- Chain ids are matched by value, not by string, so `0x6300B5EA` and
  `0x6300b5ea` stop being two chains.

---

#### How to test

```bash
cd apps/wallet && pnpm test && pnpm build:types
```

- Load `.output/chrome-mv3 unpacked`, open any https page (e.g. `www.google.com`), then
paste into the page console:
```js
(async () => {
  const e = window.ethereum
  const r = (method, ...params) => e.request({ method, params }).catch(x => `ERR ${x.code}: ${x.message}`)
  const log = async (label, p) => console.log(label.padEnd(20), await p)

  const [addr] = await r('eth_requestAccounts')
  console.log('account'.padEnd(20), addr)
  await log('block @mainnet', r('eth_blockNumber'))
  await log('switch 0x6300B5EA', r('wallet_switchEthereumChain', { chainId: '0x6300B5EA' }))
  await log('chainId', r('eth_chainId'))
  await log('block @status', r('eth_blockNumber'))
  await log('balance @status', r('eth_getBalance', addr, 'latest'))
  await log('send @status', r('eth_sendTransaction', { to: addr, value: '0x1' }))
  await log('switch 0x1', r('wallet_switchEthereumChain', { chainId: '0x1' }))
  await log('block @mainnet', r('eth_blockNumber'))
})()
```
Expect the following output:
```js
account              0xD7C1...87C
block @mainnet       0x1898799
switch 0x6300B5EA    null
chainId              0x6300b5ea
block @status        ERR 4901: Chain 1660990954 is not available
balance @status      ERR 4901: Chain 1660990954 is not available
send @status         ERR 4200: Transactions can only be sent on Ethereum mainnet. This dApp is connected to Status Network Sepolia.
switch 0x1           null
block @mainnet       0x1898799
```

- Then run:
```js
(async () => {
  const e = window.ethereum
  const r = (method, ...params) => e.request({ method, params }).catch(x => `ERR ${x.code}: ${x.message}`)
  const log = async (label, p) => console.log(label.padEnd(20), await p)

  const [addr] = await r('eth_requestAccounts')
  await log('switch 0x6300B5EA', r('wallet_switchEthereumChain', { chainId: '0x6300B5EA' }))
  await e.request({ method: 'personal_sign', params: ['0x68690a', addr] })
})()
```
Expect the approval pop up to show Status Network Sepolia with its icon.