### PR TITLE
fix(release): drop stale yarn workspaces field from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,28 +1,6 @@
 {
   "type": "module",
   "private": true,
-  "workspaces": {
-    "packages": [
-      "packages/eslint-config",
-      "packages/status-js",
-      "packages/colors",
-      "packages/icons",
-      "packages/components",
-      "packages/wallet",
-      "packages/status-network",
-      "packages/community-contracts",
-      "apps/community-dapp",
-      "apps/hub",
-      "apps/status.app",
-      "apps/get.status.app",
-      "apps/status.network",
-      "apps/connector",
-      "apps/portfolio",
-      "apps/wallet",
-      "apps/api",
-      "e2e"
-    ]
-  },
   "keywords": [],
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
Fixes https://github.com/status-im/status-web/actions/runs/32475878556/job/96754533093.

`@manypkg/find-root` checks `workspaces` in `package.json` before falling back to
`pnpm-workspace.yaml`. That field was still present and had drifted, omitting
`packages/ethereum-provider` and `packages/sitemap-utils`.

Changesets therefore resolved the repo as a yarn workspace and failed the Release
workflow:

```
Found changeset slimy-houses-rhyme for package @status-im/ethereum-provider which is not in the workspace
```

Removing the field makes `pnpm-workspace.yaml` the single source of truth. The repo
already enforces pnpm (`only-allow pnpm`, `packageManager: pnpm@9.12.3`) and nothing
else reads the field.

`@status-im/ethereum-provider` becomes visible to changesets for the first time.
It is not `private` and config sets `access: public`, so merging will publish it to
npm at `0.1.1`.

---

#### How to test

```bash
pnpm changeset status
```

Passes on this branch, listing `@status-im/ethereum-provider` under patch bumps.