### PR TITLE
fix(status.app): restore code block background on content pages

### DIFF
--- a/apps/status.app/src/app/_components/content/code-block.tsx
+++ b/apps/status.app/src/app/_components/content/code-block.tsx
@@ -9,12 +9,13 @@ import { onlyText } from 'react-children-utilities'
 
 import { useCopyToClipboard } from '../../_hooks/use-copy-to-clipboard'
 
-export function CodeBlock(props: React.ComponentProps<'div'>) {
+export function CodeBlock(props: React.ComponentProps<'figure'>) {
+  const { children, ...rest } = props
   const [, copy] = useCopyToClipboard()
   const t = useTranslations('common')
 
   // note: https://github.com/atomiks/rehype-pretty-code/issues/34#issuecomment-1529567170 source
-  const code = onlyText(props.children)
+  const code = onlyText(children)
 
   const [success, setSuccess] = useState(false)
 
@@ -23,8 +24,8 @@ export function CodeBlock(props: React.ComponentProps<'div'>) {
   }, [success])
 
   return (
-    <div>
-      <div className="relative my-5 grid scrollbar-none [&>pre]:max-h-[624px] [&>pre]:rounded-12 [&>pre]:bg-neutral-90 [&>pre]:p-6">
+    <figure {...rest} className="my-5">
+      <div className="relative grid scrollbar-none [&>pre]:max-h-[624px] [&>pre]:rounded-12 [&>pre]:bg-neutral-90 [&>pre]:p-6">
         <div className="absolute right-3 top-3 block" data-theme="dark">
           <Button
             variant="outline"
@@ -36,8 +37,8 @@ export function CodeBlock(props: React.ComponentProps<'div'>) {
             aria-label={t('copyCode')}
           />
         </div>
-        {props.children}
+        {children}
       </div>
-    </div>
+    </figure>
   )
 }

--- a/apps/status.app/src/app/_components/content/code-block.tsx
+++ b/apps/status.app/src/app/_components/content/code-block.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState } from 'react'
 
 import { Button } from '@status-im/components'
 import { CheckIcon, CopyIcon } from '@status-im/icons/20'
+import { cx } from 'class-variance-authority'
 import { useTranslations } from 'next-intl'
 import { onlyText } from 'react-children-utilities'
 
 import { useCopyToClipboard } from '../../_hooks/use-copy-to-clipboard'
 
 export function CodeBlock(props: React.ComponentProps<'figure'>) {
-  const { children, ...rest } = props
+  const { children, className, ...rest } = props
   const [, copy] = useCopyToClipboard()
   const t = useTranslations('common')
 
@@ -24,7 +25,7 @@ export function CodeBlock(props: React.ComponentProps<'figure'>) {
   }, [success])
 
   return (
-    <figure {...rest} className="my-5">
+    <figure {...rest} className={cx('my-5', className)}>
       <div className="relative grid scrollbar-none [&>pre]:max-h-[624px] [&>pre]:rounded-12 [&>pre]:bg-neutral-90 [&>pre]:p-6">
         <div className="absolute right-3 top-3 block" data-theme="dark">
           <Button

--- a/apps/status.app/src/app/_components/content/index.tsx
+++ b/apps/status.app/src/app/_components/content/index.tsx
@@ -366,14 +366,7 @@ const baseComponents = {
   pre: (props: ComponentProps<'pre'>) => (
     <pre {...props} className="overflow-scroll scrollbar-none" />
   ),
-  div: (props: ComponentProps<'div'>) => {
-    // note: style parent elements of `code` wrapped by `rehype-pretty-code` plugin
-    if (Object.hasOwn(props, 'data-rehype-pretty-code-fragment')) {
-      return <CodeBlock {...props} />
-    }
-
-    return <div {...props} />
-  },
+  div: (props: ComponentProps<'div'>) => <div {...props} />,
   code: (props: any) => {
     const multiline = Children.toArray(props.children).length > 1
 
@@ -396,9 +389,14 @@ const baseComponents = {
     // note: http://localhost:3000/help/getting-started/download-status-for-linux example for scrolling
     return <code className="w-fit" {...props} />
   },
-  figure: (props: ComponentProps<'figure'>) => (
-    <figure {...props} className="my-5" />
-  ),
+  figure: (props: ComponentProps<'figure'>) => {
+    // note: style the element `rehype-pretty-code` wraps highlighted code in
+    if (Object.hasOwn(props, 'data-rehype-pretty-code-figure')) {
+      return <CodeBlock {...props} />
+    }
+
+    return <figure {...props} className="my-5" />
+  },
   iframe: (props: React.ComponentProps<'iframe'>) => {
     // todo?: match youtube props to use aspect-video
     return (


### PR DESCRIPTION
Code blocks had no background in light mode, leaving `github-dark` syntax colors on white.

Before: https://status.app/specs/status-1to1-chat
<img width="723" height="533" alt="Screenshot 2026-08-25 at 2 04 11 AM" src="https://github.com/user-attachments/assets/4976e1bf-1f44-4067-b615-99b061c6220c" />

After: https://status-website-git-fix-specs-code-block-ba-fc5414-status-im-web.vercel.app/specs/status-1to1-chat

<img width="685" height="624" alt="Screenshot 2026-08-25 at 2 03 56 AM" src="https://github.com/user-attachments/assets/0625cb48-5155-4b26-84e2-7231897a4d25" />
