### PR TITLE
fix(status.app): declare canonical URLs as absolute on every route

### DIFF
--- a/apps/status.app/src/app/(sharing)/layout.tsx
+++ b/apps/status.app/src/app/(sharing)/layout.tsx
@@ -1,5 +1,14 @@
 import { Providers } from './_providers'
 
+import type { Metadata } from 'next'
+
+// Deep links into the app that render user-supplied community and profile
+// data. `robots.txt` already keeps crawlers out; this states the same thing in
+// the HTML, so these routes need no canonical of their own.
+export const metadata: Metadata = {
+  robots: { index: false },
+}
+
 type Props = {
   children: React.ReactNode
 }

--- a/apps/status.app/src/app/(website)/insights/epics/[epic]/layout.tsx
+++ b/apps/status.app/src/app/(website)/insights/epics/[epic]/layout.tsx
@@ -1,0 +1,16 @@
+import { CanonicalMetadata } from '~app/_metadata'
+
+type Props = {
+  children: React.ReactNode
+  params: Promise<{ epic: string }>
+}
+
+export async function generateMetadata({ params }: Pick<Props, 'params'>) {
+  const { epic } = await params
+
+  return CanonicalMetadata(`/insights/epics/${epic}`)
+}
+
+export default function EpicLayout({ children }: Props) {
+  return children
+}

--- a/apps/status.app/src/app/(website)/insights/orphans/layout.tsx
+++ b/apps/status.app/src/app/(website)/insights/orphans/layout.tsx
@@ -1,0 +1,11 @@
+import { CanonicalMetadata } from '~app/_metadata'
+
+export const metadata = CanonicalMetadata('/insights/orphans')
+
+type Props = {
+  children: React.ReactNode
+}
+
+export default function OrphansLayout({ children }: Props) {
+  return children
+}

--- a/apps/status.app/src/app/(website)/insights/page.tsx
+++ b/apps/status.app/src/app/(website)/insights/page.tsx
@@ -1,5 +1,11 @@
 import { redirect } from 'next/navigation'
 
+import { CanonicalMetadata } from '~app/_metadata'
+
+// This route renders no content of its own, so it points at the page it hands
+// off to rather than leaving the hand-off without a canonical.
+export const metadata = CanonicalMetadata('/insights/epics')
+
 export default function InsightsPage() {
   return redirect('/insights/epics')
 }

--- a/apps/status.app/src/app/(website)/insights/repos/layout.tsx
+++ b/apps/status.app/src/app/(website)/insights/repos/layout.tsx
@@ -1,0 +1,11 @@
+import { CanonicalMetadata } from '~app/_metadata'
+
+export const metadata = CanonicalMetadata('/insights/repos')
+
+type Props = {
+  children: React.ReactNode
+}
+
+export default function ReposLayout({ children }: Props) {
+  return children
+}

--- a/apps/status.app/src/app/[locale]/(website)/insights/epics/[epic]/layout.tsx
+++ b/apps/status.app/src/app/[locale]/(website)/insights/epics/[epic]/layout.tsx
@@ -1,0 +1,2 @@
+export * from '~website/insights/epics/[epic]/layout'
+export { default } from '~website/insights/epics/[epic]/layout'

--- a/apps/status.app/src/app/[locale]/(website)/insights/epics/layout.tsx
+++ b/apps/status.app/src/app/[locale]/(website)/insights/epics/layout.tsx
@@ -1,0 +1,2 @@
+export * from '~website/insights/epics/layout'
+export { default } from '~website/insights/epics/layout'

--- a/apps/status.app/src/app/[locale]/(website)/insights/orphans/layout.tsx
+++ b/apps/status.app/src/app/[locale]/(website)/insights/orphans/layout.tsx
@@ -1,0 +1,2 @@
+export * from '~website/insights/orphans/layout'
+export { default } from '~website/insights/orphans/layout'

--- a/apps/status.app/src/app/[locale]/(website)/insights/repos/layout.tsx
+++ b/apps/status.app/src/app/[locale]/(website)/insights/repos/layout.tsx
@@ -1,0 +1,2 @@
+export * from '~website/insights/repos/layout'
+export { default } from '~website/insights/repos/layout'

--- a/apps/status.app/src/app/_metadata.ts
+++ b/apps/status.app/src/app/_metadata.ts
@@ -11,6 +11,32 @@ const DEFAULT_OG_IMAGE = createCloudinaryUrl(
   'Open Graph/Status_Open_Graph_01:1200:630'
 )
 
+/**
+ * Resolve a canonical path to the absolute, query-free URL it should declare.
+ *
+ * Canonicals have to be absolute in the HTML as served. Next resolves a
+ * relative value against the *rendered* pathname, which for the `[locale]`
+ * subtree is the internally rewritten `/en/...` path, a URL that only redirects
+ * back to the one being rendered. Query strings are dropped so that every
+ * referral variant (`?ref=...`, `?utm_campaign=...`) collapses onto one URL.
+ * why: https://github.com/status-im/status-web/issues/1307
+ */
+export function toCanonicalUrl(path: string): string {
+  const url = new URL(path, DEFAULT_SITE_URL)
+  url.search = ''
+  url.hash = ''
+  return url.href
+}
+
+/**
+ * Metadata for a client-rendered route, which cannot export metadata itself.
+ * Mount it on a server `layout.tsx` so the segment still declares where it
+ * lives, without touching the title and description it inherits.
+ */
+export function CanonicalMetadata(canonical: string): Metadata {
+  return { alternates: { canonical: toCanonicalUrl(canonical) } }
+}
+
 type Input = Metadata & {
   title: NonNullable<Metadata['title']>
   description?: string
@@ -25,6 +51,7 @@ export function Metadata(input: Input): Metadata {
       ? input.alternates.canonical
       : undefined
   const override = canonical ? getSeoOverride(canonical) : undefined
+  const canonicalUrl = canonical ? toCanonicalUrl(canonical) : undefined
 
   const finalTitle = override?.title ?? input.title
   const finalDescription = override?.description ?? input.description
@@ -40,10 +67,13 @@ export function Metadata(input: Input): Metadata {
     ...input,
     title: finalTitle,
     description: finalDescription,
+    ...(canonicalUrl && {
+      alternates: { ...input.alternates, canonical: canonicalUrl },
+    }),
     openGraph: {
       type: 'website',
       images: [DEFAULT_OG_IMAGE],
-      url: './',
+      url: canonicalUrl ?? './',
       title: ogTitle,
       description: finalDescription,
       siteName: DEFAULT_SITE_NAME,
@@ -108,12 +138,10 @@ export function BlogMetadata(config: BlogMetadataConfig): Metadata {
   }
 
   // Canonical URL
-  if (canonical) {
-    metadata.alternates = {
-      canonical: canonical.startsWith('http')
-        ? canonical
-        : `${DEFAULT_SITE_URL}${canonical}`,
-    }
+  const canonicalUrl = canonical ? toCanonicalUrl(canonical) : undefined
+
+  if (canonicalUrl) {
+    metadata.alternates = { canonical: canonicalUrl }
   }
 
   // Open Graph metadata
@@ -126,10 +154,8 @@ export function BlogMetadata(config: BlogMetadataConfig): Metadata {
     locale: 'en',
   }
 
-  if (canonical) {
-    baseOG.url = canonical.startsWith('http')
-      ? canonical
-      : `${DEFAULT_SITE_URL}${canonical}`
+  if (canonicalUrl) {
+    baseOG.url = canonicalUrl
   }
 
   // Article-specific Open Graph properties

--- a/apps/status.app/src/app/_metadata.ts
+++ b/apps/status.app/src/app/_metadata.ts
@@ -7,6 +7,11 @@ import type { Metadata } from 'next'
 const DEFAULT_SITE_NAME = 'Status'
 const DEFAULT_SITE_URL = SITE_URL
 const DEFAULT_TWITTER_SITE = '@ethstatus'
+
+/** Shared with the root layout so an inheriting route keeps the same title. */
+export const DEFAULT_TITLE = 'Status — Make the jump to web3'
+export const DEFAULT_DESCRIPTION =
+  'The open-source, decentralised wallet and messenger. Own your crypto and chat privately.'
 const DEFAULT_OG_IMAGE = createCloudinaryUrl(
   'Open Graph/Status_Open_Graph_01:1200:630'
 )
@@ -26,15 +31,6 @@ export function toCanonicalUrl(path: string): string {
   url.search = ''
   url.hash = ''
   return url.href
-}
-
-/**
- * Metadata for a client-rendered route, which cannot export metadata itself.
- * Mount it on a server `layout.tsx` so the segment still declares where it
- * lives, without touching the title and description it inherits.
- */
-export function CanonicalMetadata(canonical: string): Metadata {
-  return { alternates: { canonical: toCanonicalUrl(canonical) } }
 }
 
 type Input = Metadata & {
@@ -190,4 +186,22 @@ export function BlogMetadata(config: BlogMetadataConfig): Metadata {
   }
 
   return metadata
+}
+
+/**
+ * Metadata for a client-rendered route, which cannot export metadata itself.
+ * Mount it on a server `layout.tsx` so the segment declares where it lives
+ * while keeping the title and description it would otherwise inherit.
+ *
+ * It goes through `Metadata` rather than returning `alternates` on its own so
+ * the route also gets an `og:url` built from the canonical. Open Graph is not
+ * deep merged across segments, so a partial object here would drop the image,
+ * title and description the root layout provides.
+ */
+export function CanonicalMetadata(canonical: string): Metadata {
+  return Metadata({
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+    alternates: { canonical },
+  })
 }

--- a/apps/status.app/src/app/admin/layout.tsx
+++ b/apps/status.app/src/app/admin/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
     template: '%s | Status Admin',
     default: 'Status Admin',
   },
+  // Authenticated tooling, kept out of the index alongside the `robots.txt`
+  // disallow rule.
+  robots: { index: false },
 }
 
 type Props = {

--- a/apps/status.app/src/app/layout.tsx
+++ b/apps/status.app/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { SITE_URL } from '~/config/site'
 import { routing } from '~/i18n/routing'
 
 import { PlatformDetector } from './_components/platform-detector'
-import { Metadata } from './_metadata'
+import { DEFAULT_DESCRIPTION, DEFAULT_TITLE, Metadata } from './_metadata'
 import { Providers } from './_providers'
 
 export const metadata = Metadata({
@@ -19,10 +19,9 @@ export const metadata = Metadata({
 
   title: {
     template: '%s',
-    default: 'Status — Make the jump to web3',
+    default: DEFAULT_TITLE,
   },
-  description:
-    'The open-source, decentralised wallet and messenger. Own your crypto and chat privately.',
+  description: DEFAULT_DESCRIPTION,
 
   twitter: {
     card: 'summary_large_image',

--- a/apps/status.app/src/app/layout.tsx
+++ b/apps/status.app/src/app/layout.tsx
@@ -24,10 +24,6 @@ export const metadata = Metadata({
   description:
     'The open-source, decentralised wallet and messenger. Own your crypto and chat privately.',
 
-  alternates: {
-    canonical: './',
-  },
-
   twitter: {
     card: 'summary_large_image',
     site: '@ethstatus',


### PR DESCRIPTION
Closes #1307

## The problem

Every page should point at its own real address, in two tags:

```html
<link rel="canonical" href="..." />
<meta property="og:url" content="..." />
```

Many pages pointed at an `/en/...` address instead. That address is not real. Open it and you get sent straight back:

```
GET https://status.app/en/insights/orphans
307 -> /insights/orphans
```

## Before / after

Taken from the real build output, file `en/insights/orphans.html`. This is the file visitors are served when they open `/insights/orphans`.

**Before**

```html
<link rel="canonical" href="https://status.app/en/insights/orphans" />
<meta property="og:url" content="https://status.app/en/insights/orphans" />
```

**After**

```html
<link rel="canonical" href="https://status.app/insights/orphans" />
<meta property="og:url" content="https://status.app/insights/orphans" />
```

Across all 657 built pages:

| Tag pointing at `/en/...` | before | after |
| --- | --- | --- |
| `canonical` | 4 | 0 |
| `og:url` | 326 | 0 |

## Why it happened

Pages that did not set their own address fell back to `'./'`, which means "wherever I am right now". The app rewrites every request to add `/en` in front, so `'./'` picked up the `/en` version.

## The fix

- Use full addresses instead of `'./'`, so `/en` cannot slip in.
- Drop `?ref=...` and `?utm_campaign=...`, so referral links all point at one address.
- Build `og:url` from the same address, so the two tags cannot disagree.
- Give the insights pages their own address, since they had none.
- Mark `/admin` and the share pages as "do not index", matching `robots.txt`.

## How to test

Open the preview page and press Ctrl+U (View Source):

https://status-website-git-fix-1307-canonical-server-html-status-im-web.vercel.app/insights/orphans

Search for `canonical`. Both tags should say `/insights/orphans` with no `/en`:

```html
<link rel="canonical" href="https://status.app/insights/orphans"/>
<meta property="og:url" content="https://status.app/insights/orphans"/>
```

Before this change both tags said `https://status.app/en/insights/orphans`, and that address only redirects back to `/insights/orphans`.

## Note

The issue also mentions a link with two `?` in it (`?from=article-linksmanifesto?from=article-links`). `from=article-links` does not appear in this repo, its git history, or the HTML of any of the 282 pages in the sitemap. Another website built that link. The canonical tag is what tells Google to ignore it.
