### PR TITLE
fix(wallet): stop underpricing transactions in the fee estimator

### DIFF
--- a/apps/wallet/src/lib/send-transaction.ts
+++ b/apps/wallet/src/lib/send-transaction.ts
@@ -95,7 +95,7 @@ export function resolveFeeParams(
       // it from our own estimate alone can undercut the quoted priority
       // (invalid EIP-1559 tx, rejected at broadcast), so honor the quoted
       // priority and add the estimator's base-fee headroom on top
-      // (its maxFeePerGas = 2*baseFee + own priority).
+      // (its maxFeePerGas = BASE_FEE_MULTIPLIER*baseFee + own priority).
       const baseFeeHeadroom =
         BigInt(fees.txParams.maxFeePerGas) -
         BigInt(fees.txParams.maxPriorityFeePerGas)

--- a/packages/wallet/src/data/services/alchemy/index.ts
+++ b/packages/wallet/src/data/services/alchemy/index.ts
@@ -1069,7 +1069,7 @@ export async function getFeeRate(
 
   const feeHistoryData = processFeeHistory({
     ...feeHistory?.result,
-    gasUsedRatio: feeHistory?.result?.gasUsedRatio?.map(String) ?? [],
+    gasUsedRatio: feeHistory?.result?.gasUsedRatio ?? [],
     reward: feeHistory?.result?.reward ?? null,
   })
 

--- a/packages/wallet/src/data/services/alchemy/index.ts
+++ b/packages/wallet/src/data/services/alchemy/index.ts
@@ -26,7 +26,11 @@ import {
   COINGECKO_REVALIDATION_TIMES,
   fetchTokensPrice,
 } from '../coingecko/index'
-import { estimateConfirmationTime, processFeeHistory } from './utils'
+import {
+  calculateFeeParams,
+  estimateConfirmationTime,
+  processFeeHistory,
+} from './utils'
 
 import type { NetworkType } from '../../api/types'
 import type {
@@ -1063,14 +1067,18 @@ export async function getFeeRate(
   }
 
   const baseFee = BigInt(baseFeeHex)
-  const priorityFee = BigInt(priorityFeeHex)
   const gasLimit = BigInt(gasLimitHex)
-  const maxFeePerGas = baseFee * 2n + priorityFee
 
   const feeHistoryData = processFeeHistory({
     ...feeHistory?.result,
     gasUsedRatio: feeHistory?.result?.gasUsedRatio ?? [],
     reward: feeHistory?.result?.reward ?? null,
+  })
+
+  const { priorityFee, maxFeePerGas } = calculateFeeParams({
+    baseFee,
+    suggestedPriorityFee: BigInt(priorityFeeHex),
+    averageP50: feeHistoryData.averageP50,
   })
 
   const ethPrice = ethPriceData?.['ETH']?.usd || 0

--- a/packages/wallet/src/data/services/alchemy/utils.test.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.test.ts
@@ -37,7 +37,7 @@ describe('processFeeHistory', () => {
 describe('calculateFeeParams', () => {
   const baseFee = 4_070_000_000n
 
-  it('floors a suggested tip below the median actually paid', () => {
+  it('floors a tip when both signals sit under it', () => {
     const { priorityFee } = calculateFeeParams({
       baseFee,
       suggestedPriorityFee: 73_182n,
@@ -45,6 +45,20 @@ describe('calculateFeeParams', () => {
     })
 
     expect(priorityFee).toBe(MIN_PRIORITY_FEE_WEI)
+  })
+
+  it('keeps the floor within an order of magnitude of a quiet-market median', () => {
+    // The tip the floor imposes is quoted to the user, so a floor far over the
+    // median paid inflates the quote by most of its own size.
+    const quietMarketP50 = 62_000_000n
+
+    const { priorityFee } = calculateFeeParams({
+      baseFee: 110_000_000n,
+      suggestedPriorityFee: 0n,
+      averageP50: quietMarketP50,
+    })
+
+    expect(priorityFee).toBeLessThan(quietMarketP50 * 10n)
   })
 
   it('floors a zero tip', () => {

--- a/packages/wallet/src/data/services/alchemy/utils.test.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { processFeeHistory } from './utils'
+
+const feeHistory = {
+  // `eth_feeHistory` returns these as floats, not hex quantities.
+  gasUsedRatio: [0.5355277, 0.5355277],
+  baseFeePerGas: ['0xf2b1a8f0', '0xf2b1a8f0'],
+  reward: [
+    ['0x5d62', '0x12e2f10e', '0x3b9aca00'],
+    ['0x5d62', '0x12e2f10e', '0x3b9aca00'],
+  ],
+}
+
+describe('processFeeHistory', () => {
+  it('reads gasUsedRatio as a float', () => {
+    expect(processFeeHistory(feeHistory).averageGasUsedRatio).toBe(0.5355277)
+  })
+
+  it('averages to zero rather than NaN on an empty history', () => {
+    const { averageGasUsedRatio, averageP50 } = processFeeHistory({
+      gasUsedRatio: [],
+      baseFeePerGas: [],
+      reward: null,
+    })
+
+    expect(averageGasUsedRatio).toBe(0)
+    expect(averageP50).toBe(0n)
+  })
+})

--- a/packages/wallet/src/data/services/alchemy/utils.test.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { processFeeHistory } from './utils'
+import {
+  BASE_FEE_MULTIPLIER,
+  calculateFeeParams,
+  MIN_PRIORITY_FEE_WEI,
+  processFeeHistory,
+} from './utils'
 
 const feeHistory = {
   // `eth_feeHistory` returns these as floats, not hex quantities.
@@ -26,5 +31,55 @@ describe('processFeeHistory', () => {
 
     expect(averageGasUsedRatio).toBe(0)
     expect(averageP50).toBe(0n)
+  })
+})
+
+describe('calculateFeeParams', () => {
+  const baseFee = 4_070_000_000n
+
+  it('floors a suggested tip below the median actually paid', () => {
+    const { priorityFee } = calculateFeeParams({
+      baseFee,
+      suggestedPriorityFee: 73_182n,
+      averageP50: 19_819_790n,
+    })
+
+    expect(priorityFee).toBe(MIN_PRIORITY_FEE_WEI)
+  })
+
+  it('floors a zero tip', () => {
+    expect(
+      calculateFeeParams({ baseFee, suggestedPriorityFee: 0n, averageP50: 0n })
+        .priorityFee,
+    ).toBe(MIN_PRIORITY_FEE_WEI)
+  })
+
+  it('keeps a suggestion above the floor', () => {
+    const suggestedPriorityFee = MIN_PRIORITY_FEE_WEI * 5n
+
+    expect(
+      calculateFeeParams({ baseFee, suggestedPriorityFee, averageP50: 0n })
+        .priorityFee,
+    ).toBe(suggestedPriorityFee)
+  })
+
+  it('takes the median when it beats both the suggestion and the floor', () => {
+    const averageP50 = MIN_PRIORITY_FEE_WEI * 3n
+
+    expect(
+      calculateFeeParams({ baseFee, suggestedPriorityFee: 1n, averageP50 })
+        .priorityFee,
+    ).toBe(averageP50)
+  })
+
+  it('leaves the ceiling room for the base fee to climb', () => {
+    const { priorityFee, maxFeePerGas } = calculateFeeParams({
+      baseFee,
+      suggestedPriorityFee: 0n,
+      averageP50: 0n,
+    })
+
+    expect(maxFeePerGas).toBe(baseFee * BASE_FEE_MULTIPLIER + priorityFee)
+    expect(maxFeePerGas).toBeGreaterThan(priorityFee)
   })
 })

--- a/packages/wallet/src/data/services/alchemy/utils.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.ts
@@ -46,6 +46,46 @@ export function processFeeHistory(feeHistory: FeeHistory) {
   }
 }
 
+/**
+ * `eth_maxPriorityFeePerGas` has been measured on mainnet returning tips ~270x
+ * below the median tip actually paid (and it may legitimately return `0x0`), so
+ * the suggestion is only a lower bound among three.
+ */
+export const MIN_PRIORITY_FEE_WEI = 1_000_000_000n
+
+/**
+ * Headroom for the base fee to keep climbing while the transaction waits. At
+ * ~70% utilisation the base fee grows ~5.2% per block, so 2x is exhausted in
+ * ~14 blocks and the transaction becomes unincludable, then evicted; 3x buys
+ * ~21 blocks.
+ */
+export const BASE_FEE_MULTIPLIER = 3n
+
+/**
+ * The tip and the ceiling compose: a sub-median tip sets how long the
+ * transaction waits, and a tight ceiling makes that wait fatal.
+ */
+export function calculateFeeParams({
+  baseFee,
+  suggestedPriorityFee,
+  averageP50,
+}: {
+  baseFee: bigint
+  suggestedPriorityFee: bigint
+  averageP50: bigint
+}) {
+  const priorityFee = [
+    suggestedPriorityFee,
+    averageP50,
+    MIN_PRIORITY_FEE_WEI,
+  ].reduce((max, fee) => (fee > max ? fee : max))
+
+  return {
+    priorityFee,
+    maxFeePerGas: baseFee * BASE_FEE_MULTIPLIER + priorityFee,
+  }
+}
+
 type FeeAverages = {
   averageP10: bigint
   averageP50: bigint

--- a/packages/wallet/src/data/services/alchemy/utils.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.ts
@@ -3,19 +3,19 @@ import { match } from 'ts-pattern'
 // Considering https://www.alchemy.com/docs/how-to-build-a-gas-fee-estimator-using-eip-1559
 
 type FeeHistory = {
-  gasUsedRatio: string[]
+  gasUsedRatio: number[]
   baseFeePerGas: string[]
   reward: Array<string[]> | null
 }
 
 export function processFeeHistory(feeHistory: FeeHistory) {
-  const blocks = feeHistory.gasUsedRatio.map((ratioHex, i) => {
+  const blocks = feeHistory.gasUsedRatio.map((ratio, i) => {
     const baseFeePerGas = BigInt(feeHistory.baseFeePerGas[i])
 
     const reward = feeHistory.reward?.[i] ?? []
 
     return {
-      gasUsedRatio: parseInt(ratioHex, 16) / 0x10000,
+      gasUsedRatio: Number(ratio),
       baseFeePerGas,
       priorityFeePerGas: {
         p10: reward[0] ? BigInt(reward[0]) : 0n,
@@ -25,8 +25,11 @@ export function processFeeHistory(feeHistory: FeeHistory) {
     }
   })
 
+  // An empty fee history would average to NaN, which `BigInt` rejects.
   const average = (getter: (block: (typeof blocks)[0]) => number) =>
-    blocks.reduce((sum, b) => sum + getter(b), 0) / blocks.length
+    blocks.length
+      ? blocks.reduce((sum, b) => sum + getter(b), 0) / blocks.length
+      : 0
 
   return {
     blocks,

--- a/packages/wallet/src/data/services/alchemy/utils.ts
+++ b/packages/wallet/src/data/services/alchemy/utils.ts
@@ -47,11 +47,12 @@ export function processFeeHistory(feeHistory: FeeHistory) {
 }
 
 /**
- * `eth_maxPriorityFeePerGas` has been measured on mainnet returning tips ~270x
- * below the median tip actually paid (and it may legitimately return `0x0`), so
- * the suggestion is only a lower bound among three.
+ * Never-zero backstop for when neither signal yields a tip: the suggestion may
+ * legitimately be `0x0`, and the p50 is `0n` whenever `eth_feeHistory` comes
+ * back without rewards. Sized to sit under the going rate rather than over it,
+ * so it underprices a congested market when it is the only signal left.
  */
-export const MIN_PRIORITY_FEE_WEI = 1_000_000_000n
+export const MIN_PRIORITY_FEE_WEI = 100_000_000n
 
 /**
  * Headroom for the base fee to keep climbing while the transaction waits. At
@@ -62,8 +63,10 @@ export const MIN_PRIORITY_FEE_WEI = 1_000_000_000n
 export const BASE_FEE_MULTIPLIER = 3n
 
 /**
- * The tip and the ceiling compose: a sub-median tip sets how long the
- * transaction waits, and a tight ceiling makes that wait fatal.
+ * `eth_maxPriorityFeePerGas` has been measured on mainnet returning tips ~270x
+ * below the median tip actually paid, hence the p50 alongside it. The tip and
+ * the ceiling compose: a sub-median tip sets how long the transaction waits,
+ * and a tight ceiling makes that wait fatal.
  */
 export function calculateFeeParams({
   baseFee,


### PR DESCRIPTION
Closes #1313.

Sends and swaps were signed at a fee the network had no reason to include,
so under load they stalled, got evicted, and Etherscan reported
"Transaction Hash not found".

- **Tip floor.** `max(eth_maxPriorityFeePerGas, feeHistory p50, 1 gwei)`. The raw suggestion ran ~270x under the median tip actually paid, and `0x0` passed the old `!priorityFeeHex` guard, making a zero tip signable. The p50 was already fetched in the same `Promise.all` and only fed an ETA string.
- **Ceiling.** `2x -> 3x` base fee: ~14 -> ~23 blocks of headroom before the tx becomes unincludable. Constant rather than trend-derived -- a 4-block window is volatile enough that a derived multiplier would need a cap anyway, and `maxFeeEth` is user-visible.
- **`gasUsedRatio`.** `parseInt(hex)` ran on a float, stopping at the `.`, so `averageGasUsedRatio` was permanently 0 and the ETA always took the idle branch. Now `Number(ratio)`, with the type corrected to `number[]` (`types.ts` already declared it that way) and the `.map(String)` at the call site dropped.

Fee math lives in one pure exported `calculateFeeParams`, so the EIP-1559
invariant is checkable in tests.

---

#### How to test

- `pnpm build && pnpm dev`, then:
```shell
curl -s -G 'http://localhost:3030/api/trpc/nodes.getFeeRate' --data-urlencode 'input={"json":{"network":"ethereum","params":{"from":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","to":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","value":"0x0"}}}'
```
Expect `maxPriorityFeePerGas` >= ~~`0x3b9aca00` (1 gwei)~~ `0x5F5E100` (0.1 gwei). On `develop` the same call returns `0x0`.
- If possible,  broadcast a send and a swap on mainnet; confirm both land.