### PR TITLE
fix(wallet): recover from stuck transactions instead of breaking the session

### DIFF
--- a/apps/wallet/src/data/ethereum/ethereum.ts
+++ b/apps/wallet/src/data/ethereum/ethereum.ts
@@ -1,4 +1,4 @@
-import { padHex } from '@status-im/wallet/utils'
+import { isEthereumTransactionHash, padHex } from '@status-im/wallet/utils'
 import { Buffer } from 'buffer'
 
 import { nonceTracker } from '../../lib/nonce-tracker'
@@ -9,6 +9,55 @@ import type { WalletCore } from '@trustwallet/wallet-core'
 const BROADCAST_TRANSACTION_URL = new URL(
   `${import.meta.env.WXT_STATUS_API_URL}/api/trpc/nodes.broadcastTransaction`,
 )
+
+/**
+ * The upstream reason, not the status code: `parseInsufficientFundsError` reads
+ * the node's `insufficient funds for gas * price + value` back out of it.
+ */
+async function readBroadcastError(response: Response): Promise<string> {
+  try {
+    const body = await response.json()
+    const message = body?.error?.json?.message ?? body?.error?.message
+    if (typeof message === 'string' && message) {
+      return message
+    }
+  } catch {
+    // Not a tRPC error envelope; the generic message is all there is.
+  }
+  return 'Failed to broadcast transaction'
+}
+
+/**
+ * `withNonce` commits on resolve, so returning anything but a real hash burns
+ * the nonce on a transaction that does not exist and gaps every later one.
+ */
+async function broadcast(rawTx: string, network: string): Promise<string> {
+  const response = await fetch(BROADCAST_TRANSACTION_URL.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      json: {
+        txHex: rawTx,
+        network,
+      },
+    }),
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error(await readBroadcastError(response))
+  }
+
+  const body = await response.json()
+  const txid: unknown = body?.result?.data?.json
+  if (typeof txid !== 'string' || !isEthereumTransactionHash(txid)) {
+    throw new Error('Broadcast returned no transaction hash')
+  }
+
+  return txid
+}
 
 export async function send({
   walletCore,
@@ -66,27 +115,7 @@ export async function send({
     const output = encoder.Ethereum.Proto.SigningOutput.decode(outputData)
     const rawTx = walletCore.HexCoding.encode(output.encoded)
 
-    // broadcast
-    const response = await fetch(BROADCAST_TRANSACTION_URL.toString(), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        json: {
-          txHex: rawTx,
-          network,
-        },
-      }),
-      cache: 'no-store',
-    })
-
-    if (!response.ok) {
-      throw new Error('Failed to broadcast transaction')
-    }
-
-    const body = await response.json()
-    const txid = body.result.data.json
+    const txid = await broadcast(rawTx, network)
 
     return { txid }
   })
@@ -150,19 +179,7 @@ export async function sendContractCall({
     const output = encoder.Ethereum.Proto.SigningOutput.decode(outputData)
     const rawTx = walletCore.HexCoding.encode(output.encoded)
 
-    const response = await fetch(BROADCAST_TRANSACTION_URL.toString(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ json: { txHex: rawTx, network } }),
-      cache: 'no-store',
-    })
-
-    if (!response.ok) {
-      throw new Error('Failed to broadcast transaction')
-    }
-
-    const body = await response.json()
-    const txid = body.result.data.json
+    const txid = await broadcast(rawTx, network)
 
     return { txid }
   })
@@ -230,27 +247,7 @@ export async function sendErc20({
     const output = encoder.Ethereum.Proto.SigningOutput.decode(outputData)
     const rawTx = walletCore.HexCoding.encode(output.encoded)
 
-    // broadcast
-    const response = await fetch(BROADCAST_TRANSACTION_URL.toString(), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        json: {
-          txHex: rawTx,
-          network,
-        },
-      }),
-      cache: 'no-store',
-    })
-
-    if (!response.ok) {
-      throw new Error('Failed to broadcast transaction')
-    }
-
-    const body = await response.json()
-    const txid = body.result.data.json
+    const txid = await broadcast(rawTx, network)
 
     return { txid }
   })

--- a/apps/wallet/src/data/nonce-tracker.ts
+++ b/apps/wallet/src/data/nonce-tracker.ts
@@ -1,6 +1,14 @@
 import { storage } from '@wxt-dev/storage'
 
 const NONCE_SESSION_KEY = 'session:nonce:tracker' as const
+const NONCE_MARK_SESSION_KEY = 'session:nonce:ahead' as const
+
+/** When the local counter was last seen ahead of an empty transaction pool. */
+export type NonceMark = {
+  block: number
+  /** Pending count then; a different one describes a new situation. */
+  pendingNonce: number
+}
 
 export async function readNonceStore(): Promise<Record<string, number>> {
   return (
@@ -12,4 +20,18 @@ export async function writeNonceStore(
   store: Record<string, number>,
 ): Promise<void> {
   await storage.setItem(NONCE_SESSION_KEY, store)
+}
+
+export async function readNonceMarkStore(): Promise<Record<string, NonceMark>> {
+  return (
+    (await storage.getItem<Record<string, NonceMark>>(
+      NONCE_MARK_SESSION_KEY,
+    )) ?? {}
+  )
+}
+
+export async function writeNonceMarkStore(
+  store: Record<string, NonceMark>,
+): Promise<void> {
+  await storage.setItem(NONCE_MARK_SESSION_KEY, store)
 }

--- a/apps/wallet/src/lib/nonce-tracker.test.ts
+++ b/apps/wallet/src/lib/nonce-tracker.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideNonce, RECONCILE_AFTER_BLOCKS } from './nonce-tracker'
+
+import type { ChainNonceState } from './nonce-tracker'
+
+const chain = (
+  pendingNonce: number,
+  latestNonce: number,
+  blockNumber: number,
+): ChainNonceState => ({ pendingNonce, latestNonce, blockNumber })
+
+describe('decideNonce', () => {
+  it('clears the mark when the chain has caught up with the local counter', () => {
+    expect(
+      decideNonce(5, chain(5, 5, 100), { block: 90, pendingNonce: 5 }),
+    ).toEqual({ action: 'clear' })
+  })
+
+  it('clears the mark while the pool still holds something', () => {
+    expect(
+      decideNonce(6, chain(5, 4, 100), { block: 90, pendingNonce: 5 }),
+    ).toEqual({ action: 'clear' })
+  })
+
+  it('marks the first time the counter is seen ahead of an empty pool', () => {
+    expect(decideNonce(6, chain(5, 5, 100), undefined)).toEqual({
+      action: 'mark',
+      mark: { block: 100, pendingNonce: 5 },
+    })
+  })
+
+  it('re-marks when the pending count has moved since the mark', () => {
+    expect(
+      decideNonce(8, chain(6, 6, 100), { block: 95, pendingNonce: 5 }),
+    ).toEqual({ action: 'mark', mark: { block: 100, pendingNonce: 6 } })
+  })
+
+  it('re-marks when the reported block is below the marked one', () => {
+    expect(
+      decideNonce(6, chain(5, 5, 80), { block: 100, pendingNonce: 5 }),
+    ).toEqual({ action: 'mark', mark: { block: 80, pendingNonce: 5 } })
+  })
+
+  it('waits inside the observation window', () => {
+    const mark = { block: 100, pendingNonce: 5 }
+    const lastWaiting = 100 + RECONCILE_AFTER_BLOCKS - 1
+    expect(decideNonce(6, chain(5, 5, lastWaiting), mark)).toEqual({
+      action: 'wait',
+    })
+  })
+
+  it('lowers the counter to the pending count once the window has passed', () => {
+    const mark = { block: 100, pendingNonce: 5 }
+    expect(
+      decideNonce(6, chain(5, 5, 100 + RECONCILE_AFTER_BLOCKS), mark),
+    ).toEqual({ action: 'reconcile', nonce: 5 })
+  })
+
+  it('lowers a counter that has run several nonces ahead', () => {
+    const mark = { block: 100, pendingNonce: 5 }
+    expect(
+      decideNonce(9, chain(5, 5, 100 + RECONCILE_AFTER_BLOCKS), mark),
+    ).toEqual({ action: 'reconcile', nonce: 5 })
+  })
+})

--- a/apps/wallet/src/lib/nonce-tracker.ts
+++ b/apps/wallet/src/lib/nonce-tracker.ts
@@ -1,10 +1,76 @@
 import { padHex } from '@status-im/wallet/utils'
 
-import { readNonceStore, writeNonceStore } from '../data/nonce-tracker'
+import {
+  readNonceMarkStore,
+  readNonceStore,
+  writeNonceMarkStore,
+  writeNonceStore,
+} from '../data/nonce-tracker'
+import { getRpcProxyUrl } from './rpc-proxy'
+
+import type { NonceMark } from '../data/nonce-tracker'
 
 const NONCE_URL_BASE = `${import.meta.env.WXT_STATUS_API_URL}/api/trpc/nodes.getNonce`
 
-async function fetchNetworkNonce(
+/**
+ * Blocks the counter must stay ahead of an empty pool before it is lowered.
+ * ~1 minute: past any delay in the node counting a transaction it accepted.
+ */
+export const RECONCILE_AFTER_BLOCKS = 5
+
+export type ChainNonceState = {
+  /** `eth_getTransactionCount(address, 'pending')`. */
+  pendingNonce: number
+  /** `eth_getTransactionCount(address, 'latest')`. */
+  latestNonce: number
+  blockNumber: number
+}
+
+export type NonceDecision =
+  | { action: 'clear' }
+  | { action: 'mark'; mark: NonceMark }
+  | { action: 'wait' }
+  | { action: 'reconcile'; nonce: number }
+
+/**
+ * Whether the local counter is tracking a transaction that no longer exists.
+ * Nothing lowered it before, so one dropped transaction left every later one
+ * signed at a gapped nonce: queued, never mined, never advancing the count.
+ *
+ * `pendingNonce === latestNonce` means the node holds nothing for the account.
+ * The mark makes that hold for `RECONCILE_AFTER_BLOCKS` so a transaction taken
+ * but not yet counted is not mistaken for a stranded one.
+ */
+export function decideNonce(
+  localNonce: number,
+  chain: ChainNonceState,
+  mark: NonceMark | undefined,
+): NonceDecision {
+  const poolIsEmpty = chain.pendingNonce === chain.latestNonce
+  if (localNonce <= chain.pendingNonce || !poolIsEmpty) {
+    return { action: 'clear' }
+  }
+
+  // A moved count or a lower block is a different situation -- restart.
+  if (
+    !mark ||
+    mark.pendingNonce !== chain.pendingNonce ||
+    chain.blockNumber < mark.block
+  ) {
+    return {
+      action: 'mark',
+      mark: { block: chain.blockNumber, pendingNonce: chain.pendingNonce },
+    }
+  }
+
+  if (chain.blockNumber - mark.block < RECONCILE_AFTER_BLOCKS) {
+    return { action: 'wait' }
+  }
+
+  return { action: 'reconcile', nonce: chain.pendingNonce }
+}
+
+async function fetchPendingNonce(
   fromAddress: string,
   network: string,
 ): Promise<number> {
@@ -27,6 +93,57 @@ async function fetchNetworkNonce(
   const body = await response.json()
   const hex: string = body.result.data.json
   return Number(hex)
+}
+
+/**
+ * Batched as the array `rpc.proxy` accepts. Chain 1 resolves to the upstream
+ * `nodes.getNonce` uses, so the counts compared below agree on a node.
+ */
+async function fetchMinedNonceAndBlock(
+  fromAddress: string,
+): Promise<{ latestNonce: number; blockNumber: number }> {
+  const calls = [
+    {
+      method: 'eth_getTransactionCount',
+      params: [fromAddress, 'latest'],
+    },
+    { method: 'eth_blockNumber', params: [] },
+  ]
+
+  const response = await fetch(getRpcProxyUrl(1), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(
+      calls.map((call, index) => ({ jsonrpc: '2.0', id: index, ...call })),
+    ),
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch chain state')
+  }
+
+  const body = (await response.json()) as {
+    id: number
+    result?: unknown
+    error?: unknown
+  }[]
+
+  const [latestNonce, blockNumber] = calls.map((_, index) => {
+    const entry = Array.isArray(body)
+      ? body.find(item => item.id === index)
+      : null
+    if (!entry || entry.error || typeof entry.result !== 'string') {
+      throw new Error('Failed to fetch chain state')
+    }
+    const value = Number(entry.result)
+    if (!Number.isFinite(value)) {
+      throw new Error('Failed to fetch chain state')
+    }
+    return value
+  })
+
+  return { latestNonce, blockNumber }
 }
 
 export type NonceTracker = ReturnType<typeof createNonceTracker>
@@ -59,11 +176,70 @@ export function createNonceTracker() {
     await storageWriteChain
   }
 
+  async function writeMark(key: string, mark: NonceMark | null): Promise<void> {
+    storageWriteChain = storageWriteChain.then(async () => {
+      const store = await readNonceMarkStore()
+      if (mark) {
+        store[key] = mark
+      } else {
+        delete store[key]
+      }
+      await writeNonceMarkStore(store)
+    })
+    await storageWriteChain
+  }
+
   /**
-   * Executes `callback` with a reserved nonce hex string for `fromAddress` on
-   * `network`. The nonce is committed to persistent session storage only when
-   * the callback resolves; a thrown error leaves the tracker unchanged so the
-   * next attempt reuses the same nonce.
+   * The nonce to sign at, lowering a counter that tracks a dropped transaction.
+   * Best-effort: if the extra reads fail, the pending count alone still sends.
+   */
+  async function resolveNonce(
+    key: string,
+    fromAddress: string,
+    network: string,
+  ): Promise<{ nonce: number; chain: ChainNonceState | null }> {
+    const localNonce = nonceCache.get(key) ?? 0
+
+    const [pending, mined] = await Promise.allSettled([
+      fetchPendingNonce(fromAddress, network),
+      fetchMinedNonceAndBlock(fromAddress),
+    ])
+    if (pending.status === 'rejected') {
+      throw pending.reason
+    }
+
+    const pendingNonce = pending.value
+    if (mined.status === 'rejected') {
+      return { nonce: Math.max(pendingNonce, localNonce), chain: null }
+    }
+
+    const chain: ChainNonceState = { pendingNonce, ...mined.value }
+    const marks = await readNonceMarkStore()
+    const decision = decideNonce(localNonce, chain, marks[key])
+
+    switch (decision.action) {
+      case 'reconcile':
+        await commitNonce(key, decision.nonce)
+        await writeMark(key, null)
+        return { nonce: decision.nonce, chain }
+      case 'mark':
+        await writeMark(key, decision.mark)
+        break
+      case 'clear':
+        if (marks[key]) await writeMark(key, null)
+        break
+      case 'wait':
+        break
+    }
+
+    return { nonce: Math.max(pendingNonce, localNonce), chain }
+  }
+
+  /**
+   * Executes `callback` with a reserved nonce for `fromAddress` on `network`.
+   * The nonce is committed to persistent session storage only when the callback
+   * resolves; a thrown error leaves the tracker unchanged so the next attempt
+   * reuses the same nonce.
    *
    * Concurrent calls for the same address/network are serialized automatically.
    */
@@ -76,13 +252,18 @@ export function createNonceTracker() {
 
     const run = async (): Promise<T> => {
       await loadNonce(key)
-      const networkNonce = await fetchNetworkNonce(fromAddress, network)
-      const localNonce = nonceCache.get(key) ?? 0
-      const nonce = Math.max(networkNonce, localNonce)
-      const nonceHex = padHex(nonce.toString(16))
+      const { nonce, chain } = await resolveNonce(key, fromAddress, network)
 
-      const result = await callback(nonceHex)
+      const result = await callback(padHex(nonce.toString(16)))
       await commitNonce(key, nonce + 1)
+      // Marking where the counter went ahead lets the next reservation tell
+      // "still propagating" from "stranded" on its first try.
+      if (chain) {
+        await writeMark(key, {
+          block: chain.blockNumber,
+          pendingNonce: chain.pendingNonce,
+        })
+      }
       return result
     }
 

--- a/apps/wallet/src/lib/nonce-tracker.ts
+++ b/apps/wallet/src/lib/nonce-tracker.ts
@@ -192,12 +192,19 @@ export function createNonceTracker() {
   /**
    * The nonce to sign at, lowering a counter that tracks a dropped transaction.
    * Best-effort: if the extra reads fail, the pending count alone still sends.
+   *
+   * `marked` reports that a mark for this pool count is already held, so the
+   * caller leaves it alone instead of restarting its window.
    */
   async function resolveNonce(
     key: string,
     fromAddress: string,
     network: string,
-  ): Promise<{ nonce: number; chain: ChainNonceState | null }> {
+  ): Promise<{
+    nonce: number
+    chain: ChainNonceState | null
+    marked: boolean
+  }> {
     const localNonce = nonceCache.get(key) ?? 0
 
     const [pending, mined] = await Promise.allSettled([
@@ -210,7 +217,11 @@ export function createNonceTracker() {
 
     const pendingNonce = pending.value
     if (mined.status === 'rejected') {
-      return { nonce: Math.max(pendingNonce, localNonce), chain: null }
+      return {
+        nonce: Math.max(pendingNonce, localNonce),
+        chain: null,
+        marked: false,
+      }
     }
 
     const chain: ChainNonceState = { pendingNonce, ...mined.value }
@@ -221,7 +232,7 @@ export function createNonceTracker() {
       case 'reconcile':
         await commitNonce(key, decision.nonce)
         await writeMark(key, null)
-        return { nonce: decision.nonce, chain }
+        return { nonce: decision.nonce, chain, marked: false }
       case 'mark':
         await writeMark(key, decision.mark)
         break
@@ -232,7 +243,8 @@ export function createNonceTracker() {
         break
     }
 
-    return { nonce: Math.max(pendingNonce, localNonce), chain }
+    const marked = decision.action === 'mark' || decision.action === 'wait'
+    return { nonce: Math.max(pendingNonce, localNonce), chain, marked }
   }
 
   /**
@@ -252,13 +264,18 @@ export function createNonceTracker() {
 
     const run = async (): Promise<T> => {
       await loadNonce(key)
-      const { nonce, chain } = await resolveNonce(key, fromAddress, network)
+      const { nonce, chain, marked } = await resolveNonce(
+        key,
+        fromAddress,
+        network,
+      )
 
       const result = await callback(padHex(nonce.toString(16)))
       await commitNonce(key, nonce + 1)
       // Marking where the counter went ahead lets the next reservation tell
-      // "still propagating" from "stranded" on its first try.
-      if (chain) {
+      // "still propagating" from "stranded" on its first try. Only the earliest
+      // mark for a pool count holds, or any send restarts the waiting window.
+      if (chain && !marked) {
         await writeMark(key, {
           block: chain.blockNumber,
           pendingNonce: chain.pendingNonce,

--- a/apps/wallet/src/lib/notifications.ts
+++ b/apps/wallet/src/lib/notifications.ts
@@ -56,3 +56,13 @@ export async function notifyTransactionFailed(
     `${amount} ${asset} transaction failed`,
   )
 }
+
+export async function notifyTransactionDropped(
+  amount: string,
+  asset: string,
+): Promise<boolean> {
+  return createNotification(
+    'Transaction Dropped',
+    `The network no longer has your ${amount} ${asset} transaction. Send it again.`,
+  )
+}

--- a/apps/wallet/src/lib/send-transaction.ts
+++ b/apps/wallet/src/lib/send-transaction.ts
@@ -163,6 +163,23 @@ function handleTransactionError(error: unknown, context: string): never {
   )
 }
 
+/**
+ * A failed broadcast rejects rather than resolving error-shaped, so the throw
+ * is where the node's reason arrives and has to be translated.
+ */
+async function sendOrThrow(
+  send: () => Promise<SendResult>,
+  context: string,
+): Promise<Hex> {
+  let result: SendResult
+  try {
+    result = await send()
+  } catch (error) {
+    handleTransactionError(error, context)
+  }
+  return requireHash(result, context)
+}
+
 function requireHash(result: SendResult, context: string): Hex {
   const txid = result.id.txid
   if (txid && typeof txid === 'object' && txid.error) {
@@ -229,21 +246,25 @@ export async function buildAndSendTransaction(
 
   if (tx.data) {
     if (isCanonicalErc20Transfer(tx.data, tx.value)) {
-      const result = await senders.sendErc20({ ...common, data: tx.data })
-      return requireHash(result, 'ERC20 transfer')
+      return sendOrThrow(
+        () => senders.sendErc20({ ...common, data: tx.data as Hex }),
+        'ERC20 transfer',
+      )
     }
 
-    const result = await senders.sendContractCall({
-      ...common,
-      data: tx.data,
-      value: tx.value.toString(16),
-    })
-    return requireHash(result, 'Contract call')
+    return sendOrThrow(
+      () =>
+        senders.sendContractCall({
+          ...common,
+          data: tx.data as Hex,
+          value: tx.value.toString(16),
+        }),
+      'Contract call',
+    )
   }
 
-  const result = await senders.send({
-    ...common,
-    amount: tx.value.toString(16),
-  })
-  return requireHash(result, 'Send transaction')
+  return sendOrThrow(
+    () => senders.send({ ...common, amount: tx.value.toString(16) }),
+    'Send transaction',
+  )
 }

--- a/apps/wallet/src/lib/storage-keys.ts
+++ b/apps/wallet/src/lib/storage-keys.ts
@@ -1,5 +1,7 @@
 export const NOTIFICATIONS_ENABLED_KEY = 'local:notifications:enabled' as const
 export const TX_NOTIFIED_KEY = 'local:tx-monitor:notified' as const
+/** Consecutive polls denying a hash, keyed by hash. */
+export const TX_MISSES_KEY = 'local:tx-monitor:misses' as const
 export const PENDING_TXS_KEY =
   'local:pending-transactions:transactions' as const
 export const NOTIFICATION_PROMPTED_KEY = 'local:notifications:prompted' as const

--- a/apps/wallet/src/lib/tx-monitor.test.ts
+++ b/apps/wallet/src/lib/tx-monitor.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyPoll, DROPPED_AFTER_MISSES } from './tx-monitor'
+
+const found = { ok: true, value: true } as const
+const missing = { ok: true, value: false } as const
+const unreachable = { ok: false } as const
+const noReceipt = { ok: true, value: null } as const
+
+describe('classifyPoll', () => {
+  it('confirms on a successful receipt', () => {
+    expect(
+      classifyPoll({ ok: true, value: { status: '0x1' } }, undefined, 0),
+    ).toEqual({ state: 'confirmed' })
+  })
+
+  it('fails on a reverted receipt', () => {
+    expect(
+      classifyPoll({ ok: true, value: { status: '0x0' } }, undefined, 0),
+    ).toEqual({ state: 'failed' })
+  })
+
+  it('keeps a transaction the node still knows pending, and resets its misses', () => {
+    expect(classifyPoll(noReceipt, found, 2)).toEqual({
+      state: 'pending',
+      misses: 0,
+    })
+  })
+
+  it('counts a miss when the node has no record of the hash', () => {
+    expect(classifyPoll(noReceipt, missing, 0)).toEqual({
+      state: 'pending',
+      misses: 1,
+    })
+  })
+
+  it('marks the transaction dropped once the misses run out', () => {
+    expect(classifyPoll(noReceipt, missing, DROPPED_AFTER_MISSES - 1)).toEqual({
+      state: 'dropped',
+    })
+  })
+
+  it('does not age a transaction towards dropped on a failed receipt poll', () => {
+    expect(classifyPoll(unreachable, undefined, 1)).toEqual({
+      state: 'unresolved',
+    })
+  })
+
+  it('does not age a transaction towards dropped on a failed probe', () => {
+    expect(classifyPoll(noReceipt, unreachable, 1)).toEqual({
+      state: 'unresolved',
+    })
+  })
+
+  it('waits rather than settling on a receipt with an unknown status', () => {
+    expect(
+      classifyPoll({ ok: true, value: { status: '0x2' } }, undefined, 0),
+    ).toEqual({ state: 'unresolved' })
+  })
+})

--- a/apps/wallet/src/lib/tx-monitor.ts
+++ b/apps/wallet/src/lib/tx-monitor.ts
@@ -6,10 +6,11 @@ import { storage } from '@wxt-dev/storage'
 
 import {
   notifyTransactionConfirmed,
+  notifyTransactionDropped,
   notifyTransactionFailed,
 } from './notifications'
 import { getRpcProxyUrl } from './rpc-proxy'
-import { PENDING_TXS_KEY, TX_NOTIFIED_KEY } from './storage-keys'
+import { PENDING_TXS_KEY, TX_MISSES_KEY, TX_NOTIFIED_KEY } from './storage-keys'
 
 type PendingTx = {
   hash: unknown
@@ -18,29 +19,91 @@ type PendingTx = {
   displayAmount?: string
 }
 
-async function fetchReceipt(
-  txHash: string,
-): Promise<{ status: string } | null> {
+type Receipt = { status: string }
+
+/** `ok: false` is a transport or RPC failure, which says nothing about the tx. */
+type RpcOutcome<T> = { ok: true; value: T } | { ok: false }
+
+/**
+ * Consecutive polls denying the hash before it counts as dropped. Three is
+ * ~90s of the node having no record of something it accepted.
+ */
+export const DROPPED_AFTER_MISSES = 3
+
+export type PollOutcome =
+  | { state: 'confirmed' }
+  | { state: 'failed' }
+  | { state: 'dropped' }
+  | { state: 'pending'; misses: number }
+  /** Nothing conclusive; leave the record as it was. */
+  | { state: 'unresolved' }
+
+/**
+ * What one poll proves. A null receipt is the normal answer for a transaction
+ * still in the pool, so counting it as a miss would mark every slow one
+ * dropped; `eth_getTransactionByHash` returning null is the real evidence.
+ */
+export function classifyPoll(
+  receipt: RpcOutcome<Receipt | null>,
+  known: RpcOutcome<boolean> | undefined,
+  misses: number,
+): PollOutcome {
+  if (!receipt.ok) return { state: 'unresolved' }
+
+  if (receipt.value) {
+    if (receipt.value.status === '0x1') return { state: 'confirmed' }
+    if (receipt.value.status === '0x0') return { state: 'failed' }
+    return { state: 'unresolved' }
+  }
+
+  if (!known?.ok) return { state: 'unresolved' }
+  if (known.value) return { state: 'pending', misses: 0 }
+
+  const next = misses + 1
+  return next >= DROPPED_AFTER_MISSES
+    ? { state: 'dropped' }
+    : { state: 'pending', misses: next }
+}
+
+async function rpcCall<T>(
+  method: string,
+  params: unknown[],
+): Promise<RpcOutcome<T | null>> {
   try {
     // note: rpc.proxy expects a plain JSON-RPC body with chainId as a query
     // param; tRPC-formatted POST bodies are rejected by the API route handler
     const res = await fetch(getRpcProxyUrl(1), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'eth_getTransactionReceipt',
-        params: [txHash],
-        id: 1,
-      }),
+      body: JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }),
     })
-    const body = (await res.json()) as {
-      result?: { status: string } | null
-    }
-    return body.result ?? null
+    if (!res.ok) return { ok: false }
+
+    const body = (await res.json()) as { result?: T | null; error?: unknown }
+    if (body.error) return { ok: false }
+    return { ok: true, value: body.result ?? null }
   } catch {
-    return null
+    return { ok: false }
   }
+}
+
+async function pollTransaction(
+  txHash: string,
+  misses: number,
+): Promise<PollOutcome> {
+  const receipt = await rpcCall<Receipt>('eth_getTransactionReceipt', [txHash])
+  // Only asked without a receipt, the only case it decides.
+  const known =
+    receipt.ok && receipt.value === null
+      ? await rpcCall<unknown>('eth_getTransactionByHash', [txHash]).then(
+          (result): RpcOutcome<boolean> =>
+            result.ok
+              ? { ok: true, value: result.value !== null }
+              : { ok: false },
+        )
+      : undefined
+
+  return classifyPoll(receipt, known, misses)
 }
 
 export const TX_MONITOR_ALARM = 'tx-monitor'
@@ -65,50 +128,67 @@ export async function checkPendingTransactions(): Promise<void> {
     if (Array.isArray(notified) && notified.length > 0) {
       await storage.setItem(TX_NOTIFIED_KEY, [])
     }
+    const misses = await storage.getItem<Record<string, number>>(TX_MISSES_KEY)
+    if (misses && Object.keys(misses).length > 0) {
+      await storage.setItem(TX_MISSES_KEY, {})
+    }
     return
   }
 
   const notified = (await storage.getItem<string[]>(TX_NOTIFIED_KEY)) ?? []
+  const misses =
+    (await storage.getItem<Record<string, number>>(TX_MISSES_KEY)) ?? {}
   const notifiedSet = new Set(notified)
   const newlyNotified: string[] = []
   const settledHashes = new Set<string>()
+  const nextMisses: Record<string, number> = {}
 
-  const receipts = await Promise.all(
+  const outcomes = await Promise.all(
     pendingTxs.map(tx => {
       const txHash = getTransactionHash(tx.hash)
       if (!isEthereumTransactionHash(txHash)) return null
 
-      return fetchReceipt(txHash).then(r => ({ tx, txHash, receipt: r }))
+      return pollTransaction(txHash, misses[txHash] ?? 0).then(outcome => ({
+        tx,
+        txHash,
+        outcome,
+      }))
     }),
   )
 
-  for (const entry of receipts) {
-    if (!entry || !entry.receipt) continue
+  for (const entry of outcomes) {
+    if (!entry) continue
 
-    const { tx, txHash, receipt } = entry
-    const alreadyNotified = notifiedSet.has(txHash)
+    const { tx, txHash, outcome } = entry
+
+    if (outcome.state === 'pending') {
+      if (outcome.misses > 0) nextMisses[txHash] = outcome.misses
+      continue
+    }
+    if (outcome.state === 'unresolved') {
+      // A failed poll must not age the transaction towards dropped.
+      const carried = misses[txHash]
+      if (carried) nextMisses[txHash] = carried
+      continue
+    }
+
     const amount = tx.displayAmount ?? String(tx.value)
     const asset = tx.asset ?? 'ETH'
 
-    if (receipt.status === '0x1') {
-      if (!alreadyNotified) {
-        const fired = await notifyTransactionConfirmed(amount, asset)
-        if (fired) {
-          newlyNotified.push(txHash)
-          notifiedSet.add(txHash)
-        }
+    if (!notifiedSet.has(txHash)) {
+      const notify =
+        outcome.state === 'confirmed'
+          ? notifyTransactionConfirmed
+          : outcome.state === 'failed'
+            ? notifyTransactionFailed
+            : notifyTransactionDropped
+      const fired = await notify(amount, asset)
+      if (fired) {
+        newlyNotified.push(txHash)
+        notifiedSet.add(txHash)
       }
-      settledHashes.add(txHash)
-    } else if (receipt.status === '0x0') {
-      if (!alreadyNotified) {
-        const fired = await notifyTransactionFailed(amount, asset)
-        if (fired) {
-          newlyNotified.push(txHash)
-          notifiedSet.add(txHash)
-        }
-      }
-      settledHashes.add(txHash)
     }
+    settledHashes.add(txHash)
   }
 
   if (settledHashes.size > 0) {
@@ -123,6 +203,8 @@ export async function checkPendingTransactions(): Promise<void> {
       await chrome.alarms.clear(TX_MONITOR_ALARM)
     }
   }
+
+  await storage.setItem(TX_MISSES_KEY, nextMisses)
 
   if (newlyNotified.length > 0) {
     await storage.setItem(TX_NOTIFIED_KEY, [...notified, ...newlyNotified])

--- a/apps/wallet/src/providers/pending-transactions-context.tsx
+++ b/apps/wallet/src/providers/pending-transactions-context.tsx
@@ -1,8 +1,10 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
 
 import { getTransactionHash } from '@status-im/wallet/utils'
+import { storage as extensionStorage } from '@wxt-dev/storage'
 
 import { Storage } from '../data/storage'
+import { PENDING_TXS_KEY } from '../lib/storage-keys'
 
 import type { ApiOutput } from '@status-im/wallet/data'
 
@@ -48,6 +50,9 @@ export function PendingTransactionsProvider({
   >([])
   const [isLoading, setIsLoading] = useState(true)
   const [storage] = useState(() => new Storage('pending-transactions'))
+  // What the stored list last looked like, so a write and the change it echoes
+  // back can be told apart from an edit made outside this page.
+  const storedRef = useRef<string | null>(null)
 
   useEffect(() => {
     const loadPendingTransactions = async () => {
@@ -56,6 +61,7 @@ export function PendingTransactionsProvider({
         const stored = result.transactions as PendingTransaction[] | undefined
 
         if (stored && Array.isArray(stored)) {
+          storedRef.current = JSON.stringify(stored)
           setPendingTransactions(stored)
         }
       } catch (error) {
@@ -68,8 +74,30 @@ export function PendingTransactionsProvider({
     loadPendingTransactions()
   }, [storage])
 
+  /**
+   * The background monitor owns the same key and settles transactions there.
+   * Without this the page keeps a copy from mount and writes it back over the
+   * removals, leaving mined transactions in the list.
+   */
+  useEffect(() => {
+    return extensionStorage.watch<PendingTransaction[]>(
+      PENDING_TXS_KEY,
+      next => {
+        const value = Array.isArray(next) ? next : []
+        const serialized = JSON.stringify(value)
+        if (serialized === storedRef.current) return
+        storedRef.current = serialized
+        setPendingTransactions(value)
+      },
+    )
+  }, [])
+
   useEffect(() => {
     if (isLoading) return
+
+    const serialized = JSON.stringify(pendingTransactions)
+    if (serialized === storedRef.current) return
+    storedRef.current = serialized
 
     storage.set({ transactions: pendingTransactions }).catch(error => {
       console.error('Failed to save pending transactions:', error)

--- a/apps/wallet/src/routes/portfolio/assets/-components/token.tsx
+++ b/apps/wallet/src/routes/portfolio/assets/-components/token.tsx
@@ -47,6 +47,7 @@ import { useEthBalance } from '@/hooks/use-eth-balance'
 import { useGasFees } from '@/hooks/use-gas-fees'
 import { renderMarkdown } from '@/lib/markdown'
 import { notifyTransactionSent } from '@/lib/notifications'
+import { parseInsufficientFundsError } from '@/lib/send-transaction'
 import { apiClient } from '@/providers/api-client'
 import { usePassword } from '@/providers/password-context'
 import { usePendingTransactions } from '@/providers/pending-transactions-context'
@@ -328,6 +329,18 @@ const Token = (props: Props) => {
   }
   const isWatchOnlyWallet = currentWallet?.type === 'hardware-qr'
 
+  /** The node's own reason where there is one, translated for the user. */
+  const broadcastOrToast = async <T,>(send: () => Promise<T>): Promise<T> => {
+    try {
+      return await send()
+    } catch (error) {
+      console.error(error)
+      const parsed = parseInsufficientFundsError(error)
+      toast.negative(parsed?.message ?? ERROR_MESSAGES.TX_FAILED)
+      throw parsed ?? error
+    }
+  }
+
   const signTransaction = async (formData: SendAssetsFormData) => {
     // Throws GasShiftedError for spikes >=30% so the modal can ask for confirmation.
     // Smaller bumps are accepted silently with fresh params.
@@ -347,14 +360,11 @@ const Token = (props: Props) => {
         maxInclusionFeePerGas: gasParams.maxPriorityFeePerGas,
       }
 
-      const result = await apiClient.wallet.account.ethereum.send.mutate(params)
-      if (!result.id || result.id.txid?.error) {
-        console.error(result.id.txid?.error)
-        toast.negative(ERROR_MESSAGES.TX_FAILED)
-        throw new Error('Transaction failed')
-      }
+      const result = await broadcastOrToast(() =>
+        apiClient.wallet.account.ethereum.send.mutate(params),
+      )
 
-      const txHash = getTransactionHash(result.id.txid ?? result.id)
+      const txHash = getTransactionHash(result.id.txid)
 
       if (!isEthereumTransactionHash(txHash)) {
         toast.negative(ERROR_MESSAGES.TX_FAILED)
@@ -411,16 +421,11 @@ const Token = (props: Props) => {
         data,
       }
 
-      const result =
-        await apiClient.wallet.account.ethereum.sendErc20.mutate(params)
+      const result = await broadcastOrToast(() =>
+        apiClient.wallet.account.ethereum.sendErc20.mutate(params),
+      )
 
-      if (!result.id || result.id.txid?.error) {
-        console.error(result.id.txid?.error)
-        toast.negative(ERROR_MESSAGES.TX_FAILED)
-        throw new Error('Transaction failed')
-      }
-
-      const txHash = getTransactionHash(result.id.txid ?? result.id)
+      const txHash = getTransactionHash(result.id.txid)
 
       if (!isEthereumTransactionHash(txHash)) {
         toast.negative(ERROR_MESSAGES.TX_FAILED)

--- a/apps/wallet/src/routes/portfolio/collectibles/-components/collectible.tsx
+++ b/apps/wallet/src/routes/portfolio/collectibles/-components/collectible.tsx
@@ -122,18 +122,7 @@ const Collectible = (props: Props) => {
         value: '0',
       })
 
-    const txid = result.id?.txid
-    if (!txid) throw new Error('Failed to send NFT')
-
-    if (
-      typeof txid === 'object' &&
-      'error' in txid &&
-      typeof txid.error === 'string'
-    ) {
-      throw new Error(txid.error)
-    }
-
-    const txHash = getTransactionHash(txid)
+    const txHash = getTransactionHash(result.id.txid)
     if (!isEthereumTransactionHash(txHash)) {
       throw new Error('Transaction hash not found')
     }

--- a/packages/wallet/src/data/api/routers/rpc.ts
+++ b/packages/wallet/src/data/api/routers/rpc.ts
@@ -18,9 +18,12 @@ const PROXY_AUTH = {
  * The upstream half of the wallet extension's chain registry
  * (`apps/wallet/src/lib/chains.ts`): a chain is only readable once it has an
  * entry here and a matching `proxyChainId` there.
+ *
+ * Chain 1 takes the `/alchemy` path `nodes.broadcastTransaction` uses: a node
+ * that does not hold the transaction answers receipt lookups with null forever.
  */
 const CHAIN_ID_TO_PROXY_PATH: Record<number, string> = {
-  1: 'ethereum/mainnet',
+  1: 'ethereum/mainnet/alchemy',
   59144: 'linea/mainnet',
   11155111: 'ethereum/sepolia',
   374: 'status/hoodi',


### PR DESCRIPTION
Closes #1314. Stacked on #1315.

One stranded transaction took the whole session down: the local nonce counter
was never lowered, so every later send was signed at a gapped nonce, accepted
into the queued pool, and never mined. Only a browser restart cleared it, and
nothing surfaced it.

#### Changes

- Proxy path: chain 1 now proxies to the same `/alchemy` path broadcast
  and nonce reads use. A node that does not hold the transaction answers
  receipt lookups with null forever, so this has to come first: the nonce
  reconciliation below compares two counts that must come from one node.
- Broadcast validation: the result was read unvalidated, so a broadcast
  that produced no transaction still burned its nonce. Failures now carry the
  node's own reason instead of the status code.
- Nonce reconciliation: when the node's pending and latest counts agree
  it holds nothing for the account, so a local counter above that is lowered,
  once it has stayed ahead for 5 blocks. Best-effort: if the extra reads fail
  the send still goes out.
- Dropped-transaction detection: a null receipt means nothing on its own,
  so `eth_getTransactionByHash` is the probe. Three consecutive polls where the
  node has no record of the hash settle it as dropped and notify. RPC failures
  do not count towards that.
- Pending-list sync: the page read the list once at mount and wrote its
  own copy back over the monitor's removals. It now watches the shared key.

#### Not included

Speed up and cancel (issue task 4) are left out of this PR after thinking it over. They are new features rather than part of the fix.

---

#### How to test

```shell
# all pass
pnpm --filter wallet test
```

```shell
cd e2e && pnpm test:wallet-send
# if playwright failure you might need to run
pnpm exec playwright install chromium
```