### PR TITLE
chore(ci): add AI PR review via the shared acid-info/ai-review workflow

### DIFF
--- a/.github/ai-review.yml
+++ b/.github/ai-review.yml
@@ -1,0 +1,16 @@
+# Per-repo settings for the shared reviewer in acid-info/ai-review.
+# Only extra_ignore, guidelines_files and ignore are settable here -- models,
+# severity threshold and diff budget are owned centrally.
+
+# Appended to the shared defaults, which already cover lockfiles, **/dist/**,
+# **/vendor/**, **/*.min.js, **/*.map, **/__snapshots__/** and **/*.generated.*.
+extra_ignore:
+  - '**/*_pb.ts' # protoc-gen-es output; the .proto sources beside it stay reviewed
+  - '**/*.gen.ts' # TanStack Router route tree in apps/wallet
+  - '**/_graphql/generated/**' # graphql-codegen output, see apps/status.app/codegen.yml
+  - '**/next-env.d.ts' # written by Next.js, "should not be edited"
+  - 'packages/icons/src/**' # svgr output; `pnpm generate` deletes and rewrites it from svg/
+
+guidelines_files:
+  - AGENTS.md
+  - .cursor/rules/components.mdc

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,19 @@
+# AI PR review. The reviewer lives in acid-info/ai-review -- edit it there.
+# Trigger: comment "/ai-review" on any PR. This file must be on the default branch.
+name: AI PR Review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: acid-info/ai-review/.github/workflows/ai-review.yml@v1
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Adds dual-model AI review on demand: comment /ai-review on a PR and the
reviewer posts inline findings. The reviewer itself lives in
[acid-info/ai-review](https://github.com/acid-info/ai-review), pinned at v1.

- extra_ignore derived from this repo's generated output: protoc-gen-es
  (*_pb.ts), the TanStack route tree, graphql-codegen output, next-env.d.ts
  and the svgr-generated packages/icons/src.
- guidelines_files points at AGENTS.md (absent today, picked up automatically
  if added) and .cursor/rules/components.mdc.
- Secrets are mapped explicitly, never inherited -- the reviewer sees only the
  two API keys, none of this repo's other secrets.

Blocked until ANTHROPIC_API_KEY and OPENAI_API_KEY are added to this repo.
Only fires once this is on develop.