### PR TITLE
fix(status.app): stop blog URLs with a dot or an invalid slug returning 500

### DIFF
--- a/apps/status.app/src/app/(website)/_lib/ghost/index.ts
+++ b/apps/status.app/src/app/(website)/_lib/ghost/index.ts
@@ -48,19 +48,32 @@ const ghostLive = GhostContentAPI({
 })
 
 /**
- * Ghost answering "no such post" is a 404 the route should render.
+ * The answers Ghost gives about the slug itself, as opposed to a failed call.
  *
- * Anything else, a 429 under crawl load, a 5xx, a network blip, is a failed
- * call. Treating those as "not found" turns a momentary Ghost outage into a
- * `notFound()` that Next then caches for the route's whole revalidate window,
- * so a crawler that arrives during the blip sees a 404 for the next hour.
+ * 404 is the ordinary miss. 422 is Ghost refusing the slug against its own
+ * `isSlug` validation, which is what a slug carrying a dot, an uppercase
+ * letter or a space gets: `/blog/run-prater-beacon-node.sh` is a filename a
+ * crawler lifted out of a code block, not a post that might exist later.
+ * Both are permanent answers about that URL, so both are the 404 to render.
+ */
+const NO_SUCH_POST_STATUS_CODES = [404, 422]
+
+/**
+ * Anything outside {@link NO_SUCH_POST_STATUS_CODES}, a 429 under crawl load,
+ * a 5xx, a network blip, is a failed call. Treating those as "not found" turns
+ * a momentary Ghost outage into a `notFound()` that Next then caches for the
+ * route's whole revalidate window, so a crawler that arrives during the blip
+ * sees a 404 for the next hour.
  */
 function isGhostNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('statusCode' in error)) {
+    return false
+  }
+
+  const { statusCode } = error as { statusCode?: number }
+
   return (
-    typeof error === 'object' &&
-    error !== null &&
-    'statusCode' in error &&
-    (error as { statusCode?: number }).statusCode === 404
+    statusCode !== undefined && NO_SUCH_POST_STATUS_CODES.includes(statusCode)
   )
 }
 

--- a/apps/status.app/src/i18n/request.ts
+++ b/apps/status.app/src/i18n/request.ts
@@ -1,14 +1,25 @@
-import { hasLocale } from 'next-intl'
 import { getRequestConfig } from 'next-intl/server'
 
 import { routing } from './routing'
 
-export default getRequestConfig(async ({ requestLocale }) => {
-  const requested = await requestLocale
-  const locale =
-    requested && hasLocale(routing.locales, requested)
-      ? requested
-      : routing.defaultLocale
+/**
+ * Resolves the locale without reading the request.
+ *
+ * `requestLocale` falls back to `headers()` whenever nothing pinned the locale
+ * first, and reading headers inside a page Next is rendering statically fails
+ * that render outright with "Page changed from static to dynamic at runtime".
+ * Requests that skip the middleware arrive in exactly that state, and the
+ * matcher skips every path containing a dot, so a crawled URL such as
+ * `/blog/run-prater-beacon-node.sh` 500s where it should render its 404.
+ *
+ * `en` is the only locale and detection is off, so the request could not have
+ * changed the answer anyway. When a second locale ships, read the locale back
+ * off the request and pin it with `setRequestLocale` in every statically
+ * rendered layout, page and `generateMetadata`.
+ * why: https://next-intl.dev/docs/getting-started/app-router
+ */
+export default getRequestConfig(async () => {
+  const locale = routing.defaultLocale
 
   return {
     locale,


### PR DESCRIPTION
`/blog/run-prater-beacon-node.sh` and every other crawled blog URL that Ghost or Next cannot resolve answers 500 instead of a 404. Two independent causes, one per commit.

- Ghost rejects invalid slugs with 422, not 404: `posts.read` fails its own `isSlug` validation for a slug carrying a dot, an uppercase letter or a space, and `isGhostNotFoundError` only accepted 404, so the error reached the page render. 422 now joins 404 as an answer about the slug.
- The i18n middleware skips every path containing a dot: those requests reach the routes with no locale pinned, `requestLocale` falls back to `headers()`, and reading headers inside a page Next renders statically fails it with "Page changed from static to dynamic at runtime". The request config now resolves the locale from `routing.defaultLocale` without touching the request, which it could do all along: `en` is the only locale and detection is off.
- Outage handling unchanged: 429, 5xx and network failures still propagate, so a Ghost blip is still never cached as a 404 for the revalidate window.

Verified against a local production build, since `next dev` renders these paths dynamically and never reaches either failure.

## How to test

- `/blog/run-prater-beacon-node.sh`, `/blog/foo.sh`, `/blog/foo.png`, `/blog/tag/foo.sh`, `/blog/Foo` and `/blog/foo%20bar` render the 404 page. All six are 500 on production today.
- `/blog/can-12-random-words-still-be-guessable`, `/blog/tag/51-attack`, `/blog` and `/` still render, in English, and `/blog/does-not-exist-xyz` is still a 404.
