### PR TITLE
fix(wallet): hide swap in production releases

### DIFF
--- a/apps/wallet/README.md
+++ b/apps/wallet/README.md
@@ -42,3 +42,36 @@ Google Chrome > Toolbar > Extensions > !Status Portfolio Wallet (Beta) > Open si
 chrome-extension://\[ID]/page.html#/portfolio
 
 chrome-extension://\[ID]/page.html#/onboarding
+
+### Swap availability
+
+`src/lib/feature-flags.ts` controls Swap (labelled "Exchange" in the UI).
+It is enabled only when WXT's `import.meta.env.MODE` is `development`,
+including standalone development builds used by E2E tests. Production builds
+hide both the token detail action and its sticky header action, including
+their disabled watch-only variants. Chrome's Developer mode toggle does not
+change this build-time flag.
+
+## Chrome Web Store release
+
+The wallet job linked in the root README uses `ci/Jenkinsfile` to build
+`wallet`, zip `.output/chrome-mv3`, archive the ZIP, and upload the artifact.
+It does not submit or publish the extension to the Chrome Web Store.
+
+To prepare the same production package locally:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm exec turbo run build --filter=wallet
+pnpm --filter wallet zip:chrome
+```
+
+Check the ZIP's manifest version is higher than the published version and
+load the extracted ZIP in a test browser. Verify Exchange is absent from
+both token headers and that Buy, Receive, and Send still appear.
+
+In the existing Web Store item `opkfeajbclhjdneghppfnfiannideafj`, open
+Package and upload the ZIP from `.output/`. Save the draft and verify the
+version and package checks before submitting for review. For manual
+publication after review, turn off automatic publishing in the submission
+dialog. Final submission/publication belongs to the release owner.

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MPL-2.0",
   "private": true,
   "type": "module",
@@ -20,7 +20,7 @@
     "build:chrome": "wxt build -b chrome --mode production",
     "build:firefox": "wxt build -b firefox --mode production",
     "build:types": "tsc --noEmit",
-    "zip:chrome": "wxt zip -b chrome",
+    "zip:chrome": "wxt zip -b chrome --mode production",
     "zip:firefox": "wxt zip -b firefox",
     "lint": "eslint src",
     "format": "prettier --write .",

--- a/apps/wallet/src/lib/environment.ts
+++ b/apps/wallet/src/lib/environment.ts
@@ -1,0 +1,2 @@
+// WXT also uses development mode for the standalone extension E2E build.
+export const IS_DEVELOPMENT = import.meta.env.MODE === 'development'

--- a/apps/wallet/src/lib/feature-flags.test.ts
+++ b/apps/wallet/src/lib/feature-flags.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('Swap availability by build mode', () => {
+  it.each(['production', 'test', 'staging'])('hides Swap in %s', async mode => {
+    vi.stubEnv('MODE', mode)
+    const { FEATURE_FLAGS } = await import('./feature-flags')
+    expect(FEATURE_FLAGS.SWAP).toBe(false)
+  })
+
+  it('shows Swap in standalone development builds even when DEV is false', async () => {
+    vi.stubEnv('MODE', 'development')
+    vi.stubEnv('DEV', false)
+    const { FEATURE_FLAGS } = await import('./feature-flags')
+    expect(FEATURE_FLAGS.SWAP).toBe(true)
+  })
+})

--- a/apps/wallet/src/lib/feature-flags.ts
+++ b/apps/wallet/src/lib/feature-flags.ts
@@ -1,0 +1,5 @@
+import { IS_DEVELOPMENT } from './environment'
+
+export const FEATURE_FLAGS = {
+  SWAP: IS_DEVELOPMENT,
+} as const

--- a/apps/wallet/src/routes/portfolio/assets/-components/token.tsx
+++ b/apps/wallet/src/routes/portfolio/assets/-components/token.tsx
@@ -45,6 +45,7 @@ import { Interface, parseUnits } from 'ethers'
 import { WatchOnlyActionTooltip } from '@/components/watch-only-action-tooltip'
 import { useEthBalance } from '@/hooks/use-eth-balance'
 import { useGasFees } from '@/hooks/use-gas-fees'
+import { FEATURE_FLAGS } from '@/lib/feature-flags'
 import { renderMarkdown } from '@/lib/markdown'
 import { notifyTransactionSent } from '@/lib/notifications'
 import { parseInsufficientFundsError } from '@/lib/send-transaction'
@@ -484,7 +485,7 @@ const Token = (props: Props) => {
               <span className="block max-w-20 truncate">Buy</span>
             </Button>
           </BuyCryptoDrawer>
-          {fromTokenAddress && (
+          {FEATURE_FLAGS.SWAP && fromTokenAddress && (
             <WatchOnlyActionTooltip
               disabled={isWatchOnlyWallet}
               content={WATCH_ONLY_ACTION_TOOLTIP}
@@ -586,7 +587,7 @@ const Token = (props: Props) => {
               </Button>
             </BuyCryptoDrawer>
 
-            {fromTokenAddress && (
+            {FEATURE_FLAGS.SWAP && fromTokenAddress && (
               <WatchOnlyActionTooltip
                 disabled={isWatchOnlyWallet}
                 content={WATCH_ONLY_ACTION_TOOLTIP}


### PR DESCRIPTION
## Changes

Hide Swap (labelled Exchange) in production while keeping it available in WXT development mode. One feature flag covers the token detail and sticky header, including watch-only wallets.

Bump the extension to 0.1.3, make ZIP production mode explicit, and document the Jenkins artifact/manual Web Store release process.

## Development / Production

Exchange appears in both headers in development and is hidden in production. Cropped screenshots below show the button areas side by side.

<img width="680" height="232" alt="swap-dev-production-buttons" src="https://github.com/user-attachments/assets/4e24a81a-7ca7-4fd2-9a67-b87eb4cb152b" />
