### PR TITLE
fix(wallet): restore UNI icons and handle image failures

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MPL-2.0",
   "private": true,
   "type": "module",

--- a/packages/wallet/src/components/activity-list/components/activity-token-logo.tsx
+++ b/packages/wallet/src/components/activity-list/components/activity-token-logo.tsx
@@ -10,15 +10,14 @@ const ActivityTokenLogo = (props: ActivityTokenLogoProps) => {
   const { symbol, address } = props
 
   const getActivityTokenLogo = (symbol: string, contractAddress?: string) => {
-    if (symbol === 'ETH') {
+    if (!contractAddress && symbol === 'ETH') {
       return 'https://assets.coingecko.com/coins/images/279/large/ethereum.png'
     }
 
-    const token = erc20TokenList.tokens.find(
-      token =>
-        token.symbol === symbol ||
-        (contractAddress &&
-          token.address.toLowerCase() === contractAddress.toLowerCase()),
+    const token = erc20TokenList.tokens.find(token =>
+      contractAddress
+        ? token.address.toLowerCase() === contractAddress.toLowerCase()
+        : token.symbol === symbol,
     )
 
     return token?.logoURI ?? ''
@@ -32,7 +31,11 @@ const ActivityTokenLogo = (props: ActivityTokenLogoProps) => {
       alt={symbol}
       src={src}
       fallback={
-        <div className="flex size-8 flex-shrink-0 items-center justify-center rounded-full bg-neutral-10 text-11 font-600 text-neutral-50">
+        <div
+          role="img"
+          aria-label={symbol}
+          className="flex size-8 flex-shrink-0 items-center justify-center rounded-full bg-neutral-10 text-11 font-600 text-neutral-50"
+        >
           {symbol.slice(0, 4).toUpperCase()}
         </div>
       }

--- a/packages/wallet/src/components/activity-list/components/activity-token-logo.tsx
+++ b/packages/wallet/src/components/activity-list/components/activity-token-logo.tsx
@@ -1,4 +1,5 @@
 import erc20TokenList from '../../../constants/erc20.json'
+import { TokenImage } from '../../token-icon/token-image'
 
 type ActivityTokenLogoProps = {
   symbol: string
@@ -25,19 +26,16 @@ const ActivityTokenLogo = (props: ActivityTokenLogoProps) => {
 
   const src = getActivityTokenLogo(symbol, address)
 
-  if (!src) {
-    return (
-      <div className="flex size-8 flex-shrink-0 items-center justify-center rounded-full bg-neutral-10 text-11 font-600 text-neutral-50">
-        {symbol.slice(0, 4).toUpperCase()}
-      </div>
-    )
-  }
-
   return (
-    <img
+    <TokenImage
       className="size-8 flex-shrink-0 rounded-full bg-neutral-10"
       alt={symbol}
       src={src}
+      fallback={
+        <div className="flex size-8 flex-shrink-0 items-center justify-center rounded-full bg-neutral-10 text-11 font-600 text-neutral-50">
+          {symbol.slice(0, 4).toUpperCase()}
+        </div>
+      }
     />
   )
 }

--- a/packages/wallet/src/components/token-icon/index.tsx
+++ b/packages/wallet/src/components/token-icon/index.tsx
@@ -28,6 +28,8 @@ export function TokenIcon({ icon, name, symbol, size }: Props) {
       className={tokenIconStyles({ size })}
       fallback={
         <div
+          role="img"
+          aria-label={name}
           className={cx([
             'flex items-center justify-center bg-neutral-20',
             tokenIconStyles({ size }),

--- a/packages/wallet/src/components/token-icon/index.tsx
+++ b/packages/wallet/src/components/token-icon/index.tsx
@@ -1,5 +1,7 @@
 import { cva, cx } from 'class-variance-authority'
 
+import { TokenImage } from './token-image'
+
 type Props = {
   icon?: string
   name: string
@@ -16,29 +18,24 @@ const tokenIconStyles = cva('rounded-full bg-neutral-10', {
   },
 })
 
-function resolveIconUrl(icon: string): string {
-  if (icon.startsWith('ipfs://')) {
-    const cid = icon.replace('ipfs://', '')
-    return `https://ipfs.io/ipfs/${cid}`
-  }
-  return icon
-}
-
 export function TokenIcon({ icon, name, symbol, size }: Props) {
   const initial = (symbol || name || '?').charAt(0).toUpperCase()
-  if (icon) {
-    const src = resolveIconUrl(icon)
-    return <img src={src} alt={name} className={tokenIconStyles({ size })} />
-  }
 
   return (
-    <div
-      className={cx([
-        'flex items-center justify-center bg-neutral-20',
-        tokenIconStyles({ size }),
-      ])}
-    >
-      <span className="font-semibold text-neutral-40">{initial}</span>
-    </div>
+    <TokenImage
+      src={icon}
+      alt={name}
+      className={tokenIconStyles({ size })}
+      fallback={
+        <div
+          className={cx([
+            'flex items-center justify-center bg-neutral-20',
+            tokenIconStyles({ size }),
+          ])}
+        >
+          <span className="font-semibold text-neutral-40">{initial}</span>
+        </div>
+      }
+    />
   )
 }

--- a/packages/wallet/src/components/token-icon/token-image.test.tsx
+++ b/packages/wallet/src/components/token-icon/token-image.test.tsx
@@ -1,0 +1,101 @@
+import { act } from 'react'
+
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ActivityTokenLogo } from '../activity-list/components/activity-token-logo'
+import { TokenLogo } from '../token-logo'
+import { TokenIcon } from './index'
+import { TokenImage } from './token-image'
+
+import type { ReactNode } from 'react'
+import type { Root } from 'react-dom/client'
+
+const uni = 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg'
+const uniHttps = 'https://ethereum-optimism.github.io/data/UNI/logo.png'
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+})
+
+function render(node: ReactNode) {
+  act(() => root.render(node))
+}
+
+describe('token image loading', () => {
+  it.each([
+    ['list', <TokenIcon icon={uni} name="Uniswap" symbol="UNI" size="24" />],
+    ['detail', <TokenLogo icon={uni} name="Uniswap" ticker="UNI" />],
+    [
+      'activity',
+      <ActivityTokenLogo
+        symbol="UNI"
+        address="0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+      />,
+    ],
+  ])(
+    'uses HTTPS for UNI and handles a failed image in the %s',
+    (_, component) => {
+      render(component)
+      const image = container.querySelector('img')!
+      expect(image.getAttribute('src')).toBe(uniHttps)
+      act(() => image.dispatchEvent(new Event('error')))
+      expect(container.querySelector('img')).toBeNull()
+      expect(container.textContent).toContain('U')
+    },
+  )
+
+  it('retries when the URL changes, including returning to an earlier URL', () => {
+    const icon = (src?: string) => (
+      <TokenImage
+        src={src}
+        alt="Token"
+        className="size-6"
+        fallback={<span>Fallback</span>}
+      />
+    )
+    render(icon('https://example.com/first.png'))
+    act(() => container.querySelector('img')!.dispatchEvent(new Event('error')))
+    expect(container.textContent).toBe('Fallback')
+    render(icon('https://example.com/second.png'))
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://example.com/second.png',
+    )
+    render(icon('https://example.com/first.png'))
+    expect(container.querySelector('img')).not.toBeNull()
+    render(icon())
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toBe('Fallback')
+  })
+
+  it('does not replace unrelated tokens that share the UNI symbol', () => {
+    render(
+      <TokenIcon
+        icon="https://example.com/other.png"
+        name="Other"
+        symbol="UNI"
+        size="24"
+      />,
+    )
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://example.com/other.png',
+    )
+  })
+
+  it('shows the existing initial when an icon is missing', () => {
+    render(<TokenIcon name="Agave" symbol="AGVE" size="24" />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toBe('A')
+  })
+})

--- a/packages/wallet/src/components/token-icon/token-image.test.tsx
+++ b/packages/wallet/src/components/token-icon/token-image.test.tsx
@@ -93,6 +93,79 @@ describe('token image loading', () => {
     )
   })
 
+  it('uses the contract address when activity tokens share a symbol', () => {
+    render(
+      <ActivityTokenLogo
+        symbol="UNI"
+        address="0xe6877ea9c28fbdec631ffbc087956d0023a76bf2"
+      />,
+    )
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://s2.coinmarketcap.com/static/img/coins/64x64/4113.png',
+    )
+  })
+
+  it.each(['UNI', 'ETH'])(
+    'does not use the %s symbol to identify an unknown contract',
+    symbol => {
+      render(
+        <ActivityTokenLogo
+          symbol={symbol}
+          address="0x0000000000000000000000000000000000000001"
+        />,
+      )
+      expect(container.querySelector('img')).toBeNull()
+      expect(container.textContent).toBe(symbol)
+    },
+  )
+
+  it.each([
+    ['UNI', uniHttps],
+    ['ETH', 'https://assets.coingecko.com/coins/images/279/large/ethereum.png'],
+  ])(
+    'keeps symbol lookup for %s activity without a contract',
+    (symbol, src) => {
+      render(<ActivityTokenLogo symbol={symbol} address="" />)
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(src)
+    },
+  )
+
+  it.each([
+    [
+      'list',
+      <TokenIcon icon={uni} name="Uniswap" symbol="UNI" size="24" />,
+      'Uniswap',
+    ],
+    ['activity', <ActivityTokenLogo symbol="UNI" address="" />, 'UNI'],
+  ])(
+    'preserves the accessible name after an image fails in the %s',
+    (_, component, name) => {
+      render(component)
+      act(() =>
+        container.querySelector('img')!.dispatchEvent(new Event('error')),
+      )
+      expect(
+        container.querySelector('[role="img"]')?.getAttribute('aria-label'),
+      ).toBe(name)
+    },
+  )
+
+  it('retries when a new source resolves to the same image URL', () => {
+    const icon = (src: string) => (
+      <TokenImage
+        src={src}
+        alt="Uniswap"
+        className="size-6"
+        fallback={<span>Fallback</span>}
+      />
+    )
+    render(icon(uni))
+    act(() => container.querySelector('img')!.dispatchEvent(new Event('error')))
+    expect(container.textContent).toBe('Fallback')
+    render(icon(uniHttps))
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(uniHttps)
+  })
+
   it('shows the existing initial when an icon is missing', () => {
     render(<TokenIcon name="Agave" symbol="AGVE" size="24" />)
     expect(container.querySelector('img')).toBeNull()

--- a/packages/wallet/src/components/token-icon/token-image.tsx
+++ b/packages/wallet/src/components/token-icon/token-image.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+
+import type { ReactNode } from 'react'
+
+// This is the same UNI image used by the Base/Celo entries in our token list.
+// Resolve by content ID, not symbol: unrelated tokens can also be named UNI.
+const UNI_ICON = 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg'
+
+function resolveIconUrl(icon?: string): string | undefined {
+  if (icon === UNI_ICON) {
+    return 'https://ethereum-optimism.github.io/data/UNI/logo.png'
+  }
+  if (icon?.startsWith('ipfs://')) {
+    return `https://ipfs.io/ipfs/${icon.slice('ipfs://'.length)}`
+  }
+  return icon || undefined
+}
+
+type Props = {
+  src?: string
+  alt: string
+  className: string
+  fallback: ReactNode
+}
+
+function ImageWithFallback({ src, alt, className, fallback }: Props) {
+  const [failed, setFailed] = useState(false)
+
+  if (!src || failed) return <>{fallback}</>
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      onError={() => setFailed(true)}
+    />
+  )
+}
+
+export function TokenImage(props: Props) {
+  const src = resolveIconUrl(props.src)
+
+  // Remount for a different URL so a previous failure does not hide the next icon.
+  return <ImageWithFallback key={src} {...props} src={src} />
+}

--- a/packages/wallet/src/components/token-icon/token-image.tsx
+++ b/packages/wallet/src/components/token-icon/token-image.tsx
@@ -43,6 +43,6 @@ function ImageWithFallback({ src, alt, className, fallback }: Props) {
 export function TokenImage(props: Props) {
   const src = resolveIconUrl(props.src)
 
-  // Remount for a different URL so a previous failure does not hide the next icon.
-  return <ImageWithFallback key={src} {...props} src={src} />
+  // Retry each incoming URL change, even if it resolves to the same image URL.
+  return <ImageWithFallback key={props.src} {...props} src={src} />
 }

--- a/packages/wallet/src/components/token-logo/index.tsx
+++ b/packages/wallet/src/components/token-logo/index.tsx
@@ -1,5 +1,7 @@
 import { cx } from 'class-variance-authority'
 
+import { TokenImage } from '../token-icon/token-image'
+
 type Props = {
   variant?: 'default' | 'small'
   name: string
@@ -12,10 +14,19 @@ const TokenLogo = (props: Props) => {
 
   return (
     <div className="flex items-center gap-1.5 pb-0">
-      <img
+      <TokenImage
         className="size-5 flex-shrink-0 rounded-full bg-neutral-10"
         alt={name}
         src={icon}
+        fallback={
+          <div
+            role="img"
+            aria-label={name}
+            className="flex size-5 flex-shrink-0 items-center justify-center rounded-full bg-neutral-10 text-11 text-neutral-50"
+          >
+            {(ticker || name || '?').charAt(0).toUpperCase()}
+          </div>
+        }
       />
       <div
         className={cx([


### PR DESCRIPTION
## Before
<img width="829" height="605" alt="Screenshot 2026-09-13 at 4 02 03 PM" src="https://github.com/user-attachments/assets/4d5a7a7b-ac93-4ead-a6fb-fdbd569b94a6" />

## After
<img width="817" height="598" alt="Screenshot 2026-09-13 at 4 00 54 PM" src="https://github.com/user-attachments/assets/5f96caf9-d7fb-4cf3-a282-763054364112" />

Uniswap's IPFS gateway can return an error or an HTML page instead of an image. Resolve its known image CID to the HTTPS logo already used by our Base and Celo token entries.

Use the same image handling in token lists, detail headers and activity history. Missing or failed images show an accessible letter fallback, and every incoming image URL change retries loading. Activity icons match the contract address when available, so tokens sharing a symbol do not receive another token's logo. Existing image sizes and styling stay unchanged.

Bump the Chrome extension version from 0.1.3 to 0.1.4.

